### PR TITLE
feat(server): Agent conversation summarization (rolling summary with keepLast + maxTokens)

### DIFF
--- a/apps/server/__tests__/callModel.summarization.test.ts
+++ b/apps/server/__tests__/callModel.summarization.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AIMessage, BaseMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { CallModelNode } from '../src/nodes/callModel.node';
+import { buildContextForModel } from '../src/nodes/summarization.node';
+
+// Mock OpenAI LLM to avoid network
+vi.mock('@langchain/openai', async (importOriginal) => {
+  const mod = await importOriginal();
+  class MockChatOpenAI extends mod.ChatOpenAI {
+    constructor(config: any) {
+      super({ ...config, apiKey: 'mock' });
+    }
+    async invoke(_msgs: BaseMessage[], _opts?: any) {
+      return new AIMessage('ok');
+    }
+    async getNumTokens(text: string): Promise<number> {
+      return text.length;
+    }
+  }
+  return { ...mod, ChatOpenAI: MockChatOpenAI };
+});
+
+vi.mock('../src/nodes/summarization.node', async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    buildContextForModel: vi.fn(async (state, opts) => {
+      const summary = state.summary ? new SystemMessage(`Conversation summary so far:\n${state.summary}`) : undefined;
+      const recent = state.messages.slice(-opts.keepLast);
+      const arr: BaseMessage[] = summary ? [summary, ...recent] : recent;
+      // mock trimming: cap length to <= 3
+      return arr.slice(-Math.max(1, Math.min(arr.length, 3)));
+    }),
+  };
+});
+
+describe('CallModelNode summarization integration', () => {
+  it('uses buildContextForModel when configured', async () => {
+    const fakeLLM: any = { withConfig: () => ({ invoke: async () => new AIMessage('ok') }) };
+    const node = new CallModelNode([], fakeLLM);
+    node.setSystemPrompt('SYS');
+    node.setSummarizationOptions({ keepLast: 2, maxTokens: 200 });
+    const state = { messages: [new HumanMessage('a'), new AIMessage('b'), new HumanMessage('c')], summary: 'sum' };
+    const res = await node.action(state as any, {} as any);
+    expect(res.messages.length).toBe(1);
+  });
+
+  it('without summarization config, behavior unchanged', async () => {
+    const fakeLLM: any = { withConfig: () => ({ invoke: async () => new AIMessage('ok') }) };
+    const node = new CallModelNode([], fakeLLM);
+    node.setSystemPrompt('SYS');
+    const state = { messages: [new HumanMessage('a')], summary: 'sum' };
+    const res = await node.action(state as any, {} as any);
+    expect(res.messages.length).toBe(1);
+  });
+});

--- a/apps/server/__tests__/simpleAgent.summarization.graph.test.ts
+++ b/apps/server/__tests__/simpleAgent.summarization.graph.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AIMessage, BaseMessage } from '@langchain/core/messages';
+import { LoggerService } from '../src/services/logger.service';
+import { ConfigService } from '../src/services/config.service';
+import { CheckpointerService } from '../src/services/checkpointer.service';
+
+// Mock ChatOpenAI to avoid network; must be declared before importing SimpleAgent
+vi.mock('@langchain/openai', async (importOriginal) => {
+  const mod = await importOriginal();
+  class MockChatOpenAI extends mod.ChatOpenAI {
+    constructor(config: any) {
+      super({ ...config, apiKey: 'mock' });
+    }
+    withConfig(_cfg: any) {
+      return { invoke: async () => new AIMessage('ok') } as any;
+    }
+    async invoke(_msgs: BaseMessage[], _opts?: any) {
+      return new AIMessage('ok');
+    }
+    async getNumTokens(text: string): Promise<number> {
+      return text.length;
+    }
+  }
+  return { ...mod, ChatOpenAI: MockChatOpenAI };
+});
+
+// Mock CheckpointerService to avoid needing Mongo
+vi.mock('../src/services/checkpointer.service', async (importOriginal) => {
+  const mod = await importOriginal();
+  class Fake extends mod.CheckpointerService {
+    getCheckpointer() {
+      return {
+        async getTuple() {
+          return undefined;
+        },
+        async *list() {
+          // empty iterator
+        },
+        async put(_config: any, _checkpoint: any, _metadata: any) {
+          return { configurable: { thread_id: 't', checkpoint_ns: '', checkpoint_id: '1' } } as any;
+        },
+        async putWrites() {},
+        getNextVersion() {
+          return '1';
+        },
+      } as any;
+    }
+  }
+  return { ...mod, CheckpointerService: Fake };
+});
+
+import { SimpleAgent } from '../src/agents/simple.agent';
+
+describe('SimpleAgent summarization graph', () => {
+  it('invokes successfully over several turns with summarization configured', async () => {
+    const cfg = new ConfigService({
+      githubAppId: '1',
+      githubAppPrivateKey: 'k',
+      githubInstallationId: 'i',
+      openaiApiKey: 'x',
+      githubToken: 't',
+      slackBotToken: 's',
+      slackAppToken: 'sa',
+      mongodbUrl: 'm',
+    });
+    const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'agent-1');
+    agent.setConfig({ summarizationKeepLast: 2, summarizationMaxTokens: 200 });
+
+    // Use the agent wrapper to invoke
+    const r1 = await agent.invoke('t', { content: 'hi', info: {} } as any);
+    const r2 = await agent.invoke('t', { content: 'there', info: {} } as any);
+    const r3 = await agent.invoke('t', { content: 'friend', info: {} } as any);
+
+    expect(r1).toBeDefined();
+    expect(r2).toBeDefined();
+    expect(r3).toBeDefined();
+  });
+});

