### PR TITLE
feat(shared): capabilities foundation (ConfigSchema via Ajv, Provisionable, Pausable, Static/DynamicConfigurable)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "types": "src/index.ts"
+  "types": "src/index.ts",
+  "devDependencies": {
+    "ajv": "^8.17.1"
+  }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,3 +7,8 @@ export type {
   PersistedGraphUpsertRequest,
   PersistedGraphUpsertResponse,
 } from '../../../apps/server/src/graph/types';
+
+// Runtime capability foundation exports (no runtime behavior)
+export type { ConfigSchema, ProvisionStateDetails } from './runtime.types';
+export { ProvisionState } from './runtime.types';
+export type { StaticConfigurable, DynamicConfigurable, Provisionable, Pausable } from './runtime.types';

--- a/packages/shared/src/runtime.types.ts
+++ b/packages/shared/src/runtime.types.ts
@@ -1,0 +1,104 @@
+/*
+  Runtime capability foundation types (shared across server, agents, tools, triggers, MCP, etc.)
+
+  ConfigSchema
+  - Uses JSON Schema Draft 2020-12 via Ajv's type definitions
+  - We intentionally type this as `import('ajv').AnySchema` to align with Ajv typings while
+    remaining agnostic of Ajv runtime usage. This is a type-only dependency.
+
+  Capability interfaces
+  - StaticConfigurable: for configuration that is provided up front (e.g., via graph definition)
+    and does not change at runtime. Implementations should expose their JSON Schema for static
+    configuration via getStaticConfigSchema, and accept config via setConfig.
+  - DynamicConfigurable: for configuration that may change at runtime (e.g., via UI while the
+    node is running). Implementations should indicate readiness (isDynamicConfigReady), provide a
+    schema via getDynamicConfigSchema, accept updates via setDynamicConfig, and optionally notify
+    consumers when the schema changes.
+  - Provisionable: for components that require external resources (e.g., creating a webhook,
+    registering with a service, warming a model). Implementations report current provisioning
+    state and can expose lifecycle methods provision/deprovision along with an optional
+    onProvisionStateChange subscription.
+  - Pausable: simple pause/resume contract with an isPaused query to support orchestration and
+    maintenance operations.
+
+  Notes
+  - These are foundational contracts only; no runtime behavior is introduced here. Concrete nodes
+    may implement any subset that applies. Server graph types remain unchanged in this iteration.
+*/
+
+export type ConfigSchema = import('ajv').AnySchema;
+
+/**
+ * Provisioning lifecycle high-level states for nodes that manage external resources.
+ */
+export enum ProvisionState {
+  NOT_READY = 'NOT_READY',
+  PROVISIONING = 'PROVISIONING',
+  READY = 'READY',
+  ERROR = 'ERROR',
+  DEPROVISIONING = 'DEPROVISIONING',
+}
+
+/**
+ * Additional details for the current provisioning state.
+ * - since: ISO timestamp when the state was entered
+ * - message: optional human-readable message (status, warnings)
+ * - error: optional error object when in ERROR state
+ * - meta: optional structured diagnostics/metadata for UI or logging
+ */
+export type ProvisionStateDetails = {
+  since: string;
+  message?: string;
+  error?: unknown;
+  meta?: Record<string, unknown>;
+};
+
+/**
+ * Static configuration provided at construction/build time and not expected to change at runtime.
+ * Implementations should validate provided config against the returned JSON Schema (Draft 2020-12).
+ */
+export interface StaticConfigurable<T = Record<string, unknown>> {
+  /** Apply the static configuration. May be synchronous or asynchronous. */
+  setConfig(cfg: T): void | Promise<void>;
+  /** Return the JSON Schema for static configuration. */
+  getStaticConfigSchema(): ConfigSchema | Promise<ConfigSchema>;
+}
+
+/**
+ * Provisionable capability for components that manage external resources.
+ * Implementations should always report a state and may expose lifecycle methods.
+ */
+export interface Provisionable {
+  /** Current provisioning state, optionally with details for UI/diagnostics. */
+  getProvisionState(): { state: ProvisionState; details?: ProvisionStateDetails };
+  /** Optional explicit provisioning action. Implement only if meaningful. */
+  provision?(): Promise<void>;
+  /** Optional explicit deprovisioning action. Implement only if meaningful. */
+  deprovision?(): Promise<void>;
+  /** Optional subscription for provisioning state changes. */
+  onProvisionStateChange?(cb: (s: { state: ProvisionState; details?: ProvisionStateDetails }) => void): void;
+}
+
+/**
+ * Dynamic configuration that may evolve while a node is running (e.g., live config UIs).
+ * Implementations should expose readiness and a JSON Schema for dynamic config.
+ */
+export interface DynamicConfigurable<T = Record<string, unknown>> {
+  /** Whether the dynamic configuration system is currently ready (e.g., schema loaded). */
+  isDynamicConfigReady(): boolean;
+  /** Return the JSON Schema for dynamic configuration (Draft 2020-12). */
+  getDynamicConfigSchema(): ConfigSchema | Promise<ConfigSchema>;
+  /** Apply an updated dynamic configuration. */
+  setDynamicConfig(cfg: T): void | Promise<void>;
+  /** Optional notification when the dynamic config schema changes at runtime. */
+  onDynamicConfigSchemaChanged?(cb: (schema: ConfigSchema) => void): void;
+}
+
+/**
+ * Pause/resume capability for operational control and maintenance windows.
+ */
+export interface Pausable {
+  pause(): Promise<void>;
+  resume(): Promise<void>;
+  isPaused(): boolean;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,11 @@ importers:
         specifier: ^7.1.6
         version: 7.1.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1)
 
-  packages/shared: {}
+  packages/shared:
+    devDependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
 
 packages:
 
@@ -1423,6 +1427,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2001,6 +2008,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2303,6 +2313,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2863,6 +2876,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
@@ -4865,6 +4882,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -5511,6 +5535,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.0: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -5758,6 +5784,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -6245,6 +6273,8 @@ snapshots:
       '@babel/runtime': 7.28.4
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 


### PR DESCRIPTION
Implements Issue #29: Standardize node capabilities across the runtime via shared types.

Summary
- Establish shared capability interfaces and supporting types so all nodes (triggers, agents, MCP, tools) can uniformly expose configuration schemas, provisioning state, and pause controls.
- No runtime behavior changes in this PR; types and exports only.

Decisions
- ConfigSchema = import('ajv').AnySchema (JSON Schema Draft 2020-12), re-exported from shared.

Changes
- packages/shared/src/runtime.types.ts (new):
  - export type ConfigSchema = import('ajv').AnySchema
  - export enum ProvisionState { NOT_READY, PROVISIONING, READY, ERROR, DEPROVISIONING }
  - export type ProvisionStateDetails = { since: string; message?: string; error?: unknown; meta?: Record<string, unknown> }
  - Interfaces with TSDoc:
    - StaticConfigurable<T = Record<string, unknown>>
    - DynamicConfigurable<T = Record<string, unknown>>
    - Provisionable
    - Pausable
  - Header docs describing JSON Schema 2020-12 via Ajv and interface roles.
- packages/shared/src/index.ts: re-export the above without breaking existing exports (TemplateNodeSchema, PersistedGraph*, etc.).

Non-goals
- No server runtime behavior changes.
- No implementation of these interfaces on specific nodes (handled in follow-up issues).

Quality
- Typescript strictness preserved; compiles cleanly.
- Lint/format pass.

References
- Closes #29