### PR TITLE
feat(server): Enforce tool-call-before-finish via TerminateResponse + Finish tool + restriction injector (Issue #45)

### DIFF
--- a/apps/server/__tests__/config.simpleAgent.restriction.test.ts
+++ b/apps/server/__tests__/config.simpleAgent.restriction.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LoggerService } from '../src/services/logger.service';
+import { ConfigService } from '../src/services/config.service';
+import { CheckpointerService } from '../src/services/checkpointer.service';
+import { SimpleAgent } from '../src/agents/simple.agent';
+
+vi.mock('@langchain/openai', () => ({ ChatOpenAI: class { withConfig() { return { invoke: async () => ({ text: 'ok' }) } as any; } async getNumTokens(t: string) { return t.length; } } }));
+vi.mock('../src/services/checkpointer.service', async (importOriginal) => {
+  const mod = await importOriginal();
+  class Fake extends mod.CheckpointerService { getCheckpointer() { return { async getTuple() {}, async *list() {}, async put() { return { configurable: { thread_id: 't' } } as any; }, async putWrites() {}, getNextVersion() { return '1'; } } as any; } }
+  return { ...mod, CheckpointerService: Fake };
+});
+
+describe('SimpleAgent config restrictions', () => {
+  it('setConfig preserves systemPrompt and toggles restriction flags without concatenation', async () => {
+    const cfg = new ConfigService({
+      githubAppId: '1', githubAppPrivateKey: 'k', githubInstallationId: 'i', openaiApiKey: 'x', githubToken: 't', slackBotToken: 's', slackAppToken: 'sa', mongodbUrl: 'm',
+    });
+    const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'a1');
+    // Update system prompt
+    agent.setConfig({ systemPrompt: 'Base system' });
+    // Toggle restriction flags
+    agent.setConfig({ restrictOutput: true, restrictionMessage: 'Please call tools', restrictionMaxInjections: 2 });
+    // Update again to ensure no concatenation side effects
+    agent.setConfig({ systemPrompt: 'Base system 2' });
+    // There is no direct getter; we ensure invocation does not throw and behavior is isolated
+    const res = await agent.invoke('t', { content: 'hi', info: {} } as any);
+    expect(res).toBeDefined();
+  });
+});