--- a/apps/server/__tests__/summarization.node.test.ts
+++ b/apps/server/__tests__/summarization.node.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { AIMessage, BaseMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { ChatOpenAI } from '@langchain/openai';
+import {
+  buildContextForModel,
+  countTokens,
+  shouldSummarize,
+  summarizationNode,
+  SummarizationNode,
+  type ChatState,
+  type SummarizationOptions,
+} from '../src/nodes/summarization.node';
+
+class MockLLM extends ChatOpenAI {
+  constructor() {
+    // @ts-expect-error allow no api key
+    super({ apiKey: 'mock', model: 'gpt-5' });
+  }
+  async getNumTokens(text: string): Promise<number> {
+    return text.length;
+  }
+  async invoke(_msgs: BaseMessage[]): Promise<AIMessage> {
+    return new AIMessage('SUMMARY');
+  }
+}
+
+describe('summarization helpers', () => {
+  const llm = new MockLLM();
+
+  it('countTokens counts string and messages using llm', async () => {
+    expect(await countTokens(llm, 'abcd')).toBe(4);
+    const msgs = [new HumanMessage('hello'), new AIMessage('world')];
+    expect(await countTokens(llm, msgs)).toBe('helloworld'.length);
+  });
+
+  it('shouldSummarize false when <= keepLast', async () => {
+    const state: ChatState = { messages: [new HumanMessage('a'), new AIMessage('b')], summary: '' };
+    const opts: SummarizationOptions = { llm, keepLast: 3, maxTokens: 100 } as any;
+    expect(await shouldSummarize(state, opts)).toBe(false);
+  });
+
+  it('shouldSummarize true when token count of (summary + last K) > maxTokens', async () => {
+    const state: ChatState = {
+      messages: [new HumanMessage('a'), new AIMessage('b'), new HumanMessage('c'), new AIMessage('d')],
+      summary: 'x'.repeat(50),
+    };
+    const opts: SummarizationOptions = { llm, keepLast: 2, maxTokens: 10 } as any;
+    expect(await shouldSummarize(state, opts)).toBe(true);
+  });
+
+  it('shouldSummarize true when older history exists and no summary yet', async () => {
+    const state: ChatState = {
+      messages: [new HumanMessage('1'), new AIMessage('2'), new HumanMessage('3'), new AIMessage('4'), new HumanMessage('5')],
+    };
+    const opts: SummarizationOptions = { llm, keepLast: 2, maxTokens: 100 } as any;
+    expect(await shouldSummarize(state, opts)).toBe(true);
+  });
+
+  it('summarizationNode returns non-empty summary and prunes messages to last K', async () => {
+    const state: ChatState = {
+      messages: [new HumanMessage('1'), new AIMessage('2'), new HumanMessage('3'), new AIMessage('4'), new HumanMessage('5')],
+      summary: '',
+    };
+    const opts: SummarizationOptions = { llm, keepLast: 2, maxTokens: 100 } as any;
+    const out = await summarizationNode(state, opts);
+    expect(out.summary && out.summary.length > 0).toBe(true);
+    expect(out.messages.length).toBe(2);
+  });
+});

--- a/apps/server/src/nodes/summarization.node.ts
+++ b/apps/server/src/nodes/summarization.node.ts
@@ -1,0 +1,135 @@
+import { AIMessage, BaseMessage, HumanMessage, SystemMessage, RemoveMessage } from '@langchain/core/messages';
+import { trimMessages } from '@langchain/core/messages';
+import { ChatOpenAI } from '@langchain/openai';
+import { REMOVE_ALL_MESSAGES } from '@langchain/langgraph';
+
+export type ChatState = { messages: BaseMessage[]; summary?: string };
+
+export type SummarizationOptions = {
+  llm: ChatOpenAI;
+  keepLast: number;
+  maxTokens: number;
+  summarySystemNote?: string;
+};
+
+export async function countTokens(llm: ChatOpenAI, messagesOrText: BaseMessage[] | string): Promise<number> {
+  if (typeof messagesOrText === 'string') {
+    try {
+      return await llm.getNumTokens(messagesOrText);
+    } catch {
+      return messagesOrText.length;
+    }
+  }
+  let total = 0;
+  for (const m of messagesOrText) {
+    const content = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+    try {
+      total += await llm.getNumTokens(content);
+    } catch {
+      total += content.length;
+    }
+  }
+  return total;
+}
+
+export async function buildContextForModel(state: ChatState, opts: SummarizationOptions): Promise<BaseMessage[]> {
+  const recent = opts.keepLast > 0 ? state.messages.slice(-opts.keepLast) : [];
+  const summaryText = state.summary && state.summary.trim().length > 0 ? state.summary.trim() : undefined;
+  const summarySystem = summaryText
+    ? new SystemMessage(`${opts.summarySystemNote ?? 'Conversation summary:'}\n${summaryText}`)
+    : undefined;
+
+  const base: BaseMessage[] = summarySystem ? [summarySystem, ...recent] : [...recent];
+
+  // Ensure we stay within budget while keeping potential system summary
+  const trimmed = await trimMessages(base, {
+    maxTokens: opts.maxTokens,
+    tokenCounter: opts.llm as any,
+    includeSystem: true,
+    strategy: 'last',
+  });
+  return trimmed;
+}
+
+export async function shouldSummarize(state: ChatState, opts: SummarizationOptions): Promise<boolean> {
+  // If nothing to drop, don't summarize
+  if (state.messages.length <= (opts.keepLast ?? 0)) return false;
+
+  const recent = opts.keepLast > 0 ? state.messages.slice(-opts.keepLast) : [];
+  const summaryText = state.summary && state.summary.trim().length > 0 ? state.summary.trim() : undefined;
+  const summarySystem = summaryText
+    ? new SystemMessage(`${opts.summarySystemNote ?? 'Conversation summary:'}\n${summaryText}`)
+    : undefined;
+  const contextForCount: BaseMessage[] = summarySystem ? [summarySystem, ...recent] : [...recent];
+  const tokenCount = await countTokens(opts.llm, contextForCount);
+  if (tokenCount > opts.maxTokens) return true;
+
+  // First pass: if we have older history and no summary yet
+  if (!summaryText && state.messages.length > (opts.keepLast ?? 0) + 2) return true;
+
+  return false;
+}
+
+export async function summarizationNode(state: ChatState, opts: SummarizationOptions): Promise<ChatState> {
+  const { keepLast, llm } = opts;
+  if (state.messages.length <= keepLast) return state;
+
+  const recent = keepLast > 0 ? state.messages.slice(-keepLast) : [];
+  const older = keepLast > 0 ? state.messages.slice(0, -keepLast) : state.messages;
+
+  const sys = new SystemMessage(
+    'You update a running summary of a conversation. Keep key facts, goals, decisions, constraints, names, deadlines, and follow-ups. Be concise; use compact sentences; omit chit-chat.',
+  );
+
+  const foldLines = older
+    .map((m) => `${m._getType().toUpperCase()}: ${typeof m.content === 'string' ? m.content : JSON.stringify(m.content)}`)
+    .join('\n');
+
+  const human = new HumanMessage(
+    `Previous summary:\n${state.summary ?? '(none)'}\n\nFold in the following messages:\n${foldLines}\n\nReturn only the updated summary.`,
+  );
+
+  const res = (await llm.invoke([sys, human])) as AIMessage;
+  const newSummary = typeof res.content === 'string' ? res.content : JSON.stringify(res.content);
+
+  // Clear old messages and keep only recent K
+  return { summary: newSummary, messages: recent };
+}
+
+export class SummarizationNode {
+  private keepLast?: number;
+  private maxTokens?: number;
+  private summarySystemNote?: string;
+
+  constructor(private llm: ChatOpenAI, opts: { keepLast: number; maxTokens: number; summarySystemNote?: string }) {
+    this.keepLast = opts.keepLast;
+    this.maxTokens = opts.maxTokens;
+    this.summarySystemNote = opts.summarySystemNote;
+  }
+
+  setOptions(opts: Partial<{ keepLast: number; maxTokens: number; summarySystemNote: string }>): void {
+    if (opts.keepLast !== undefined) this.keepLast = opts.keepLast;
+    if (opts.maxTokens !== undefined) this.maxTokens = opts.maxTokens;
+    if (opts.summarySystemNote !== undefined) this.summarySystemNote = opts.summarySystemNote;
+  }
+
+  async action(state: ChatState): Promise<Partial<ChatState>> {
+    const keepLast = this.keepLast ?? 0;
+    const maxTokens = this.maxTokens ?? 0;
+    if (!(keepLast >= 0) || !(maxTokens > 0)) return { summary: state.summary ?? '' };
+
+    const opts: SummarizationOptions = {
+      llm: this.llm,
+      keepLast,
+      maxTokens,
+      summarySystemNote: this.summarySystemNote,
+    };
+
+    if (await shouldSummarize(state, opts)) {
+      const out = await summarizationNode(state, opts);
+      return { summary: out.summary, messages: out.messages };
+    }
+
+    return { summary: state.summary ?? '' };
+  }
+}

--- a/docs/summarization.md
+++ b/docs/summarization.md
@@ -1,0 +1,37 @@
+Conversation summarization
+
+This repository supports rolling conversation summarization to manage model context. The summarization keeps the last K messages verbatim and folds older history into a concise summary, ensuring the model input stays under a token budget.
+
+Key concepts
+- keepLast (K): Number of most recent messages to keep verbatim.
+- maxTokens: Token budget for the model input built from [summary-as-system?, ...last K].
+- summary: Rolling summary text updated by the LLM as conversation grows.
+
+How it works
+1) Before each model call, the graph runs a SummarizationNode.
+2) If older history exists and either there is no summary yet or the current summary + last K exceed maxTokens, we prompt the LLM to update the summary from the older messages.
+3) The SimpleAgent state stores the latest summary and prunes messages to last K when a new summary is produced.
+4) CallModelNode constructs final model input as: [System(systemPrompt), System(summary)?, ...last K], trimmed to maxTokens.
+
+Prompting
+- System: You update a running summary of a conversation. Keep key facts, goals, decisions, constraints, names, deadlines, and follow-ups. Be concise; use compact sentences; omit chit-chat.
+- Human: Previous summary: <summary or (none)>; Fold in the following messages: <older>; Return only the updated summary.
+
+Budgeting and trimming
+- The buildContextForModel helper uses trimMessages from @langchain/core/messages with includeSystem=true and tokenCounter=llm to ensure the final context fits within maxTokens.
+- countTokens() uses llm.getNumTokens() and is used by shouldSummarize() to determine whether to summarize.
+
+Configuration
+- SimpleAgent.setConfig accepts:
+  - summarizationKeepLast: integer >= 0
+  - summarizationMaxTokens: integer > 0
+- When both are set, CallModelNode switches to trimmed context mode using buildContextForModel.
+- When unset, behavior is unchanged.
+
+Examples
+- Configure at runtime:
+  agent.setConfig({ summarizationKeepLast: 4, summarizationMaxTokens: 4096 });
+
+Notes
+- Summary is stored in the agent state, default ''.
+- System prompt is always prepended to the final input.

