### PR TITLE
feat(container): platform support for image pull and container creation (typed, no-any)

### DIFF
--- a/apps/server/src/entities/containerProvider.entity.ts
+++ b/apps/server/src/entities/containerProvider.entity.ts
@@ -2,7 +2,7 @@ import { ContainerOpts, ContainerService } from '../services/container.service';
 import { ContainerEntity } from './container.entity';
 
 export class ContainerProviderEntity {
-  private cfg?: Pick<ContainerOpts, 'image' | 'env'>;
+  private cfg?: Pick<ContainerOpts, 'image' | 'env' | 'platform'>;
 
   constructor(
     private containerService: ContainerService,
@@ -12,7 +12,7 @@ export class ContainerProviderEntity {
 
   // No-op configurability to satisfy Configurable interface for graph registration
   setConfig(cfg: Record<string, unknown>): void {
-    this.cfg = cfg as Pick<ContainerOpts, 'image' | 'env'>; // TODO: do proper parsing/validation with schema
+    this.cfg = cfg as Pick<ContainerOpts, 'image' | 'env' | 'platform'>; // TODO: do proper parsing/validation with schema
   }
 
   async provide(threadId: string) {

--- a/apps/server/src/types/dockerode-augmentation.d.ts
+++ b/apps/server/src/types/dockerode-augmentation.d.ts
@@ -1,0 +1,12 @@
+import 'dockerode';
+
+declare module 'dockerode' {
+  interface ContainerCreateOptions {
+    Platform?: string;
+    Entrypoint?: string | string[];
+  }
+
+  interface ImagePullOptions {
+    platform?: string;
+  }
+}


### PR DESCRIPTION
Addressed review: removed `any` casts; added module augmentation for dockerode types.

Changes since opening:
- Introduced apps/server/src/types/dockerode-augmentation.d.ts with:
  - ContainerCreateOptions.Platform and Entrypoint typings
  - ImagePullOptions.platform typing
- ContainerService:
  - ensureImage now uses typed ImagePullOptions and `docker.pull(image, pullOpts, cb)` when platform provided
  - create options set Platform and Entrypoint directly (no casts)
  - Stream handling uses typed PassThrough/Writable instead of `as any` sink objects
- No behavioral changes; only typing and minor refactor to satisfy strict TS.

This ensures all passed values comply with interfaces under `strict` tsconfig.
