### PR TITLE
feat(call_agent): response modes (sync|async/ignore) + caller_agent runtime; docs+tests (#43)

### DIFF
--- a/apps/server/src/agents/base.agent.ts
+++ b/apps/server/src/agents/base.agent.ts
@@ -67,7 +67,7 @@ export abstract class BaseAgent implements TriggerListener, StaticConfigurable {
         {
           messages: { method: 'append', items: batch.map((msg) => new HumanMessage(JSON.stringify(msg))) },
         },
-        { ...this.config, configurable: { ...this.config?.configurable, thread_id: thread } },
+        { ...this.config, configurable: { ...this.config?.configurable, thread_id: thread, caller_agent: this } },
       )) as { messages: BaseMessage[] };
       const lastMessage = response.messages?.[response.messages.length - 1];
       this.logger.info(`Agent response in thread ${thread}: ${lastMessage?.text}`);

--- a/apps/server/src/nodes/tools.node.ts
+++ b/apps/server/src/nodes/tools.node.ts
@@ -46,7 +46,13 @@ export class ToolsNode extends BaseNode {
             return createMessage(`Tool '${tc.name}' not found.`);
           }
           try {
-            const output = await tool.invoke(tc, { configurable: { thread_id: config?.configurable?.thread_id } });
+            const output = await tool.invoke(tc, {
+              configurable: {
+                thread_id: config?.configurable?.thread_id,
+                // pass through the caller agent if provided by the parent agent's runtime
+                caller_agent: (config as any)?.configurable?.caller_agent,
+              },
+            });
             const content = typeof output === 'string' ? output : JSON.stringify(output);
             if (content.length > 50000) {
               return createMessage(`Error (output too long: ${content.length} characters).`);

--- a/apps/server/src/tools/call_agent.tool.ts
+++ b/apps/server/src/tools/call_agent.tool.ts
@@ -28,14 +28,18 @@ export const CallAgentToolStaticConfigSchema = z.object({
     .regex(/^[a-z0-9_]{1,64}$/)
     .optional()
     .describe('Optional tool name (a-z, 0-9, underscore). Default: call_agent'),
+  response: z.enum(['sync', 'async', 'ignore']).default('sync'),
 });
 
-type WithThreadId = LangGraphRunnableConfig & { configurable?: { thread_id?: string } };
+type WithRuntime = LangGraphRunnableConfig & { configurable?: { thread_id?: string; caller_agent?: BaseAgent } };
+
+type SentAck = { status: 'sent' };
 
 export class CallAgentTool extends BaseTool {
   private description = 'Call another agent with a message and optional context.';
   private name: string | undefined;
   private targetAgent: BaseAgent | undefined;
+  private responseMode: 'sync' | 'async' | 'ignore' = 'sync';
 
   constructor(private logger: LoggerService) {
     super();
@@ -46,12 +50,13 @@ export class CallAgentTool extends BaseTool {
   }
 
   async setConfig(cfg: Record<string, unknown>): Promise<void> {
-  const parsed = CallAgentToolStaticConfigSchema.safeParse(cfg);
+    const parsed = CallAgentToolStaticConfigSchema.safeParse(cfg);
     if (!parsed.success) {
       throw new Error('Invalid CallAgentTool config');
     }
     this.description = parsed.data.description ?? this.description;
     this.name = parsed.data.name ?? this.name;
+    this.responseMode = parsed.data.response ?? this.responseMode;
   }
 
   init(config?: LangGraphRunnableConfig): DynamicStructuredTool {
@@ -59,13 +64,13 @@ export class CallAgentTool extends BaseTool {
       async (raw, runtimeCfg) => {
         const parsed = invocationSchema.parse(raw);
         const hasContext = !!parsed.context;
-        this.logger.info('call_agent invoked', { targetAttached: !!this.targetAgent, hasContext });
+        this.logger.info('call_agent invoked', { targetAttached: !!this.targetAgent, hasContext, responseMode: this.responseMode });
 
         if (!this.targetAgent) return 'Target agent is not connected';
 
         const parentThreadId =
-          (runtimeCfg as WithThreadId | undefined)?.configurable?.thread_id ??
-          (config as WithThreadId | undefined)?.configurable?.thread_id;
+          (runtimeCfg as WithRuntime | undefined)?.configurable?.thread_id ??
+          (config as WithRuntime | undefined)?.configurable?.thread_id;
         if (!parentThreadId) {
           throw new Error('thread_id is required');
         }
@@ -82,9 +87,44 @@ export class CallAgentTool extends BaseTool {
         };
 
         try {
-          const res: BaseMessage | undefined = await this.targetAgent.invoke(targetThreadId, [triggerMessage]);
-          if (!res) return '';
-          return res.text ?? '';
+          if (this.responseMode === 'sync') {
+            const res: BaseMessage | undefined = await this.targetAgent.invoke(targetThreadId, [triggerMessage]);
+            if (!res) return '';
+            return res.text ?? '';
+          }
+
+          // For async/ignore, fire and return immediately
+          const promise = this.targetAgent
+            .invoke(targetThreadId, [triggerMessage])
+            .then(async (res) => {
+              if (this.responseMode !== 'async') return; // ignore mode: no callback
+              try {
+                const caller = (runtimeCfg as WithRuntime | undefined)?.configurable?.caller_agent ??
+                  (config as WithRuntime | undefined)?.configurable?.caller_agent;
+                if (!caller) {
+                  this.logger.error('call_agent async callback skipped: caller_agent missing');
+                  return;
+                }
+                const childText = res?.text ?? '';
+                const callbackMsg: TriggerMessage = {
+                  content: childText,
+                  info: { from: 'agent', childThreadId: parsed.childThreadId },
+                };
+                await caller.invoke(parentThreadId, [callbackMsg]);
+              } catch (err: any) {
+                // Best-effort: log only, no error propagation to tool caller
+                this.logger.error('Error during async callback to parent agent', err?.message || err, err?.stack);
+              }
+            })
+            .catch((err) => {
+              // Log error from child invoke; no error callback to parent for now
+              this.logger.error('Error calling agent (async/ignore mode)', err?.message || err, err?.stack);
+            });
+
+          // Ensure promise is not unhandled in environments without global handlers
+          void promise;
+          const ack: SentAck = { status: 'sent' };
+          return ack;
         } catch (err: any) {
           this.logger.error('Error calling agent', err?.message || err, err?.stack);
           return `Error calling agent: ${err?.message || String(err)}`;

--- a/docs/tool-call-agent.md
+++ b/docs/tool-call-agent.md
@@ -1,10 +1,15 @@
 # CallAgentTool
 
 Purpose
-- Let one agent synchronously invoke another agent as a subtask.
+- Let one agent invoke another agent as a subtask.
 
 Configuration
 - description: string (required). Shown to the LLM as the tool description.
+- name: string (optional) Tool name override.
+- response: 'sync' | 'async' | 'ignore' (optional, default 'sync')
+  - sync: default. Wait for the child agent to complete and return its text.
+  - async: return {status: 'sent'} immediately; when the child completes, the parent (caller) is invoked with a TriggerMessage carrying the child output.
+  - ignore: return {status: 'sent'} immediately and do not callback.
 
 Ports
 - targetPorts
@@ -14,26 +19,35 @@ Ports
 
 Invocation schema (LLM arguments)
 - input: string (required). The message to forward.
-- context: object (optional). Passed through to TriggerMessage.info.
+- context: any (optional). Passed through to TriggerMessage.info when calling the child.
+- childThreadId: string (required). Appended to the parent thread id as `${parentThreadId}__${childThreadId}` to form the child thread id.
 
 Behavior
 - If no target agent attached: returns exactly the string "Target agent is not connected".
-- Thread ID is read from config.configurable.thread_id; if missing, defaults to "default".
-- Forwards TriggerMessage { content: input, info: context || {} } to BaseAgent.invoke(threadId, [message]).
-- Returns the target agent's last message text if available; otherwise a JSON string of the message; empty string if no result.
-- Errors are caught and returned as text: `Error calling agent: <message>`.
+- Parent thread id comes from runtime config: configurable.thread_id.
+- Child thread id = `${parentThreadId}__${childThreadId}`.
+- Forwards TriggerMessage { content: input, info: context || {} } to BaseAgent.invoke(childThreadId, [message]).
+- sync: returns the child agent's last message text (empty string if undefined).
+- async: returns `{status: 'sent'}` immediately; when the child completes, invokes the caller agent with:
+  - thread: parentThreadId
+  - message: { content: <childText>, info: { from: 'agent', childThreadId: <childThreadId> } }
+- ignore: returns `{status: 'sent'}` immediately; no callback is made even if the child succeeds or fails.
+- Async errors are only logged; no error callback is sent to parent.
+
+Caller agent reference (runtime wiring)
+- Async callbacks require the caller agent instance to be available at runtime as `configurable.caller_agent`.
+- The BaseAgent passes `caller_agent: this` into the graph runtime, and ToolsNode forwards `configurable.caller_agent` into the tool invocation runtime config.
 
 Graph wiring example
 
 Nodes
 - A: { template: 'simpleAgent' }
 - B: { template: 'simpleAgent' }
-- T: { template: 'callAgentTool', config: { description: "Call B to evaluate something" } }
+- T: { template: 'callAgentTool', config: { description: "Call B to evaluate something", response: 'async' } }
 
 Edges
 - { source: 'A', sourceHandle: 'tools', target: 'T', targetHandle: '$self' }
 - { source: 'T', sourceHandle: 'agent', target: 'B', targetHandle: '$self' }
 
 Notes
-- The description field is the only valid configuration key; any other keys are ignored.
-- Logging: each invocation logs info with { targetAttached: boolean, hasContext: boolean } and errors with message and stack.
+- Logging: each invocation logs info with { targetAttached, hasContext, responseMode } and errors with message and stack.


### PR DESCRIPTION
Implements Issue #43: Add response mode to call_agent.tool (sync | async | ignore) and pass caller_agent via runtime config.

What changed
- CallAgentTool
  - Static config extended with `response: 'sync' | 'async' | 'ignore'` (default 'sync')
  - Sync (default): behavior unchanged (await child and return text)
  - Async: return `{status: 'sent'}` immediately; when child completes, invoke the parent thread via caller_agent with TriggerMessage `{ content: <childText>, info: { from: 'agent', childThreadId } }`
  - Ignore: return `{status: 'sent'}` immediately; no callback
  - Robust logging; best-effort async error logging without upstream error callback
- Runtime propagation of caller agent
  - BaseAgent.invoke now injects `caller_agent: this` into graph runtime configurable
  - ToolsNode forwards `configurable.caller_agent` into tool runtime config (alongside thread_id)
- Docs
  - docs/tool-call-agent.md updated to document response modes and async callback shape/requirement
- Tests
  - New tests for async and ignore modes; existing tests unchanged and still green

Notes
- Parent thread id from runtimeCfg.configurable.thread_id
- Child thread id = `${parentThreadId}__${childThreadId}`
- ToolsNode continues to stringify non-string outputs; returning `{status:'sent'}` works

Quality gates
- Tests: pnpm -C apps/server test -> all tests passed locally
- Prettier: ran on modified files

Acceptance
- Default sync unchanged
- Async posts a TriggerMessage to parent when child completes
- Ignore never posts back

Closes #43.