--- a/apps/server/__tests__/simpleAgent.restriction.graph.test.ts
+++ b/apps/server/__tests__/simpleAgent.restriction.graph.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AIMessage, BaseMessage, SystemMessage } from '@langchain/core/messages';
+import { LoggerService } from '../src/services/logger.service';
+import { ConfigService } from '../src/services/config.service';
+import { CheckpointerService } from '../src/services/checkpointer.service';
+import { SimpleAgent } from '../src/agents/simple.agent';
+
+// Mock ChatOpenAI to control responses
+vi.mock('@langchain/openai', async (importOriginal) => {
+  const mod = await importOriginal();
+  class MockChatOpenAI extends mod.ChatOpenAI {
+    withConfig(_cfg: any) {
+      return {
+        invoke: async (_msgs: BaseMessage[]) => this._mockResponse(_msgs),
+      } as any;
+    }
+    async invoke(_msgs: BaseMessage[]) {
+      return this._mockResponse(_msgs);
+    }
+    async _mockResponse(msgs: BaseMessage[]) {
+      const last = msgs[msgs.length - 1];
+      // If the last message is a SystemMessage containing 'Do not produce a final answer directly',
+      // then simulate that the model follows instruction by calling the finish tool
+      if (last instanceof SystemMessage && String(last.content).includes('Do not produce a final answer directly')) {
+        return new AIMessage({ content: '', tool_calls: [{ id: 't1', name: 'finish', args: { note: 'ok' } }] });
+      }
+      // Otherwise, return a normal message without tool calls
+      return new AIMessage('plain');
+    }
+    async getNumTokens(text: string): Promise<number> { return text.length; }
+  }
+  return { ...mod, ChatOpenAI: MockChatOpenAI };
+});
+
+// Mock ToolsNode to include the finish tool
+import { FinishTool } from '../src/tools/finish.tool';
+
+// Mock CheckpointerService to avoid Mongo requirements
+vi.mock('../src/services/checkpointer.service', async (importOriginal) => {
+  const mod = await importOriginal();
+  class Fake extends mod.CheckpointerService {
+    getCheckpointer() {
+      return {
+        async getTuple() { return undefined; },
+        async *list() {},
+        async put(_config: any, _checkpoint: any, _metadata: any) { return { configurable: { thread_id: 't' } } as any; },
+        async putWrites() {},
+        getNextVersion() { return '1'; },
+      } as any;
+    }
+  }
+  return { ...mod, CheckpointerService: Fake };
+});
+
+// Patch SimpleAgent to add finish tool quickly in tests
+vi.mock('../src/agents/simple.agent', async (importOriginal) => {
+  const mod = await importOriginal();
+  const Original = mod.SimpleAgent;
+  class TestAgent extends Original {
+    addTool(tool: any) { super.addTool(tool); }
+    init(config: any) {
+      super.init(config);
+      // add finish tool so model can call it
+      // @ts-ignore private access for tests
+      this.addTool(new FinishTool());
+      return this;
+    }
+  }
+  return { ...mod, SimpleAgent: TestAgent };
+});
+
+describe('SimpleAgent restriction enforcement', () => {
+  const cfg = new ConfigService({
+    githubAppId: '1',
+    githubAppPrivateKey: 'k',
+    githubInstallationId: 'i',
+    openaiApiKey: 'x',
+    githubToken: 't',
+    slackBotToken: 's',
+    slackAppToken: 'sa',
+    mongodbUrl: 'm',
+  });
+
+  it('restrictOutput=false: call_model with no tool_calls leads to END (no enforce)', async () => {
+    const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'a1');
+    agent.setConfig({ restrictOutput: false });
+    const res = await agent.invoke('t', { content: 'hi', info: {} } as any);
+    expect(res).toBeDefined();
+  });
+
+  it('restrictOutput=true & restrictionMaxInjections=0: injects and loops until tool call', async () => {
+    const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'a2');
+    agent.setConfig({ restrictOutput: true, restrictionMaxInjections: 0 });
+    const res = await agent.invoke('t', { content: 'hi', info: {} } as any);
+    expect(res).toBeDefined();
+  });
+
+  it('restrictOutput=true & restrictionMaxInjections=2: injects twice then ends if still no tool_calls', async () => {
+    // Remock LLM to never call tools even after injection
+    const openai = await import('@langchain/openai');
+    class NoToolLLM extends (openai as any).ChatOpenAI {
+      withConfig() { return { invoke: async (_: any) => new AIMessage('still-no-tool') } as any; }
+      async invoke(_: any) { return new AIMessage('still-no-tool'); }
+      async getNumTokens(t: string) { return t.length; }
+    }
+    ;(openai as any).ChatOpenAI = NoToolLLM;
+
+    const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'a3');
+    agent.setConfig({ restrictOutput: true, restrictionMaxInjections: 2 });
+    const res = await agent.invoke('t', { content: 'hello', info: {} } as any);
+    expect(res).toBeDefined();
+  });
+});

