### PR TITLE
UI: Node kind badges, human titles, custom title support; prep for bash→shell tool rename

### DIFF
--- a/apps/ui/src/builder/AgentBuilder.tsx
+++ b/apps/ui/src/builder/AgentBuilder.tsx
@@ -24,6 +24,7 @@ import { LeftPalette } from './panels/LeftPalette';
 import { RightPropertiesPanel } from './panels/RightPropertiesPanel';
 import { useBuilderState } from './hooks/useBuilderState';
 import type { BuilderNodeKind } from './types';
+import { getDisplayTitle } from './lib/display';
 
 interface CanvasAreaProps {
   nodes: RFNode[];
@@ -123,6 +124,10 @@ export function AgentBuilder() {
   }, [selectedNode, rightTab]);
 
   const isCheckpointEligible = selectedNode?.data.template === 'simpleAgent';
+  const selectedDisplayTitle = selectedNode
+    ? getDisplayTitle(templates, selectedNode.data.template, selectedNode.data.config)
+    : 'No Selection';
+
   return (
     <DndProvider backend={HTML5Backend}>
       <ReactFlowProvider>
@@ -149,7 +154,7 @@ export function AgentBuilder() {
           </TemplatesProvider>
           <aside className="w-96 shrink-0 border-l bg-sidebar p-0 flex flex-col overflow-hidden">
             <div className="border-b flex items-center gap-2 px-4 h-10">
-              <div className="text-xs font-semibold tracking-wide">{selectedNode ? selectedNode.data.template : 'No Selection'}</div>
+              <div className="text-xs font-semibold tracking-wide">{selectedDisplayTitle}</div>
               {isCheckpointEligible && (
                 <div className="ml-auto flex gap-1">
                   <button

--- a/apps/ui/src/builder/lib/display.ts
+++ b/apps/ui/src/builder/lib/display.ts
@@ -1,0 +1,51 @@
+import type { TemplateNodeSchema } from 'shared';
+
+export function getTemplateSchema(templates: TemplateNodeSchema[], templateName: string | undefined) {
+  if (!templateName) return undefined;
+  return templates.find((t) => t.name === templateName);
+}
+
+export function getDisplayTitle(
+  templates: TemplateNodeSchema[],
+  templateName: string,
+  config?: Record<string, unknown>
+) {
+  const custom = (config as any)?.title as string | undefined;
+  if (custom && custom.trim().length > 0) return custom.trim();
+  const tpl = getTemplateSchema(templates, templateName);
+  return tpl?.title || templateName;
+}
+
+export function getKind(templates: TemplateNodeSchema[], templateName: string) {
+  return getTemplateSchema(templates, templateName)?.kind as TemplateNodeSchema['kind'] | undefined;
+}
+
+export function kindLabel(kind?: TemplateNodeSchema['kind']) {
+  switch (kind) {
+    case 'trigger':
+      return 'Trigger';
+    case 'agent':
+      return 'Agent';
+    case 'tool':
+      return 'Tool';
+    case 'mcp':
+      return 'MCP';
+    default:
+      return 'Node';
+  }
+}
+
+export function kindBadgeClasses(kind?: TemplateNodeSchema['kind']) {
+  switch (kind) {
+    case 'trigger':
+      return 'bg-amber-100 text-amber-900 border border-amber-200';
+    case 'agent':
+      return 'bg-blue-100 text-blue-900 border border-blue-200';
+    case 'tool':
+      return 'bg-slate-100 text-slate-900 border border-slate-200';
+    case 'mcp':
+      return 'bg-violet-100 text-violet-900 border border-violet-200';
+    default:
+      return 'bg-muted text-foreground border border-muted-foreground/20';
+  }
+}

--- a/apps/ui/src/builder/nodeTypes/TemplateNode.tsx
+++ b/apps/ui/src/builder/nodeTypes/TemplateNode.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
 import { useTemplates } from '../useTemplates';
+import { getDisplayTitle, getKind, kindBadgeClasses, kindLabel } from '../lib/display';
 
 interface BuilderNodeData {
   template: string;
@@ -14,10 +15,16 @@ function TemplateNodeComponent({ data }: NodeProps<BuilderNodeData>) {
   const targetPorts = schema?.targetPorts || [];
   const sourcePorts = schema?.sourcePorts || [];
 
+  const displayTitle = getDisplayTitle(templates, data.template, data.config);
+  const kind = getKind(templates, data.template);
+
   return (
-    <div className="rounded-md border bg-card text-xs shadow-sm min-w-[200px]">
-      <div className="drag-handle cursor-move select-none rounded-t-md bg-muted px-2 py-1 font-medium">
-        {data.template}
+    <div className="rounded-md border bg-card text-xs shadow-sm min-w-[220px]">
+      <div className="drag-handle cursor-move select-none rounded-t-md bg-muted px-2 py-1 font-medium flex items-center gap-2">
+        <span className={`inline-block rounded px-1.5 py-0.5 text-[10px] leading-none ${kindBadgeClasses(kind)}`}>
+          {kindLabel(kind)}
+        </span>
+        <span>{displayTitle}</span>
       </div>
       <div className="px-2 py-2">
         <div className="flex items-stretch gap-3">

--- a/apps/ui/src/builder/panels/LeftPalette.tsx
+++ b/apps/ui/src/builder/panels/LeftPalette.tsx
@@ -1,15 +1,16 @@
 import { useDrag } from 'react-dnd';
 import { DND_ITEM_NODE } from '../dnd';
 import type { TemplateNodeSchema } from 'shared';
+import { kindBadgeClasses, kindLabel } from '../lib/display';
 
 interface PaletteItemProps {
-  template: string;
+  template: TemplateNodeSchema;
 }
 function PaletteItem({ template }: PaletteItemProps) {
   const [{ isDragging }, dragRef] = useDrag(
     () => ({
       type: DND_ITEM_NODE,
-      item: { kind: template },
+      item: { kind: template.name },
       collect: (monitor) => ({ isDragging: monitor.isDragging() }),
     }),
     [template],
@@ -20,11 +21,14 @@ function PaletteItem({ template }: PaletteItemProps) {
   return (
     <div
       ref={setRef}
-      className={`cursor-move select-none rounded border bg-card px-2 py-1 text-xs shadow-sm ${
+      className={`cursor-move select-none rounded border bg-card px-2 py-1 text-xs shadow-sm flex items-center gap-2 ${
         isDragging ? 'opacity-50' : ''
       }`}
     >
-      <span className="text-primary">{template}</span>
+      <span className={`inline-block rounded px-1.5 py-0.5 text-[10px] leading-none ${kindBadgeClasses(template.kind)}`}>
+        {kindLabel(template.kind)}
+      </span>
+      <span className="text-primary">{template.title || template.name}</span>
     </div>
   );
 }
@@ -34,7 +38,7 @@ export function LeftPalette({ templates }: { templates: TemplateNodeSchema[] }) 
     <div className="flex flex-col gap-2">
       <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Nodes</div>
       {templates.map((t) => (
-        <PaletteItem key={t.name} template={t.name} />
+        <PaletteItem key={t.name} template={t} />
       ))}
     </div>
   );

--- a/apps/ui/src/builder/panels/RightPropertiesPanel.tsx
+++ b/apps/ui/src/builder/panels/RightPropertiesPanel.tsx
@@ -1,4 +1,6 @@
 import type { Node } from 'reactflow';
+import type { TemplateNodeSchema } from 'shared';
+import { useTemplates } from '../useTemplates';
 
 interface BuilderPanelNodeData { template: string; name?: string; config?: Record<string, unknown>; }
 interface Props {
@@ -7,18 +9,35 @@ interface Props {
 }
 
 export function RightPropertiesPanel({ node, onChange }: Props) {
+  const { templates } = useTemplates();
   if (!node) {
     return <div className="text-xs text-muted-foreground">Select a node to edit its properties.</div>;
   }
   const { data } = node;
+  const tpl = templates.find((t: TemplateNodeSchema) => t.name === data.template);
   const update = (patch: Record<string, unknown>) => onChange(node.id, patch);
-  const configString = JSON.stringify(data.config || {}, null, 2);
+  const cfg = (data.config || {}) as Record<string, unknown>;
+  const title = (cfg.title as string) || '';
+  const configString = JSON.stringify(cfg, null, 2);
+
   return (
     <div className="space-y-3">
-      <div className="text-[10px] uppercase text-muted-foreground">Template: {data.template}</div>
+      <div className="text-[10px] uppercase text-muted-foreground">
+        Template: {data.template}
+        {tpl?.title ? <span className="ml-2 text-[10px] italic text-muted-foreground">(Default: {tpl.title})</span> : null}
+      </div>
       <div>
-        <label className="mb-1 block text-[10px] uppercase text-muted-foreground">Name</label>
-        <input value={data.name || ''} onChange={e => update({ name: e.target.value })} className="w-full rounded border bg-background px-2 py-1 text-xs" />
+        <label className="mb-1 block text-[10px] uppercase text-muted-foreground">Title</label>
+        <input
+          value={title}
+          onChange={e => {
+            const next = { ...(data.config || {}), title: e.target.value } as Record<string, unknown>;
+            update({ config: next });
+          }}
+          placeholder={tpl?.title || data.template}
+          className="w-full rounded border bg-background px-2 py-1 text-xs"
+        />
+        <div className="mt-1 text-[10px] text-muted-foreground">If set, this title overrides the default label shown on the node.</div>
       </div>
       <div>
         <label className="mb-1 block text-[10px] uppercase text-muted-foreground">Config (JSON)</label>


### PR DESCRIPTION
This PR improves the Builder UX to align with recent backend template metadata and naming changes.

What’s included
- Node display helpers
  - Added apps/ui/src/builder/lib/display.ts to compute displayTitle and badge styles
  - displayTitle = config.title (if set) → TemplateNodeSchema.title → template name
- Canvas node header
  - TemplateNode now shows a small colored badge for kind (trigger/agent/tool/mcp) and the human-readable title
- Right pane header
  - Selected node title now uses the computed displayTitle instead of the technical template name
- Palette
  - Shows a badge per kind and uses TemplateNodeSchema.title for display
  - Drag payload still uses the technical name so types remain unchanged
- Properties panel
  - New Title field wired to config.title (overrides default title)
  - Shows template technical name and default title hint

Notes
- No code references to bashTool exist in UI; backend rename to shellTool will show up automatically via template title
- “containerProvider” title → “Workspace” is driven by server title; UI now consistently uses server titles

Affected files
- apps/ui/src/builder/lib/display.ts (new)
- apps/ui/src/builder/nodeTypes/TemplateNode.tsx
- apps/ui/src/builder/AgentBuilder.tsx
- apps/ui/src/builder/panels/LeftPalette.tsx
- apps/ui/src/builder/panels/RightPropertiesPanel.tsx

Manual test plan
- Start backend and UI
- Verify palette shows kind badges and human titles
- Drag nodes; verify canvas nodes show badge + title
- Edit Title in properties; observe live update in right header and canvas node, and persistence (POST /api/graph contains config.title)

Open questions
- Badge colors: trigger=amber, agent=blue, tool=slate, mcp=violet. Happy to adjust.

No backend changes in this PR.