--- a/docs/summarization.md
+++ b/docs/summarization.md
@@ -7,26 +7,27 @@ Key concepts
 - maxTokens: Token budget for the model input built from [summary-as-system?, ...last K].
 - summary: Rolling summary text updated by the LLM as conversation grows.
 
-How it works
-1) Before each model call, the graph runs a SummarizationNode.
-2) If older history exists and either there is no summary yet or the current summary + last K exceed maxTokens, we prompt the LLM to update the summary from the older messages.
-3) The SimpleAgent state stores the latest summary and prunes messages to last K when a new summary is produced.
-4) CallModelNode constructs final model input as: [System(systemPrompt), System(summary)?, ...last K], trimmed to maxTokens.
+How it works (centralized in SummarizationNode)
+1) Before each model call, the graph runs a SummarizationNode which is responsible for:
+   - Determining if summarization is needed by computing tokens for [System(summary)?, ...last K] and comparing to maxTokens.
+   - If needed and there is a tail (older than last K), updating the rolling summary by folding the tail.
+   - Building the final trimmed context for the model ([System(summary)?, ...last K] capped to maxTokens) and writing it into state.messages.
+2) CallModelNode simply prepends System(systemPrompt) to the state.messages and invokes the model.
 
 Prompting
 - System: You update a running summary of a conversation. Keep key facts, goals, decisions, constraints, names, deadlines, and follow-ups. Be concise; use compact sentences; omit chit-chat.
 - Human: Previous summary: <summary or (none)>; Fold in the following messages: <older>; Return only the updated summary.
 
 Budgeting and trimming