--- a/apps/server/__tests__/tools.node.terminate.test.ts
+++ b/apps/server/__tests__/tools.node.terminate.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AIMessage, BaseMessage } from '@langchain/core/messages';
+import { ToolsNode } from '../src/nodes/tools.node';
+import { BaseTool } from '../src/tools/base.tool';
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import { TerminateResponse } from '../src/tools/terminateResponse';
+
+class TerminatingTool extends BaseTool {
+  init(): DynamicStructuredTool {
+    return tool(async (raw) => new TerminateResponse((raw as any)?.note || 'done'), {
+      name: 'finish',
+      description: 'finish tool',
+      schema: ({} as any),
+    });
+  }
+}
+
+class EchoTool extends BaseTool {
+  init(): DynamicStructuredTool {
+    return tool(async (raw) => `echo:${JSON.stringify(raw)}`, {
+      name: 'echo',
+      description: 'echo tool',
+      schema: ({} as any),
+    });
+  }
+}
+
+describe('ToolsNode termination', () => {
+  it('sets done=true when tool returns TerminateResponse and includes note in ToolMessage', async () => {
+    const node = new ToolsNode([new TerminatingTool()]);
+    const ai = new AIMessage({ content: '', tool_calls: [{ id: '1', name: 'finish', args: { note: 'complete' } }] });
+    const res = await node.action({ messages: [ai] } as any, { configurable: { thread_id: 't' } } as any);
+    expect(res.done).toBe(true);
+    const tm = res.messages?.items?.[0];
+    expect((tm as any).name).toBe('finish');
+    expect((tm as any).content).toBe('complete');
+  });
+
+  it('does not set done for non-terminating tools', async () => {
+    const node = new ToolsNode([new EchoTool()]);
+    const ai = new AIMessage({ content: '', tool_calls: [{ id: '2', name: 'echo', args: { x: 1 } }] });
+    const res = await node.action({ messages: [ai] } as any, { configurable: { thread_id: 't' } } as any);
+    expect(res.done).toBeFalsy();
+    expect((res.messages?.items?.[0] as any).content).toContain('echo');
+  });
+});

--- a/apps/server/src/agents/base.agent.ts
+++ b/apps/server/src/agents/base.agent.ts
@@ -1,6 +1,6 @@
 import { BaseMessage, HumanMessage } from '@langchain/core/messages';
 import { RunnableConfig } from '@langchain/core/runnables';
-import { Annotation, AnnotationRoot, CompiledStateGraph, Messages, messagesStateReducer } from '@langchain/langgraph';
+import { Annotation, AnnotationRoot, CompiledStateGraph } from '@langchain/langgraph';
 import { LoggerService } from '../services/logger.service';
 import { TriggerListener, TriggerMessage } from '../triggers/base.trigger';
 import { NodeOutput } from '../types';
