### PR TITLE
feat(server): CallAgentTool supports childThreadId to avoid thread conflicts

### DIFF
--- a/apps/server/__tests__/call_agent.tool.test.ts
+++ b/apps/server/__tests__/call_agent.tool.test.ts
@@ -37,7 +37,7 @@ describe('CallAgentTool unit', () => {
   it('calls attached agent and returns its response.text', async () => {
     const tool = new CallAgentTool(new LoggerService());
     await tool.setConfig({ description: 'desc' });
-    const agent = new FakeAgent(new LoggerService(), async (thread, msgs) => {
+    const agent = new FakeAgent(new LoggerService(), async (thread, _msgs) => {
       expect(thread).toBe('t2');
       return new AIMessage('OK');
     });
@@ -66,6 +66,22 @@ describe('CallAgentTool unit', () => {
     const dynamic = tool.init();
     expect(dynamic.description).toBe('My desc');
     expect(dynamic.name).toBe('call_agent');
+  });
+
+  it('concatenates childThreadId with parent thread_id when provided', async () => {
+    const tool = new CallAgentTool(new LoggerService());
+    await tool.setConfig({ description: 'desc' });
+    const agent = new FakeAgent(new LoggerService(), async (thread, _msgs) => {
+      expect(thread).toBe('parent__sub');
+      return new AIMessage('OK');
+    });
+    tool.setAgent(agent);
+    const dynamic = tool.init();
+    const out = await dynamic.invoke(
+      { input: 'ping', childThreadId: 'sub' },
+      { configurable: { thread_id: 'parent' } } as any,
+    );
+    expect(out).toBe('OK');
   });
 });
 

--- a/apps/server/__tests__/call_agent.tool.test.ts
+++ b/apps/server/__tests__/call_agent.tool.test.ts
@@ -30,7 +30,10 @@ describe('CallAgentTool unit', () => {
     const tool = new CallAgentTool(new LoggerService());
     await expect(tool.setConfig({ description: 'desc' })).resolves.toBeUndefined();
     const dynamic: DynamicStructuredTool = tool.init();
-    const out = await dynamic.invoke({ input: 'hi' }, { configurable: { thread_id: 't1' } } as any);
+    const out = await dynamic.invoke(
+      { input: 'hi', childThreadId: 'x' },
+      { configurable: { thread_id: 't1' } } as any,
+    );
     expect(out).toBe('Target agent is not connected');
   });
 
@@ -38,12 +41,15 @@ describe('CallAgentTool unit', () => {
     const tool = new CallAgentTool(new LoggerService());
     await tool.setConfig({ description: 'desc' });
     const agent = new FakeAgent(new LoggerService(), async (thread, _msgs) => {
-      expect(thread).toBe('t2');
+      expect(thread).toBe('t2__sub');
       return new AIMessage('OK');
     });
     tool.setAgent(agent);
     const dynamic = tool.init();
-    const out = await dynamic.invoke({ input: 'ping' }, { configurable: { thread_id: 't2' } } as any);
+    const out = await dynamic.invoke(
+      { input: 'ping', childThreadId: 'sub' },
+      { configurable: { thread_id: 't2' } } as any,
+    );
     expect(out).toBe('OK');
   });
 
@@ -56,7 +62,10 @@ describe('CallAgentTool unit', () => {
     });
     tool.setAgent(agent);
     const dynamic = tool.init();
-    const out = await dynamic.invoke({ input: 'x', context: { deep: 42 } }, { configurable: { thread_id: 't3' } } as any);
+    const out = await dynamic.invoke(
+      { input: 'x', context: { deep: 42 }, childThreadId: 'c' },
+      { configurable: { thread_id: 't3' } } as any,
+    );
     expect(out).toBe('OK');
   });
 

--- a/apps/server/src/tools/call_agent.tool.ts
+++ b/apps/server/src/tools/call_agent.tool.ts
@@ -10,6 +10,13 @@ import { BaseMessage } from '@langchain/core/messages';
 const invocationSchema = z.object({
   input: z.string().min(1).describe('The message to forward to the target agent.'),
   context: z.any().optional().describe('Optional structured metadata; forwarded into TriggerMessage.info'),
+  childThreadId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Optional child thread identifier. If provided, the target agent will be invoked in `${parentThreadId}__${childThreadId}`.',
+    ),
 });
 
 const configSchema = z.object({ description: z.string().min(1).optional() }); // TODO: make description non optional
@@ -45,12 +52,16 @@ export class CallAgentTool extends BaseTool {
 
         if (!this.targetAgent) return 'Target agent is not connected';
 
-        const threadId =
+        const parentThreadId =
           (runtimeCfg as WithThreadId | undefined)?.configurable?.thread_id ??
           (config as WithThreadId | undefined)?.configurable?.thread_id;
-        if (!threadId) {
+        if (!parentThreadId) {
           throw new Error('thread_id is required');
         }
+
+        const targetThreadId = parsed.childThreadId
+          ? `${parentThreadId}__${parsed.childThreadId}`
+          : parentThreadId;
 
         const info =
           parsed.context && typeof parsed.context === 'object' && !Array.isArray(parsed.context)
@@ -62,7 +73,7 @@ export class CallAgentTool extends BaseTool {
         };
 
         try {
-          const res: BaseMessage | undefined = await this.targetAgent.invoke(threadId, [triggerMessage]);
+          const res: BaseMessage | undefined = await this.targetAgent.invoke(targetThreadId, [triggerMessage]);
           if (!res) return '';
           return res.text ?? '';
         } catch (err: any) {

--- a/apps/server/src/tools/call_agent.tool.ts
+++ b/apps/server/src/tools/call_agent.tool.ts
@@ -9,13 +9,15 @@ import { BaseMessage } from '@langchain/core/messages';
 
 const invocationSchema = z.object({
   input: z.string().min(1).describe('The message to forward to the target agent.'),
-  context: z.any().optional().describe('Optional structured metadata; forwarded into TriggerMessage.info'),
+  context: z
+    .any()
+    .optional()
+    .describe('Optional structured metadata; forwarded into TriggerMessage.info'),
   childThreadId: z
     .string()
     .min(1)
-    .optional()
     .describe(
-      'Optional child thread identifier. If provided, the target agent will be invoked in `${parentThreadId}__${childThreadId}`.',
+      'Required child thread identifier used to maintain a persistent conversation with the child agent. Use the same value to continue the same conversation across multiple calls; use a new value to start a separate conversation. The effective child thread is computed as `${parentThreadId}__${childThreadId}`.',
     ),
 });
 
@@ -59,9 +61,7 @@ export class CallAgentTool extends BaseTool {
           throw new Error('thread_id is required');
         }
 
-        const targetThreadId = parsed.childThreadId
-          ? `${parentThreadId}__${parsed.childThreadId}`
-          : parentThreadId;
+        const targetThreadId = `${parentThreadId}__${parsed.childThreadId}`;
 
         const info =
           parsed.context && typeof parsed.context === 'object' && !Array.isArray(parsed.context)


### PR DESCRIPTION
Addressed review comments:
- childThreadId is now required in the invocation schema.
- Improved description to clarify why this field exists (persistent conversation semantics) and how it computes the effective child thread id.
- Updated tests to always supply childThreadId.

PTAL.