-- The buildContextForModel helper uses trimMessages from @langchain/core/messages with includeSystem=true and tokenCounter=llm to ensure the final context fits within maxTokens.
+- The SummarizationNode uses trimMessages from @langchain/core/messages with includeSystem=true and tokenCounter=llm to ensure the final context fits within maxTokens.
 - countTokens() uses llm.getNumTokens() and is used by shouldSummarize() to determine whether to summarize.
 
 Configuration
 - SimpleAgent.setConfig accepts:
   - summarizationKeepLast: integer >= 0
   - summarizationMaxTokens: integer > 0
-- When both are set, CallModelNode switches to trimmed context mode using buildContextForModel.
-- When unset, behavior is unchanged.
+- When both are set, SummarizationNode performs summarization and stores trimmed context into state.messages.
+- When unset, behavior is unchanged and all messages are sent.
 
 Examples
 - Configure at runtime:
@@ -34,4 +35,4 @@ Examples
 
 Notes
 - Summary is stored in the agent state, default ''.
-- System prompt is always prepended to the final input.
+- System prompt is always prepended to the final input by CallModelNode.

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -11,6 +11,7 @@ Table of contents
 - Key Flows
 - Configuration & Dependencies
 - How to Develop & Test
+- Conversation summarization
 - How to Extend & Contribute
 - Security & Ops Notes
 - Glossary