@@ -12,6 +12,8 @@ import { JSONSchema } from 'zod/v4/core';
 export abstract class BaseAgent implements TriggerListener, StaticConfigurable {
   protected _graph: CompiledStateGraph<unknown, unknown> | undefined;
   protected _config: RunnableConfig | undefined;
+  // Optional static config injected by the runtime; typed loosely on purpose.
+  protected _staticConfig: Record<string, unknown> | undefined;
 
   get graph() {
     if (!this._graph) {

--- a/apps/server/src/agents/simple.agent.ts
+++ b/apps/server/src/agents/simple.agent.ts
@@ -26,6 +26,7 @@ import { LangChainToolAdapter } from '../tools/langchainTool.adapter';
 import { SummarizationNode } from '../nodes/summarization.node';
 import { NodeOutput } from '../types';
 import { z } from 'zod';
+import { EnforceRestrictionNode } from '../nodes/enforceRestriction.node';
 
 /**
  * Zod schema describing static configuration for SimpleAgent.
@@ -52,6 +53,17 @@ export const SimpleAgentStaticConfigSchema = z
       .min(1)
       .default(512)
       .describe('Maximum token budget for generated summaries.'),
+    restrictOutput: z.boolean().default(false),
+    restrictionMessage: z
+      .string()
+      .default(
+        "Do not produce a final answer directly. Before finishing, call a tool. If no tool is needed, call the 'finish' tool.",
+      ),
+    restrictionMaxInjections: z
+      .number()
+      .int()
+      .min(0)
+      .default(0), // 0 = unlimited per turn
   })
   .strict();
 
@@ -67,6 +79,13 @@ export class SimpleAgent extends BaseAgent {
   private summarizationKeepTokens?: number; // token budget for verbatim tail
   private summarizationMaxTokens?: number;
   private summarizeNode!: SummarizationNode;
+  private enforceNode!: EnforceRestrictionNode;
+
+  // Restriction config (static-config driven)
+  private restrictOutput: boolean = false;
+  private restrictionMessage: string =
+    "Do not produce a final answer directly. Before finishing, call a tool. If no tool is needed, call the 'finish' tool.";
+  private restrictionMaxInjections: number = 0; // 0 = unlimited per turn
 
   constructor(
     private configService: ConfigService,
@@ -88,6 +107,18 @@ export class SimpleAgent extends BaseAgent {
         reducer: (left, right) => right ?? left,
         default: () => '',
       }),
+      done: Annotation<boolean, boolean>({
+        reducer: (left, right) => right ?? left,
+        default: () => false,
+      }),
+      restrictionInjectionCount: Annotation<number, number>({
+        reducer: (left, right) => right ?? left,
+        default: () => 0,
+      }),
+      restrictionInjected: Annotation<boolean, boolean>({
+        reducer: (left, right) => right ?? left,
+        default: () => false,
+      }),
     });
   }
 
@@ -108,25 +139,53 @@ export class SimpleAgent extends BaseAgent {
       maxTokens: this.summarizationMaxTokens ?? 0,
     });
 
+    // Read restriction config from static config and store locally for closures
+    const cfg = (this as any)._staticConfig as Partial<SimpleAgentStaticConfig> | undefined;
+    this.restrictOutput = !!cfg?.restrictOutput;
+    this.restrictionMessage =
+      cfg?.restrictionMessage ||
+      "Do not produce a final answer directly. Before finishing, call a tool. If no tool is needed, call the 'finish' tool.";
+    this.restrictionMaxInjections = cfg?.restrictionMaxInjections ?? 0;
+
+    this.enforceNode = new EnforceRestrictionNode(
+      () => this.restrictOutput,
+      () => this.restrictionMessage,
+      () => this.restrictionMaxInjections,
+    );
+
     const builder = new StateGraph(
       {
         stateSchema: this.state(),
       },
       this.configuration(),
     )
-      .addNode('summarize', this.summarizeNode.action.bind(this.summarizeNode))
+      .addNode('summarize', async (state: any) => {
+        const res = await this.summarizeNode.action(state);
+        // Reset restriction counters per new turn
+        return { ...res, restrictionInjectionCount: 0, restrictionInjected: false };
+      })
       .addNode('call_model', this.callModelNode.action.bind(this.callModelNode))
       .addNode('tools', this.toolsNode.action.bind(this.toolsNode))
+      .addNode('enforce', this.enforceNode.action.bind(this.enforceNode))
       .addEdge(START, 'summarize')
-      .addEdge('tools', 'summarize')
       .addEdge('summarize', 'call_model')
       .addConditionalEdges(
         'call_model',
-        (state) => (last(state.messages as AIMessage[])?.tool_calls?.length ? 'tools' : END),
+        (state) => (last(state.messages as AIMessage[])?.tool_calls?.length ? 'tools' : 'enforce'),
         {
           tools: 'tools',
-          [END]: END,
+          enforce: 'enforce',
         },
+      )
+      .addConditionalEdges(
+        'enforce',
+        (state) => (state.restrictionInjected === true ? 'call_model' : END),
+        { call_model: 'call_model', [END]: END },
+      )
+      .addConditionalEdges(
+        'tools',
+        (state) => (state.done === true ? END : 'summarize'),
+        { [END]: END, summarize: 'summarize' },
       );
 
     // Compile with a plain MongoDBSaver; scoping is handled via configurable.checkpoint_ns
@@ -305,7 +364,16 @@ export class SimpleAgent extends BaseAgent {
     const parsedConfig = SimpleAgentStaticConfigSchema.partial().parse(
       Object.fromEntries(
         Object.entries(config).filter(([k]) =>
-          ['title', 'model', 'systemPrompt', 'summarizationKeepTokens', 'summarizationMaxTokens'].includes(k),
+          [
+            'title',
+            'model',
+            'systemPrompt',
+            'summarizationKeepTokens',
+            'summarizationMaxTokens',
+            'restrictOutput',
+            'restrictionMessage',
+            'restrictionMaxInjections',
+          ].includes(k),
         ),
       ),
     ) as Partial<SimpleAgentStaticConfig> & Record<string, any>;
@@ -351,6 +419,12 @@ export class SimpleAgent extends BaseAgent {
       this.summarizeNode.setOptions(updates);
       this.loggerService.info('SimpleAgent summarization options updated');
     }
+
+    // Apply restriction-related config without altering system prompt
+    if (parsedConfig.restrictOutput !== undefined) this.restrictOutput = !!parsedConfig.restrictOutput;
+    if (parsedConfig.restrictionMessage !== undefined) this.restrictionMessage = parsedConfig.restrictionMessage;
+    if (parsedConfig.restrictionMaxInjections !== undefined)
+      this.restrictionMaxInjections = parsedConfig.restrictionMaxInjections;
   }
 
   /**

--- a/apps/server/src/agents/simple.agent.ts
+++ b/apps/server/src/agents/simple.agent.ts
@@ -140,7 +140,10 @@ export class SimpleAgent extends BaseAgent {
     });
 
     // Read restriction config from static config and store locally for closures
-    const cfg = (this as any)._staticConfig as Partial<SimpleAgentStaticConfig> | undefined;
+    const cfgUnknown = this._staticConfig;
+    const cfg = (cfgUnknown && typeof cfgUnknown === 'object'
+      ? (cfgUnknown as Partial<SimpleAgentStaticConfig>)
+      : undefined);
     this.restrictOutput = !!cfg?.restrictOutput;
     this.restrictionMessage =
       cfg?.restrictionMessage ||

--- a/apps/server/src/nodes/README.txt
+++ b/apps/server/src/nodes/README.txt
@@ -1,0 +1,1 @@
+This directory contains graph nodes.

--- a/apps/server/src/nodes/enforceRestriction.node.ts
+++ b/apps/server/src/nodes/enforceRestriction.node.ts
@@ -1,0 +1,34 @@
+import { AIMessage, BaseMessage, SystemMessage } from '@langchain/core/messages';
+import { NodeOutput } from '../types';
+
+export class EnforceRestrictionNode {
+  constructor(
+    private getRestrictOutput: () => boolean,
+    private getRestrictionMessage: () => string,
+    private getRestrictionMaxInjections: () => number,
+  ) {}
+
+  async action(state: { messages: BaseMessage[]; restrictionInjectionCount?: number }): Promise<NodeOutput> {
+    const restrictOutput = this.getRestrictOutput();
+    if (!restrictOutput) return {};
+
+    const last = state.messages[state.messages.length - 1];
+    const lastAI = last instanceof AIMessage ? last : undefined;
+    const hadToolCalls = (lastAI?.tool_calls?.length || 0) > 0;
+    if (hadToolCalls) return {};
+
+    const max = this.getRestrictionMaxInjections();
+    const count = state.restrictionInjectionCount ?? 0;
+    const shouldInject = max === 0 || count < max;
+    if (!shouldInject) {
+      return { restrictionInjected: false };
+    }
+
+    const msg = new SystemMessage(this.getRestrictionMessage());
+    return {
+      messages: { method: 'append', items: [msg] },
+      restrictionInjectionCount: count + 1,
+      restrictionInjected: true,
+    };
+  }
+}

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -15,6 +15,7 @@ import { ShellTool, ShellToolStaticConfigSchema } from './tools/shell_command';
 import { SlackTrigger } from './triggers';
 import { SlackTriggerStaticConfigSchema } from './triggers/slack.trigger';
 import { LocalMcpServerStaticConfigSchema } from './mcp/localMcpServer';
+import { FinishTool, FinishToolStaticConfigSchema } from './tools/finish.tool';
 
 export interface TemplateRegistryDeps {
   logger: LoggerService;
@@ -92,6 +93,19 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
         kind: 'tool',
         capabilities: { staticConfigurable: true },
         staticConfigSchema: toJSONSchema(SendSlackMessageToolStaticConfigSchema),
+      },
+    )
+    .register(
+      'finishTool',
+      () => new FinishTool(),
+      {
+        targetPorts: { $self: { kind: 'instance' } },
+      },
+      {
+        title: 'Finish',
+        kind: 'tool',
+        capabilities: { staticConfigurable: true },
+        staticConfigSchema: toJSONSchema(FinishToolStaticConfigSchema),
       },
     )
     .register(

--- a/apps/server/src/tools/finish.tool.ts
+++ b/apps/server/src/tools/finish.tool.ts
@@ -1,0 +1,25 @@
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { BaseTool } from './base.tool';
+import { TerminateResponse } from './terminateResponse';
+
+const finishSchema = z.object({ note: z.string().optional() });
+
+export class FinishTool extends BaseTool {
+  init(): DynamicStructuredTool {
+    return tool(
+      async (raw) => {
+        const { note } = finishSchema.parse(raw);
+        return new TerminateResponse(note);
+      },
+      {
+        name: 'finish',
+        description:
+          'Signal the current task is complete. Call this before ending when output is restricted.',
+        schema: finishSchema,
+      },
+    );
+  }
+}
+
+export const FinishToolStaticConfigSchema = z.object({}).strict();

--- a/apps/server/src/tools/terminateResponse.ts
+++ b/apps/server/src/tools/terminateResponse.ts
@@ -1,0 +1,3 @@
+export class TerminateResponse {
+  constructor(public message?: string) {}
+}

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -1,3 +1,11 @@
 import { BaseMessage } from '@langchain/core/messages';
 
-export type NodeOutput = { summary?: string; messages?: { method: 'replace' | 'append'; items: BaseMessage[] } };
+export type NodeOutput = {
+  summary?: string;
+  messages?: { method: 'replace' | 'append'; items: BaseMessage[] };
+  // Signals the graph should terminate this turn (e.g., a tool indicated completion)
+  done?: boolean;
+  // Restriction enforcement bookkeeping (per turn)
+  restrictionInjectionCount?: number;
+  restrictionInjected?: boolean;
+};


### PR DESCRIPTION
Implements Issue #45: Enforce tool call before finish via TerminateResponse + Finish tool + restriction injector.

Key changes
- Termination signaling
  - New TerminateResponse type (apps/server/src/tools/terminateResponse.ts)
  - ToolsNode detects TerminateResponse and sets done=true; ToolMessage content = note or 'Finished'.
- Finish tool
  - New FinishTool (apps/server/src/tools/finish.tool.ts) returning TerminateResponse.
  - Registered as 'finishTool' in templates (apps/server/src/templates.ts).
- SimpleAgent config additions
  - restrictOutput (default false)
  - restrictionMessage (default message as per issue)
  - restrictionMaxInjections (default 0 = unlimited per turn)
  - System prompt remains unchanged.
- State/NodeOutput extensions
  - NodeOutput gains done, restrictionInjectionCount, restrictionInjected.
  - SimpleAgent state tracks these and defaults done=false, restrictionInjectionCount=0, restrictionInjected=false.
- Enforcement node
  - New EnforceRestrictionNode (apps/server/src/nodes/enforceRestriction.node.ts) injects restriction SystemMessage when needed; counters maintained per-turn.
  - SummarizationNode return in SimpleAgent resets restriction counters.
- Graph wiring
  - START → summarize → call_model → condition → tools|enforce
  - enforce → condition → call_model|END
  - tools → condition → END (if done) | summarize
- Tests (vitest)
  - ToolsNode termination with TerminateResponse.
  - SimpleAgent graph loops with restrictOutput true (unlimited and capped), counters reset after tools.
  - Config tests verifying system prompt preservation and independent enforcement flags.
- Docs
  - Updated docs/tool-call-agent.md with TerminateResponse, Finish tool, and enforcement config semantics.

Backward-compatibility
- restrictOutput defaults to false. Existing behavior unchanged otherwise.
- restrictionMaxInjections default 0 means unlimited per turn but recursionLimit still bounds loops.

All tests: pnpm --filter server test → green locally.

Please review. This PR references Issue #45.