### PR TITLE
UI: Auto-filter checkpoint stream by selected agent (agentId support)

### DIFF
--- a/apps/ui/src/builder/AgentBuilder.tsx
+++ b/apps/ui/src/builder/AgentBuilder.tsx
@@ -169,7 +169,7 @@ export function AgentBuilder() {
               {rightTab === 'checkpoint' && isCheckpointEligible ? (
                 <div className="space-y-4">
                   <div className="text-[10px] uppercase text-muted-foreground">Checkpoint Stream</div>
-                  <CheckpointStreamPanel />
+                  <CheckpointStreamPanel agentId={selectedNode?.id} />
                 </div>
               ) : (
                 <RightPropertiesPanel node={selectedNode} onChange={updateNodeData} />

--- a/apps/ui/src/components/stream/CheckpointStreamPanel.tsx
+++ b/apps/ui/src/components/stream/CheckpointStreamPanel.tsx
@@ -6,16 +6,18 @@ import { StatusChip } from './StatusChip';
 
 interface Props {
   defaultThreadId?: string;
+  agentId?: string;
   url?: string;
 }
 
-export function CheckpointStreamPanel({ defaultThreadId = '', url }: Props) {
+export function CheckpointStreamPanel({ defaultThreadId = '', agentId, url }: Props) {
   const [threadId, setThreadId] = useState(defaultThreadId);
   const [autoScroll, setAutoScroll] = useState(true);
 
   const { items, status, error, connected, isPaused, pause, resume, clear, retry, dropped } = useCheckpointStream({
     url,
     threadId: threadId || undefined,
+    agentId,
   });
 
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -98,7 +100,7 @@ export function CheckpointStreamPanel({ defaultThreadId = '', url }: Props) {
           />
         ))}
       </div>
-      <p className="text-xs text-muted-foreground">Leave both inputs empty to stream all writes (capped live list).</p>
+      <p className="text-xs text-muted-foreground">Leave threadId empty to stream all writes (capped live list).</p>
     </div>
   );
 }

--- a/apps/ui/src/hooks/useCheckpointStream.ts
+++ b/apps/ui/src/hooks/useCheckpointStream.ts
@@ -16,6 +16,7 @@ export interface CheckpointWriteClient {
 export interface UseCheckpointStreamParams {
   url?: string;
   threadId?: string;
+  agentId?: string;
   maxItems?: number;
   autoStart?: boolean;
 }
@@ -27,6 +28,7 @@ interface InitialPayload { items: any[] } // eslint-disable-line @typescript-esl
 export function useCheckpointStream({
   url = 'http://localhost:3010',
   threadId,
+  agentId,
   maxItems = 500,
   autoStart = true,
 }: UseCheckpointStreamParams) {
@@ -93,12 +95,13 @@ export function useCheckpointStream({
 
     const initPayload: Record<string, string> = {};
     if (threadId) initPayload.threadId = threadId;
+    if (agentId) initPayload.agentId = agentId;
     socket.emit('init', initPayload);
 
     return () => {
       socket.disconnect();
     };
-  }, [url, threadId, isPaused, maxItems]);
+  }, [url, threadId, agentId, isPaused, maxItems]);
 
   useEffect(() => {
     if (!autoStart) return;


### PR DESCRIPTION
Implements #10

Context
Builder shows a Checkpoint tab when a SimpleAgent node is selected. The stream should automatically filter to that agent.

Changes
- hooks: add agentId to useCheckpointStream params and include it in socket init payload; re-init when agentId changes.
- panel: accept agentId prop and forward to hook; updated helper copy.
- builder: supply selectedNode.id as agentId when rendering CheckpointStreamPanel for simpleAgent nodes.

Acceptance
- Selecting a SimpleAgent node shows only its writes; switching selection switches the stream.
- No additional input is visible for agent selection.
- Socket init payload uses { agentId, threadId } (no "namespace" term in UI).

Notes
- Backwards compatible: agentId is optional, threadId filter still works.
