### PR TITLE
feat(server): configurable CallAgentTool name to allow multiple instances per agent

### DIFF
--- a/apps/server/__tests__/call_agent_multiple_instances.test.ts
+++ b/apps/server/__tests__/call_agent_multiple_instances.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { AIMessage } from '@langchain/core/messages';
+import { CallAgentTool } from '../src/tools/call_agent.tool';
+import { LoggerService } from '../src/services/logger.service';
+
+class FakeAgent {
+  async invoke(thread: string) {
+    return new AIMessage(`ok-${thread}`);
+  }
+}
+
+describe('CallAgentTool configurable name', () => {
+  it('registers different names and routes calls accordingly', async () => {
+    const logger = new LoggerService();
+
+    const toolDocs = new CallAgentTool(logger);
+    await toolDocs.setConfig({ description: 'docs', name: 'call_agent_docs' });
+    toolDocs.setAgent(new FakeAgent() as any);
+    const dynDocs = toolDocs.init();
+
+    const toolOps = new CallAgentTool(logger);
+    await toolOps.setConfig({ description: 'ops', name: 'call_agent_ops' });
+    toolOps.setAgent(new FakeAgent() as any);
+    const dynOps = toolOps.init();
+
+    expect(dynDocs.name).toBe('call_agent_docs');
+    expect(dynOps.name).toBe('call_agent_ops');
+
+    const out1 = await dynDocs.invoke({ input: 'x' }, { configurable: { thread_id: 'p' } } as any);
+    const out2 = await dynOps.invoke({ input: 'y' }, { configurable: { thread_id: 'p' } } as any);
+    expect(out1).toContain('ok-p');
+    expect(out2).toContain('ok-p');
+  });
+});


### PR DESCRIPTION
This PR addresses issue #16.

- Add optional `name` in CallAgentTool config with pattern ^[a-z0-9_]{1,64}$
- Use provided `name` as tool name returned to the LLM; default remains `call_agent`
- Add tests to ensure multiple instances can coexist and be invoked by distinct names

Rationale: Enables registering multiple callAgentTool instances on a single agent without name collisions.