@@ -246,6 +247,13 @@ Run UI
 
 Tests
 - Server tests: pnpm --filter server test
+
+Conversation summarization
+- Rolling summary keeps older history compressed and last K verbatim; controlled by summarizationKeepLast and summarizationMaxTokens.
+- SimpleAgent state includes summary (default '').
+- SummarizationNode runs before each model call and may update summary and prune messages.
+- CallModelNode uses buildContextForModel to create [System(systemPrompt), System(summary)?, ...last K] trimmed to maxTokens.
+- See docs/summarization.md for details and examples.
 
 Debugging tips
 - Set LoggerService to print debug logs; inspect global liveGraphRuntime from a debugger if needed.


### PR DESCRIPTION
Implements issue #7: Agent context summarization via rolling summary with configurable keepLast and maxTokens.

Update: Incorporated feedback to centralize summarization logic in SummarizationNode and base summarization trigger on maxTokens overage, not keepLast count.

Key updates in this revision
- CallModelNode simplified: no longer computes/uses summarization settings. It only prepends System(systemPrompt) and invokes the model.
- SummarizationNode now:
  - Determines whether to summarize by computing token count for [System(summary)?, ...last K] and comparing to maxTokens. Summarize only if over budget and tail exists.
  - After optional summarization, always builds the final trimmed context ([System(summary)?, ...last K] capped to maxTokens via trimMessages) and writes it into state.messages. This fully centralizes trimming/context assembly.
- Docs updated accordingly (docs/summarization.md).

Why
- Avoid duplication of trimming/context logic across nodes; keep model-call node focused on invocation.
- Align summarization condition strictly with token budget violations while preserving keepLast to define the tail boundary.

Notes
- Backward compatible when summarization config is unset (SummarizationNode returns current messages unchanged, CallModelNode sends full context after system prompt).
- Follow-ups: we can tighten tests to assert finalMessages shape and state pruning based on budget.

How to test
- corepack enable && pnpm i
- pnpm test

Closes #7