### PR TITLE
Refactor: Agent-side MessagesBuffer + scheduling; triggers simplified; tool-time injection

### DIFF
--- a/apps/server/__tests__/base.trigger.pausable.test.ts
+++ b/apps/server/__tests__/base.trigger.pausable.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { BaseTrigger, BaseTriggerOptions, TriggerMessage } from '../src/triggers/base.trigger';
+import { BaseTrigger, TriggerMessage } from '../src/triggers/base.trigger';
 
 class TestTrigger extends BaseTrigger {
-  constructor(options?: BaseTriggerOptions) { super(options); }
+  constructor() { super(); }
   send(thread: string, messages: TriggerMessage[]) { return this['notify'](thread, messages); }
 }
 
@@ -24,28 +24,5 @@ describe('BaseTrigger Pausable', () => {
     await t.send('th1', [{ content: 'd', info: {} }]);
     expect(calls.length).toBe(2);
     expect(calls[1].msgs.map(m => m.content)).toEqual(['d']);
-  });
-
-  it('works with debounce + paused gating', async () => {
-    vi.useFakeTimers();
-    const t = new TestTrigger({ debounceMs: 50 });
-    const batches: string[][] = [];
-    await t.subscribe({ invoke: async (_thread, msgs) => { batches.push(msgs.map(m => m.content)); } });
-
-    // Pause, then send -> should drop
-    t.pause();
-    t.send('th', [{ content: 'x', info: {} }]);
-    await Promise.resolve();
-    expect(batches.length).toBe(0);
-
-    // Resume and send two within window -> single batch
-    t.resume();
-    t.send('th', [{ content: 'a', info: {} }]);
-    vi.advanceTimersByTime(25);
-    t.send('th', [{ content: 'b', info: {} }]);
-    await vi.advanceTimersByTimeAsync(50);
-    expect(batches.length).toBe(1);
-    expect(batches[0]).toEqual(['a', 'b']);
-    vi.useRealTimers();
   });
 });

--- a/apps/server/__tests__/base.trigger.test.ts
+++ b/apps/server/__tests__/base.trigger.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BaseTrigger, BaseTriggerOptions, TriggerMessage } from '../src/triggers/base.trigger';
+import { BaseTrigger, TriggerMessage } from '../src/triggers/base.trigger';
 
 // Concrete test subclass exposing protected notify
 class TestTrigger extends BaseTrigger {
-  constructor(options?: BaseTriggerOptions) {
-    super(options);
+  constructor() {
+    super();
   }
   emit(thread: string, messages: TriggerMessage[]) {
     return this.notify(thread, messages);
@@ -16,7 +16,7 @@ describe('BaseTrigger', () => {
     vi.useRealTimers();
   });
 
-  it('delivers immediately without debounce/waitForBusy', async () => {
+  it('delivers to listeners immediately', async () => {
     const trigger = new TestTrigger();
     const received: { thread: string; messages: TriggerMessage[] }[] = [];
     await trigger.subscribe({
@@ -27,99 +27,5 @@ describe('BaseTrigger', () => {
     await trigger.emit('t1', [{ content: 'a', info: {} }]);
     expect(received.length).toBe(1);
     expect(received[0].messages.map((m) => m.content)).toEqual(['a']);
-  });
-
-  it('debounces messages within window', async () => {
-    vi.useFakeTimers();
-    const trigger = new TestTrigger({ debounceMs: 100 });
-    const received: TriggerMessage[][] = [];
-    await trigger.subscribe({
-      invoke: async (_thread, messages) => {
-        received.push(messages);
-      },
-    });
-    trigger.emit('t1', [{ content: 'a', info: {} }]);
-    vi.advanceTimersByTime(50);
-    trigger.emit('t1', [{ content: 'b', info: {} }]);
-    vi.advanceTimersByTime(99); // still not fired
-    expect(received.length).toBe(0);
-    vi.advanceTimersByTime(1); // reach 100ms since last
-    await Promise.resolve(); // allow microtasks
-    expect(received.length).toBe(1);
-    expect(received[0].map((m) => m.content)).toEqual(['a', 'b']);
-    vi.useRealTimers();
-  });
-
-  it('waitForBusy aggregates while listener busy (no debounce)', async () => {
-    const trigger = new TestTrigger({ waitForBusy: true });
-    const receivedBatches: string[][] = [];
-    const first = { resolve: null as null | (() => void) };
-    await trigger.subscribe({
-      invoke: async (_thread, messages) => {
-        receivedBatches.push(messages.map((m) => m.content));
-        if (!first.resolve) {
-          await new Promise<void>((res) => {
-            first.resolve = res;
-          });
-        }
-      },
-    });
-    // First emit starts busy listener
-    trigger.emit('t1', [{ content: 'a', info: {} }]);
-    // During busy, we emit more messages
-    trigger.emit('t1', [{ content: 'b', info: {} }]);
-    trigger.emit('t1', [{ content: 'c', info: {} }]);
-    expect(receivedBatches.length).toBe(1); // only first delivered so far
-    // Finish first listener
-    if (first.resolve) {
-      first.resolve();
-    }
-    // Allow event loop to process next flush
-    await new Promise((res) => setTimeout(res, 0));
-    expect(receivedBatches.length).toBe(2);
-    expect(receivedBatches[1]).toEqual(['b', 'c']);
-  });
-
-  it('waitForBusy + debounce merges messages and flushes after busy then debounce', async () => {
-    vi.useFakeTimers();
-    const trigger = new TestTrigger({ waitForBusy: true, debounceMs: 50 });
-    const batches: string[][] = [];
-    let firstResolve: (() => void) | null = null as any;
-    await trigger.subscribe({
-      invoke: async (_thread, messages) => {
-        batches.push(messages.map((m) => m.content));
-        if (!firstResolve) {
-          await new Promise<void>((res) => {
-            firstResolve = res;
-          });
-        }
-      },
-    });
-    // Emit first message at t=0 (debounce 50ms)
-    trigger.emit('t1', [{ content: 'a', info: {} }]);
-    vi.advanceTimersByTime(49);
-    expect(batches.length).toBe(0);
-    vi.advanceTimersByTime(1); // t=50ms first flush -> listener busy (unresolved promise)
-    await Promise.resolve();
-    expect(batches.length).toBe(1);
-    // Emit two more messages during busy period
-    trigger.emit('t1', [{ content: 'b', info: {} }]);
-    trigger.emit('t1', [{ content: 'c', info: {} }]);
-    expect(batches.length).toBe(1);
-    // Resolve first busy listener -> schedules second debounce (50ms)
-    if (firstResolve) firstResolve();
-    // Allow promise resolution and scheduling of debounce timer
-    await Promise.resolve();
-    await Promise.resolve();
-    // Still only first batch
-    expect(batches.length).toBe(1);
-    // Advance almost full debounce window - should not flush yet
-  await vi.advanceTimersByTimeAsync(49);
-    expect(batches.length).toBe(1);
-  // Advance remaining 1ms to trigger flush and await async timers
-  await vi.advanceTimersByTimeAsync(1);
-    expect(batches.length).toBe(2);
-    expect(batches[1]).toEqual(['b', 'c']);
-    vi.useRealTimers();
   });
 });

--- a/apps/server/__tests__/messagesBuffer.test.ts
+++ b/apps/server/__tests__/messagesBuffer.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MessagesBuffer, ProcessBuffer } from '../src/agents/messagesBuffer';
+
+describe('MessagesBuffer', () => {
+  it('drains immediately when debounce=0', () => {
+    const b = new MessagesBuffer({ debounceMs: 0 });
+    b.enqueue('t', { content: 'a', info: {} } as any, 1000);
+    expect(b.tryDrain('t', ProcessBuffer.AllTogether, 1001).map((m) => m.content)).toEqual(['a']);
+  });
+
+  it('debounces until window elapses', () => {
+    const b = new MessagesBuffer({ debounceMs: 50 });
+    b.enqueue('t', { content: 'a', info: {} } as any, 0);
+    expect(b.tryDrain('t', ProcessBuffer.AllTogether, 10)).toEqual([]);
+    b.enqueue('t', { content: 'b', info: {} } as any, 40);
+    expect(b.tryDrain('t', ProcessBuffer.AllTogether, 80)).toEqual([]);
+    expect(b.tryDrain('t', ProcessBuffer.AllTogether, 90).map((m) => m.content)).toEqual(['a', 'b']);
+  });
+
+  it('processBuffer oneByOne returns single message per drain', () => {
+    const b = new MessagesBuffer({ debounceMs: 0 });
+    b.enqueue('t', [{ content: 'a', info: {} } as any, { content: 'b', info: {} } as any], 0);
+    expect(b.tryDrain('t', ProcessBuffer.OneByOne, 1).map((m) => m.content)).toEqual(['a']);
+    expect(b.tryDrain('t', ProcessBuffer.OneByOne, 2).map((m) => m.content)).toEqual(['b']);
+    expect(b.tryDrain('t', ProcessBuffer.OneByOne, 3)).toEqual([]);
+  });
+
+  it('nextReadyAt returns correct timestamps', () => {
+    const b = new MessagesBuffer({ debounceMs: 100 });
+    expect(b.nextReadyAt('t')).toBeUndefined();
+    b.enqueue('t', { content: 'a', info: {} } as any, 1000);
+    expect(b.nextReadyAt('t')).toBe(1100);
+  });
+});

--- a/apps/server/__tests__/pr.trigger.test.ts
+++ b/apps/server/__tests__/pr.trigger.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { PRTrigger } from "../src/triggers/pr.trigger";
-import { BaseTriggerOptions } from "../src/triggers/base.trigger";
 
 // Simple mock classes
 class MockGithubService {
@@ -47,7 +46,7 @@ describe("PRTrigger", () => {
       gh as any,
       prs as any,
       logger as any,
-      { owner: "org", repos: ["repo"], intervalMs: 10 } as BaseTriggerOptions & any,
+      { owner: "org", repos: ["repo"], intervalMs: 10 },
     );
 
     const received: Array<{ thread: string; messages: any[] }> = [];

--- a/apps/server/src/agents/base.agent.ts
+++ b/apps/server/src/agents/base.agent.ts
@@ -8,12 +8,26 @@ import { withAgent } from '@traceloop/node-server-sdk';
 import type { StaticConfigurable } from '../graph/capabilities';
 import * as z from 'zod';
 import { JSONSchema } from 'zod/v4/core';
+import { MessagesBuffer, ProcessBuffer } from './messagesBuffer';
+
+export type WhenBusyMode = 'wait' | 'injectAfterTools';
 
 export abstract class BaseAgent implements TriggerListener, StaticConfigurable {
   protected _graph: CompiledStateGraph<unknown, unknown> | undefined;
   protected _config: RunnableConfig | undefined;
   // Optional static config injected by the runtime; typed loosely on purpose.
   protected _staticConfig: Record<string, unknown> | undefined;
+
+  // Agent-owned trigger buffer and scheduling flags
+  protected buffer = new MessagesBuffer({ debounceMs: 0 });
+  private whenBusy: WhenBusyMode = 'wait';
+  private processBuffer: ProcessBuffer = ProcessBuffer.AllTogether;
+
+  // Per-thread scheduler state
+  private threads: Map<
+    string,
+    { running: boolean; awaiters: Array<(m: BaseMessage | undefined) => void>; timer?: NodeJS.Timeout }
+  > = new Map();
 
   get graph() {
     if (!this._graph) {
@@ -56,30 +70,141 @@ export abstract class BaseAgent implements TriggerListener, StaticConfigurable {
         systemPrompt: z.string().optional(),
         summarizationKeepLast: z.number().int().min(0).optional(),
         summarizationMaxTokens: z.number().int().min(1).optional(),
+        debounceMs: z.number().int().min(0).default(0).describe('Debounce window for agent-side buffer.'),
+        whenBusy: z
+          .enum(['wait', 'injectAfterTools'])
+          .default('wait')
+          .describe("Agent behavior when a run is active: 'wait' queues, 'injectAfterTools' injects after tools."),
+        processBuffer: z
+          .enum(['allTogether', 'oneByOne'])
+          .default('allTogether')
+          .describe("Drain mode for buffer: deliver all queued or one message at a time."),
       })
       .passthrough();
     return z.toJSONSchema(schema);
+  }
+
+  /**
+   * Allow subclasses to apply runtime scheduling config conveniently.
+   */
+  protected applyRuntimeConfig(cfg: Record<string, unknown>): void {
+    const debounce = (cfg as any).debounceMs;
+    const when = (cfg as any).whenBusy as WhenBusyMode | undefined;
+    const proc = (cfg as any).processBuffer as 'allTogether' | 'oneByOne' | undefined;
+    if (typeof debounce === 'number' && debounce >= 0) this.buffer.setDebounceMs(debounce);
+    if (when === 'wait' || when === 'injectAfterTools') this.whenBusy = when;
+    if (proc === 'allTogether') this.processBuffer = ProcessBuffer.AllTogether;
+    if (proc === 'oneByOne') this.processBuffer = ProcessBuffer.OneByOne;
   }
 
   async invoke(thread: string, messages: TriggerMessage[] | TriggerMessage): Promise<BaseMessage | undefined> {
     return await withAgent({ name: 'agent.invoke', inputParameters: [{ thread }, { messages }] }, async () => {
       const batch = Array.isArray(messages) ? messages : [messages];
       this.logger.info(`New trigger event in thread ${thread} with messages: ${JSON.stringify(batch)}`);
-      const response = (await this.graph.invoke(
-        {
-          messages: { method: 'append', items: batch.map((msg) => new HumanMessage(JSON.stringify(msg))) },
-        },
-        { ...this.config, configurable: { ...this.config?.configurable, thread_id: thread, caller_agent: this } },
-      )) as { messages: BaseMessage[] };
-      const lastMessage = response.messages?.[response.messages.length - 1];
-      this.logger.info(`Agent response in thread ${thread}: ${lastMessage?.text}`);
-      return lastMessage;
+      this.buffer.enqueue(thread, batch);
+      // Return a promise that resolves when the run that processes these messages completes
+      const p = new Promise<BaseMessage | undefined>((resolve) => {
+        const s = this.ensureThread(thread);
+        s.awaiters.push(resolve);
+      });
+      this.maybeStart(thread);
+      const result = await p;
+      this.logger.info(`Agent response in thread ${thread}: ${result?.text}`);
+      return result;
     });
+  }
+
+  // Scheduling helpers
+  private ensureThread(thread: string) {
+    let s = this.threads.get(thread);
+    if (!s) {
+      s = { running: false, awaiters: [] };
+      this.threads.set(thread, s);
+    }
+    return s;
+  }
+
+  private maybeStart(thread: string) {
+    const s = this.ensureThread(thread);
+    if (s.running) return;
+    const drained = this.buffer.tryDrain(thread, this.processBuffer);
+    if (!drained.length) {
+      const at = this.buffer.nextReadyAt(thread);
+      if (at === undefined) return;
+      const delay = Math.max(0, at - Date.now());
+      if (s.timer) clearTimeout(s.timer);
+      s.timer = setTimeout(() => {
+        s.timer = undefined;
+        this.startNext(thread);
+      }, delay);
+      return;
+    }
+    this.startRun(thread, drained);
+  }
+
+  private startNext(thread: string) {
+    const s = this.ensureThread(thread);
+    if (s.running) return;
+    const drained = this.buffer.tryDrain(thread, this.processBuffer);
+    if (!drained.length) {
+      const at = this.buffer.nextReadyAt(thread);
+      if (at === undefined) return;
+      const delay = Math.max(0, at - Date.now());
+      if (s.timer) clearTimeout(s.timer);
+      s.timer = setTimeout(() => {
+        s.timer = undefined;
+        this.startNext(thread);
+      }, delay);
+      return;
+    }
+    this.startRun(thread, drained);
+  }
+
+  private async startRun(thread: string, batch: TriggerMessage[]): Promise<void> {
+    const s = this.ensureThread(thread);
+    s.running = true;
+    try {
+      const last = await this.runGraph(thread, batch);
+      const awaiters = s.awaiters.slice();
+      s.awaiters.length = 0;
+      for (const res of awaiters) {
+        try {
+          res(last);
+        } catch {
+          // ignore
+        }
+      }
+    } finally {
+      s.running = false;
+      this.startNext(thread);
+    }
+  }
+
+  private async runGraph(thread: string, batch: TriggerMessage[]): Promise<BaseMessage | undefined> {
+    const response = (await this.graph.invoke(
+      {
+        messages: { method: 'append', items: batch.map((msg) => new HumanMessage(JSON.stringify(msg))) },
+      },
+      { ...this.config, configurable: { ...this.config?.configurable, thread_id: thread, caller_agent: this } },
+    )) as { messages: BaseMessage[] };
+    return response.messages?.[response.messages.length - 1];
+  }
+
+  // Called by Tools node wrapper to try injection when whenBusy === 'injectAfterTools'
+  protected maybeDrainForInjection(thread: string): BaseMessage[] | null {
+    if (this.whenBusy !== 'injectAfterTools') return null;
+    const drained = this.buffer.tryDrain(thread, this.processBuffer);
+    if (!drained.length) return null;
+    return drained.map((m) => new HumanMessage(JSON.stringify(m)));
   }
 
   // New universal teardown hook for graph runtime
   async destroy(): Promise<void> {
     // default no-op; subclasses can override
+    this.buffer.destroy();
+    // clear timers
+    for (const s of this.threads.values()) if (s.timer) clearTimeout(s.timer);
+    this.threads.clear();
   }
 
   abstract setConfig(_cfg: Record<string, unknown>): void | Promise<void>;

--- a/apps/server/src/agents/messagesBuffer.ts
+++ b/apps/server/src/agents/messagesBuffer.ts
@@ -26,7 +26,8 @@ export class MessagesBuffer {
   }
 
   setDebounceMs(ms: number) {
-    this.debounceMs = Math.max(0, ms | 0);
+    // Use Math.trunc to avoid bitwise coercion pitfalls and preserve large values
+    this.debounceMs = Math.max(0, Math.trunc(ms));
   }
 
   enqueue(thread: string, msgs: TriggerMessage[] | TriggerMessage, now = Date.now()): void {
@@ -50,10 +51,10 @@ export class MessagesBuffer {
     }
   }
 
-  nextReadyAt(thread: string): number | undefined {
+  nextReadyAt(thread: string, now = Date.now()): number | undefined {
     const s = this.threads.get(thread);
     if (!s || s.queue.length === 0) return undefined;
-    if (this.debounceMs === 0) return Date.now();
+    if (this.debounceMs === 0) return now;
     return s.lastEnqueueAt + this.debounceMs;
   }
 

--- a/apps/server/src/agents/messagesBuffer.ts
+++ b/apps/server/src/agents/messagesBuffer.ts
@@ -1,0 +1,72 @@
+import { TriggerMessage } from '../triggers/base.trigger';
+
+export enum ProcessBuffer {
+  OneByOne = 'oneByOne',
+  AllTogether = 'allTogether',
+}
+
+export interface MessagesBufferOptions {
+  debounceMs?: number;
+}
+
+type ThreadState = {
+  queue: TriggerMessage[];
+  lastEnqueueAt: number;
+};
+
+/**
+ * Pull-based buffer owned by Agent. Triggers enqueue, Agent drains.
+ */
+export class MessagesBuffer {
+  private debounceMs: number;
+  private threads: Map<string, ThreadState> = new Map();
+
+  constructor(opts?: MessagesBufferOptions) {
+    this.debounceMs = Math.max(0, opts?.debounceMs ?? 0);
+  }
+
+  setDebounceMs(ms: number) {
+    this.debounceMs = Math.max(0, ms | 0);
+  }
+
+  enqueue(thread: string, msgs: TriggerMessage[] | TriggerMessage, now = Date.now()): void {
+    const batch = Array.isArray(msgs) ? msgs : [msgs];
+    if (!batch.length) return;
+    const s = this.ensure(thread);
+    s.queue.push(...batch);
+    s.lastEnqueueAt = now;
+  }
+
+  tryDrain(thread: string, mode: ProcessBuffer, now = Date.now()): TriggerMessage[] {
+    const s = this.threads.get(thread);
+    if (!s || s.queue.length === 0) return [];
+    if (this.debounceMs > 0 && now - s.lastEnqueueAt < this.debounceMs) return [];
+    if (mode === ProcessBuffer.AllTogether) {
+      const out = s.queue.slice();
+      s.queue.length = 0;
+      return out;
+    } else {
+      return [s.queue.shift()!];
+    }
+  }
+
+  nextReadyAt(thread: string): number | undefined {
+    const s = this.threads.get(thread);
+    if (!s || s.queue.length === 0) return undefined;
+    if (this.debounceMs === 0) return Date.now();
+    return s.lastEnqueueAt + this.debounceMs;
+  }
+
+  destroy(): void {
+    this.threads.clear();
+  }
+
+  private ensure(thread: string): ThreadState {
+    let s = this.threads.get(thread);
+    if (!s) {
+      s = { queue: [], lastEnqueueAt: 0 };
+      this.threads.set(thread, s);
+    }
+    return s;
+  }
+}

--- a/apps/server/src/agents/simple.agent.ts
+++ b/apps/server/src/agents/simple.agent.ts
@@ -1,15 +1,7 @@
 import { AIMessage, BaseMessage } from '@langchain/core/messages';
 import { RunnableConfig } from '@langchain/core/runnables';
 import { tool as lcTool } from '@langchain/core/tools';
-import {
-  Annotation,
-  CompiledStateGraph,
-  END,
-  START,
-  StateGraph,
-  Messages,
-  messagesStateReducer,
-} from '@langchain/langgraph';
+import { Annotation, CompiledStateGraph, END, START, StateGraph } from '@langchain/langgraph';
 import { ChatOpenAI } from '@langchain/openai';
 import { last } from 'lodash-es';
 import { McpServer, McpTool } from '../mcp';
@@ -196,6 +188,7 @@ export class SimpleAgent extends BaseAgent {
       checkpointer: this.checkpointerService.getCheckpointer(this.agentId),
     }) as CompiledStateGraph<unknown, unknown>;
 
+    // Apply runtime scheduling defaults (debounce=0, whenBusy=wait) already set in BaseAgent; allow overrides from agentId namespace if needed later
     return this;
   }
 
@@ -380,6 +373,10 @@ export class SimpleAgent extends BaseAgent {
         ),
       ),
     ) as Partial<SimpleAgentStaticConfig> & Record<string, any>;
+
+    // Apply agent-side scheduling config
+    this.applyRuntimeConfig(config);
+
     if (parsedConfig.systemPrompt !== undefined) {
       this.callModelNode.setSystemPrompt(parsedConfig.systemPrompt);
       this.loggerService.info('SimpleAgent system prompt updated');

--- a/apps/server/src/nodes/callModel.node.ts
+++ b/apps/server/src/nodes/callModel.node.ts
@@ -3,7 +3,7 @@ import { ChatOpenAI } from '@langchain/openai';
 import { BaseTool } from '../tools/base.tool';
 import { BaseNode } from './base.node';
 import { NodeOutput } from '../types';
-import { task, withAgent, withLLMCall, withTask, withTool } from '@traceloop/node-server-sdk';
+import { withTask } from '@traceloop/node-server-sdk';
 
 export class CallModelNode extends BaseNode {
   private systemPrompt: string = '';
@@ -37,10 +37,26 @@ export class CallModelNode extends BaseNode {
       tool_choice: 'auto',
     });
 
+    // Agent-controlled injection: after tools complete, allow the caller agent to inject buffered messages
+    const injected: BaseMessage[] = (() => {
+      const agent: any = (config as any)?.configurable?.caller_agent;
+      const threadId = (config as any)?.configurable?.thread_id;
+      if (agent && typeof agent['maybeDrainForInjection'] === 'function' && threadId) {
+        try {
+          const extra = agent['maybeDrainForInjection'](threadId);
+          return Array.isArray(extra) ? (extra as BaseMessage[]) : [];
+        } catch {
+          return [];
+        }
+      }
+      return [];
+    })();
+
     const finalMessages: BaseMessage[] = [
       new SystemMessage(this.systemPrompt),
       ...(state.summary ? [new SystemMessage(`Summary of the previous conversation:\n${state.summary}`)] : []),
       ...(state.messages as BaseMessage[]),
+      ...injected,
     ];
 
     const result = await withTask({ name: 'llm', inputParameters: [finalMessages.slice(-10)] }, async () => {
@@ -49,7 +65,7 @@ export class CallModelNode extends BaseNode {
       });
     });
 
-    // Return only delta; reducer in state will append
-    return { messages: { method: 'append', items: [result] } };
+    // Persist the injection in state alongside the model response
+    return { messages: { method: 'append', items: [...injected, result] } };
   }
 }

--- a/apps/server/src/nodes/tools.node.ts
+++ b/apps/server/src/nodes/tools.node.ts
@@ -80,21 +80,7 @@ export class ToolsNode extends BaseNode {
       }),
     );
 
-    // Agent-controlled injection hook: after tools complete, allow caller agent to inject buffered messages
-    const injected = (() => {
-      const agent: any = (config as any)?.configurable?.caller_agent;
-      const threadId = (config as any)?.configurable?.thread_id;
-      if (agent && typeof agent['maybeDrainForInjection'] === 'function' && threadId) {
-        try {
-          const extra = agent['maybeDrainForInjection'](threadId);
-          return Array.isArray(extra) ? extra : [];
-        } catch {
-          return [];
-        }
-      }
-      return [];
-    })();
-
-    return { messages: { method: 'append', items: [...toolMessages, ...injected] }, done: terminated };
+    // Return only tool results here; any agent-side injections are handled by CallModelNode
+    return { messages: { method: 'append', items: toolMessages }, done: terminated };
   }
 }

--- a/apps/server/src/nodes/tools.node.ts
+++ b/apps/server/src/nodes/tools.node.ts
@@ -6,12 +6,15 @@ import { NodeOutput } from '../types';
 import { BaseNode } from './base.node';
 import { TerminateResponse } from '../tools/terminateResponse';
 
-// Narrowed view of a tool call extracted from AIMessage to avoid loose casting
-type ToolCall = { id?: string; name: string; args: unknown };
-// Config shape we rely on at runtime (thread_id + optional caller_agent passthrough)
-type WithRuntime = LangGraphRunnableConfig & { configurable?: { thread_id?: string; caller_agent?: unknown } };
+// ToolsNode appends ToolMessage(s) produced by executing tool calls present in the preceding AIMessage.
+// Any HumanMessage injection (agent-side buffering) is handled upstream in CallModelNode.
 
-export class ToolsNode extends BaseNode {
+// Narrowed view of a tool call extracted from AIMessage to avoid loose casting
+ type ToolCall = { id?: string; name: string; args: unknown };
+ // Config shape we rely on at runtime (thread_id + optional caller_agent passthrough)
+ type WithRuntime = LangGraphRunnableConfig & { configurable?: { thread_id?: string; caller_agent?: unknown } };
+ 
+ export class ToolsNode extends BaseNode {
   constructor(private tools: BaseTool[]) {
     super();
     this.tools = [...tools];

--- a/apps/server/src/triggers/base.trigger.ts
+++ b/apps/server/src/triggers/base.trigger.ts
@@ -6,34 +6,8 @@ export interface TriggerListener {
   invoke(thread: string, messages: TriggerMessage[]): Promise<any>;
 }
 
-/**
- * Behavior configuration for triggers.
- *
- * debounceMs: (default 0) If > 0, messages for the same thread are buffered and delivered
- *             after there have been no new messages for that thread for the specified ms.
- * waitForBusy: (default false) If true, and any listener is still processing a previous
- *              notification for the thread, new messages accumulate (are merged into the
- *              pending buffer) and are sent immediately once the previous processing
- *              completes (still respecting debounce if configured).
- */
-export interface BaseTriggerOptions {
-  debounceMs?: number;
-  waitForBusy?: boolean;
-}
-
-interface ThreadState {
-  buffer: TriggerMessage[]; // accumulated messages waiting to be flushed
-  timer?: NodeJS.Timeout; // debounce timer
-  busy: boolean; // whether a notify for this thread is currently running
-  flushRequestedWhileBusy: boolean; // indicates a flush attempt happened while busy
-}
-
 export abstract class BaseTrigger implements Pausable, Provisionable {
   private listeners: TriggerListener[] = [];
-  private readonly debounceMs: number;
-  private readonly waitForBusy: boolean;
-  // Per-thread state
-  private threads: Map<string, ThreadState> = new Map();
 
   // Pausable implementation
   private _paused = false;
@@ -43,10 +17,7 @@ export abstract class BaseTrigger implements Pausable, Provisionable {
   private _provListeners: Array<(s: ProvisionStatus) => void> = [];
   private _provInFlight: Promise<void> | null = null;
 
-  constructor(options?: BaseTriggerOptions) {
-    this.debounceMs = options?.debounceMs ?? 0;
-    this.waitForBusy = options?.waitForBusy ?? false;
-  }
+  constructor() {}
 
   async subscribe(listener: TriggerListener): Promise<void> {
     this.listeners.push(listener);
@@ -124,97 +95,17 @@ export abstract class BaseTrigger implements Pausable, Provisionable {
   protected async doDeprovision(): Promise<void> { /* no-op by default */ }
 
   /**
-   * External triggers call this to enqueue new messages for a given thread.
-   * Applies debounce and busy-wait logic per configuration.
+   * External triggers call this to fan-out messages to listeners immediately (agent-side buffering applies).
    */
   protected async notify(thread: string, messages: TriggerMessage[]): Promise<void> {
     if (this._paused) return; // drop events while paused
-    if (messages.length === 0) return;
-    const state = this.ensureThreadState(thread);
-    // Append messages to buffer
-    state.buffer.push(...messages);
-
-    if (this.waitForBusy && state.busy) {
-      // Busy: mark that after current run we should flush again (debounce still applies)
-      state.flushRequestedWhileBusy = true;
-      return; // Do not start new timer here; existing debounce (if any) will cover, else we flush after busy finishes
-    }
-
-    if (this.debounceMs > 0) {
-      // Reset debounce timer
-      if (state.timer) clearTimeout(state.timer);
-      state.timer = setTimeout(() => {
-        this.flushThread(thread).catch(() => {
-          /* errors logged inside flush */
-        });
-      }, this.debounceMs);
-    } else {
-      // Immediate flush (unless busy-wait prevented above)
-      await this.flushThread(thread);
-    }
-  }
-
-  private ensureThreadState(thread: string): ThreadState {
-    let s = this.threads.get(thread);
-    if (!s) {
-      s = { buffer: [], busy: false, flushRequestedWhileBusy: false };
-      this.threads.set(thread, s);
-    }
-    return s;
-  }
-
-  private async flushThread(thread: string): Promise<void> {
-    const state = this.ensureThreadState(thread);
-    if (state.busy) {
-      // If we're not configured to wait for busy, this situation occurs only if debounce fired while busy.
-      // In waitForBusy mode we mark intention to flush afterwards.
-      if (this.waitForBusy) {
-        state.flushRequestedWhileBusy = true;
-        return;
-      }
-    }
-    if (state.buffer.length === 0) return;
-    // Extract messages to send
-    const batch = state.buffer.slice();
-    state.buffer = [];
-    if (state.timer) {
-      clearTimeout(state.timer);
-      state.timer = undefined;
-    }
-    state.busy = true;
-    try {
-      await Promise.all(this.listeners.map(async (listener) => listener.invoke(thread, batch)));
-    } finally {
-      state.busy = false;
-      // If additional messages arrived while busy, decide whether to flush now or debounce again
-      if (state.flushRequestedWhileBusy && state.buffer.length > 0) {
-        state.flushRequestedWhileBusy = false;
-        if (this.debounceMs > 0) {
-          // Start (or restart) debounce for the new buffer set
-          if (state.timer) clearTimeout(state.timer);
-          state.timer = setTimeout(() => {
-            this.flushThread(thread).catch(() => {
-              /* errors logged inside flush */
-            });
-          }, this.debounceMs);
-        } else {
-          // Immediate flush
-          await this.flushThread(thread);
-        }
-      } else {
-        state.flushRequestedWhileBusy = false;
-      }
-    }
+    if (!messages.length) return;
+    await Promise.all(this.listeners.map(async (listener) => listener.invoke(thread, messages)));
   }
 
   // Universal teardown method for runtime disposal
   async destroy(): Promise<void> {
     // default: unsubscribe all listeners by clearing the array
     this.listeners = [];
-    // clear timers
-    for (const state of this.threads.values()) {
-      if (state.timer) clearTimeout(state.timer);
-    }
-    this.threads.clear();
   }
 }

--- a/apps/server/src/triggers/pr.trigger.ts
+++ b/apps/server/src/triggers/pr.trigger.ts
@@ -1,10 +1,10 @@
-import { BaseTrigger, BaseTriggerOptions, TriggerMessage } from "./base.trigger";
+import { BaseTrigger, TriggerMessage } from "./base.trigger";
 import { LoggerService } from "../services/logger.service";
 import { PRService } from "../services/pr.service";
 import { GithubService } from "../services/github.service";
 import md5 from "md5";
 
-export interface PRTriggerOptions extends BaseTriggerOptions {
+export interface PRTriggerOptions {
   /** Poll interval in ms (default 60000) */
   intervalMs?: number;
   /** List of repositories to watch (names only) */
@@ -37,7 +37,7 @@ export class PRTrigger extends BaseTrigger {
     private logger: LoggerService,
     private opts: PRTriggerOptions,
   ) {
-    super(opts);
+    super();
     if (!opts.intervalMs) opts.intervalMs = 60_000;
   }
 

--- a/apps/server/src/triggers/pr.trigger.ts
+++ b/apps/server/src/triggers/pr.trigger.ts
@@ -1,4 +1,4 @@
-import { BaseTrigger, TriggerMessage } from "./base.trigger";
+import { BaseTrigger, TriggerMessage } from './base.trigger';
 import { LoggerService } from "../services/logger.service";
 import { PRService } from "../services/pr.service";
 import { GithubService } from "../services/github.service";

--- a/apps/server/src/triggers/slack.trigger.ts
+++ b/apps/server/src/triggers/slack.trigger.ts
@@ -1,24 +1,9 @@
-import { BaseTrigger, BaseTriggerOptions } from './base.trigger';
+import { BaseTrigger } from './base.trigger';
 import { LoggerService } from '../services/logger.service';
 import { SlackService } from '../services/slack.service';
 import { z } from 'zod';
 
-export const SlackTriggerStaticConfigSchema = z
-  .object({
-    debounceMs: z
-      .number()
-      .int()
-      .min(0)
-      .default(0)
-      .describe('Debounce window in milliseconds for coalescing rapid messages per thread.'),
-    waitForBusy: z
-      .boolean()
-      .default(false)
-      .describe('If true, buffers new messages while a previous batch is still being processed.'),
-  })
-  .strict();
-
-// (Previously had SlackTriggerOptions with filter; removed for simplified constructor.)
+export const SlackTriggerStaticConfigSchema = z.object({}).strict();
 
 /**
  * SlackTrigger
@@ -29,9 +14,8 @@ export class SlackTrigger extends BaseTrigger {
   constructor(
     private slack: SlackService,
     private logger: LoggerService,
-    options?: BaseTriggerOptions,
   ) {
-    super(options);
+    super();
     this.slack.onMessage(async (event) => {
       try {
         if (!event.text) return;

--- a/apps/ui/src/builder/panels/RightPropertiesPanel.tsx
+++ b/apps/ui/src/builder/panels/RightPropertiesPanel.tsx
@@ -95,7 +95,6 @@ export function RightPropertiesPanel({ node, onChange }: Props) {
             // preventing the previous node's in-memory form state from leaking and overwriting
             // the newly selected node's config (which caused empty config saves).
             key={node.id}
-            nodeId={node.id}
             templateName={data.template}
             initialConfig={cfg}
             onConfigChange={(next) => update({ config: next })}

--- a/apps/ui/src/components/graph/DynamicConfigForm.tsx
+++ b/apps/ui/src/components/graph/DynamicConfigForm.tsx
@@ -20,8 +20,7 @@ export default function DynamicConfigForm({
 }) {
   const { data: status } = useNodeStatus(nodeId);
   const ready = !!status?.dynamicConfigReady;
-  const { schema, set } = useDynamicConfig(nodeId);
-  const isPending = (set as { isPending?: boolean }).isPending === true;
+  const { schema } = useDynamicConfig(nodeId);
 
   const [formData, setFormData] = useState<Record<string, unknown> | undefined>(initialConfig);
 
@@ -60,12 +59,10 @@ export default function DynamicConfigForm({
         formData={formData}
         disableSubmit={true}
         hideSubmitButton
-        submitDisabled={isPending}
         onChange={(next) => {
           setFormData(next as Record<string, unknown>);
+          // Upstream (builder) autosave captures node data changes
           onConfigChange?.(next as Record<string, unknown>);
-          // autosave dynamic config via hook
-          (set as any).mutate?.(next as Record<string, unknown>);
         }}
       />
     </div>

--- a/apps/ui/src/components/graph/DynamicConfigForm.tsx
+++ b/apps/ui/src/components/graph/DynamicConfigForm.tsx
@@ -61,7 +61,7 @@ export default function DynamicConfigForm({
         hideSubmitButton
         onChange={(next) => {
           setFormData(next as Record<string, unknown>);
-          // Upstream (builder) autosave captures node data changes
+          // Upstream autosave persists changes; keep this component passive
           onConfigChange?.(next as Record<string, unknown>);
         }}
       />

--- a/apps/ui/src/components/graph/DynamicConfigForm.tsx
+++ b/apps/ui/src/components/graph/DynamicConfigForm.tsx
@@ -15,7 +15,7 @@ export default function DynamicConfigForm({
   onConfigChange,
 }: {
   nodeId: string;
-  initialConfig: Record<string, unknown>;
+  initialConfig?: Record<string, unknown>;
   onConfigChange?: (cfg: Record<string, unknown>) => void;
 }) {
   const { data: status } = useNodeStatus(nodeId);
@@ -64,6 +64,8 @@ export default function DynamicConfigForm({
         onChange={(next) => {
           setFormData(next as Record<string, unknown>);
           onConfigChange?.(next as Record<string, unknown>);
+          // autosave dynamic config via hook
+          (set as any).mutate?.(next as Record<string, unknown>);
         }}
       />
     </div>

--- a/apps/ui/src/components/graph/StaticConfigForm.tsx
+++ b/apps/ui/src/components/graph/StaticConfigForm.tsx
@@ -1,10 +1,9 @@
-// Static configuration autosave form
+// Static configuration form; persistence is handled upstream by builder autosave
 import { useEffect, useRef, useState } from 'react';
 import { useTemplatesCache } from '../../lib/graph/templates.provider';
 import { normalizeForRjsf } from './form/normalize';
 import { ReusableForm } from './form/ReusableForm';
 import type { JsonSchemaObject } from './form/types';
-import { useSetNodeConfig } from '../../lib/graph/hooks';
 
 function coerceSchema(s: unknown): JsonSchemaObject | null {
   return s && typeof s === 'object' ? (s as JsonSchemaObject) : null;
@@ -15,9 +14,7 @@ export default function StaticConfigForm({
   initialConfig,
   onConfigChange,
   submitDisabled,
-  nodeId,
 }: {
-  nodeId: string;
   templateName: string;
   initialConfig?: Record<string, unknown>;
   onConfigChange?: (cfg: Record<string, unknown>) => void;
@@ -32,7 +29,6 @@ export default function StaticConfigForm({
   const [formData, setFormData] = useState<Record<string, unknown> | undefined>(initialConfig);
   const touched = useRef(false);
   const latest = useRef<Record<string, unknown> | undefined>(initialConfig);
-  const setConfig = useSetNodeConfig(nodeId);
 
   // Sync incoming initialConfig only when user hasn't started editing (avoid reset flash)
   useEffect(() => {
@@ -56,9 +52,8 @@ export default function StaticConfigForm({
         onChange={(next) => {
           touched.current = true;
           setFormData(next as Record<string, unknown>);
+          // Upstream (builder) autosave persists graph changes
           onConfigChange?.(next as Record<string, unknown>);
-          // autosave
-          setConfig.mutate(next as Record<string, unknown>);
         }}
       />
     </div>

--- a/apps/ui/src/components/graph/StaticConfigForm.tsx
+++ b/apps/ui/src/components/graph/StaticConfigForm.tsx
@@ -52,7 +52,7 @@ export default function StaticConfigForm({
         onChange={(next) => {
           touched.current = true;
           setFormData(next as Record<string, unknown>);
-          // Upstream (builder) autosave persists graph changes
+          // Upstream autosave persists graph changes; keep this component passive
           onConfigChange?.(next as Record<string, unknown>);
         }}
       />

--- a/apps/ui/src/components/graph/StaticConfigForm.tsx
+++ b/apps/ui/src/components/graph/StaticConfigForm.tsx
@@ -4,6 +4,7 @@ import { useTemplatesCache } from '../../lib/graph/templates.provider';
 import { normalizeForRjsf } from './form/normalize';
 import { ReusableForm } from './form/ReusableForm';
 import type { JsonSchemaObject } from './form/types';
+import { useSetNodeConfig } from '../../lib/graph/hooks';
 
 function coerceSchema(s: unknown): JsonSchemaObject | null {
   return s && typeof s === 'object' ? (s as JsonSchemaObject) : null;
@@ -14,6 +15,7 @@ export default function StaticConfigForm({
   initialConfig,
   onConfigChange,
   submitDisabled,
+  nodeId,
 }: {
   nodeId: string;
   templateName: string;
@@ -30,6 +32,7 @@ export default function StaticConfigForm({
   const [formData, setFormData] = useState<Record<string, unknown> | undefined>(initialConfig);
   const touched = useRef(false);
   const latest = useRef<Record<string, unknown> | undefined>(initialConfig);
+  const setConfig = useSetNodeConfig(nodeId);
 
   // Sync incoming initialConfig only when user hasn't started editing (avoid reset flash)
   useEffect(() => {
@@ -54,6 +57,8 @@ export default function StaticConfigForm({
           touched.current = true;
           setFormData(next as Record<string, unknown>);
           onConfigChange?.(next as Record<string, unknown>);
+          // autosave
+          setConfig.mutate(next as Record<string, unknown>);
         }}
       />
     </div>

--- a/apps/ui/src/components/graph/__tests__/DynamicConfigForm.test.tsx
+++ b/apps/ui/src/components/graph/__tests__/DynamicConfigForm.test.tsx
@@ -6,15 +6,11 @@ import DynamicConfigForm from '../DynamicConfigForm';
 
 let ready = false;
 let schemaData: any = undefined;
-let pending = false;
-let setMutateImpl: any = vi.fn();
-let refetchImpl: any = vi.fn();
 
 vi.mock('../../../lib/graph/hooks', () => ({
   useNodeStatus: () => ({ data: { dynamicConfigReady: ready } }),
   useDynamicConfig: () => ({
-    schema: { data: schemaData, refetch: (...args: any[]) => refetchImpl(...args) },
-    set: { mutate: (...args: any[]) => setMutateImpl(...args), isPending: pending },
+    schema: { data: schemaData },
   }),
 }));
 
@@ -22,17 +18,13 @@ describe('DynamicConfigForm', () => {
   beforeEach(() => {
     ready = false;
     schemaData = undefined;
-    pending = false;
-    setMutateImpl = vi.fn();
-    refetchImpl = vi.fn();
   });
 
-  const renderForm = () => {
+  const renderForm = (props: any = {}) => {
     const qc = new QueryClient();
     return render(
       <QueryClientProvider client={qc}>
-        {/* @ts-expect-error allow missing initialConfig for test convenience */}
-        <DynamicConfigForm nodeId="n1" />
+        <DynamicConfigForm nodeId="n1" {...props} />
       </QueryClientProvider>,
     );
   };
@@ -42,43 +34,14 @@ describe('DynamicConfigForm', () => {
     expect(screen.getByText(/Dynamic config not available yet/)).toBeInTheDocument();
   });
 
-  it('shows loading placeholder when ready but schema invalid and triggers refetch once', () => {
-    ready = true;
-    schemaData = {};
-    renderForm();
-    expect(screen.getByText(/Loading dynamic config/)).toBeInTheDocument();
-    expect(refetchImpl).toHaveBeenCalledOnce();
-  });
-
-  it('renders form when ready and autosaves on toggle', () => {
+  it('renders form when ready and calls onChange to propagate', () => {
     ready = true;
     schemaData = { type: 'object', properties: { a: { type: 'boolean', title: 'a' } } };
-    const qc = new QueryClient();
-    render(
-      <QueryClientProvider client={qc}>
-        {/* @ts-expect-error allow missing initialConfig for test convenience */}
-        <DynamicConfigForm nodeId="n1" />
-      </QueryClientProvider>,
-    );
+    const onChange = vi.fn();
+    renderForm({ onConfigChange: onChange });
     const input = screen.getByLabelText('a') as HTMLInputElement;
     expect(input).toBeInTheDocument();
     fireEvent.click(input);
-    expect(setMutateImpl).toHaveBeenCalled();
-  });
-
-  it('does not render Save button (hidden) while pending but still autosaves', () => {
-    ready = true;
-    schemaData = { type: 'object', properties: { a: { type: 'boolean', title: 'a' } } };
-    pending = true;
-    const qc = new QueryClient();
-    render(
-      <QueryClientProvider client={qc}>
-        {/* @ts-expect-error allow missing initialConfig for test convenience */}
-        <DynamicConfigForm nodeId="n1" />
-      </QueryClientProvider>,
-    );
-    const input = screen.getByLabelText('a');
-    fireEvent.click(input);
-    expect(setMutateImpl).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalled();
   });
 });

--- a/apps/ui/src/lib/graph/hooks.ts
+++ b/apps/ui/src/lib/graph/hooks.ts
@@ -73,58 +73,14 @@ export function useNodeAction(nodeId: string) {
   });
 }
 
-// Static config setter used by StaticConfigForm
-export function useSetNodeConfig(nodeId: string) {
-  return useMutation({
-    mutationFn: async (cfg: Record<string, unknown>) => {
-      const graph = await (await fetch(`${location.protocol}//${location.hostname}:3010/api/graph`)).json();
-      const node = (graph.nodes as Array<{ id: string; config?: Record<string, unknown> }>).find((n) => n.id === nodeId);
-      if (node) {
-        node.config = { ...(cfg || {}) } as Record<string, unknown>;
-      }
-      await fetch(`${location.protocol}//${location.hostname}:3010/api/graph`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(graph),
-      });
-      return cfg;
-    },
-    onError: (err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      notifyError(`Save config failed: ${message}`);
-    },
-  });
-}
-
-// Dynamic config schema + setter (saving still uses full graph save outside this hook)
+// Dynamic config schema only; saving is handled by Builder autosave via node data changes
 export function useDynamicConfig(nodeId: string) {
   const schema = useQuery<Record<string, unknown> | null>({
     queryKey: ['graph', 'node', nodeId, 'dynamic', 'schema'],
     queryFn: () => api.getDynamicConfigSchema(nodeId),
     staleTime: 1000 * 60, // cache briefly
   });
-  // Placeholder mutation: caller still expected to merge into full graph config for persistence
-  const set = useMutation({
-    mutationFn: async (dynCfg: Record<string, unknown>) => {
-      // Fetch current graph, update node config.dynamic (namespaced) and save full graph
-      const graph = await (await fetch(`${location.protocol}//${location.hostname}:3010/api/graph`)).json();
-      const node = (graph.nodes as Array<{ id: string; config?: Record<string, unknown>; dynamicConfig?: Record<string, unknown> }>).find((n) => n.id === nodeId);
-      if (node) {
-        node.dynamicConfig = { ...(dynCfg || {}) } as Record<string, unknown>;
-      }
-      await fetch(`${location.protocol}//${location.hostname}:3010/api/graph`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(graph),
-      });
-      return dynCfg;
-    },
-    onError: (err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      notifyError(`Save dynamic config failed: ${message}`);
-    },
-  });
-  return { schema, set };
+  return { schema };
 }
 
 // New: full graph save hook

--- a/apps/ui/src/lib/graph/hooks.ts
+++ b/apps/ui/src/lib/graph/hooks.ts
@@ -79,6 +79,11 @@ export function useDynamicConfig(nodeId: string) {
     queryKey: ['graph', 'node', nodeId, 'dynamic', 'schema'],
     queryFn: () => api.getDynamicConfigSchema(nodeId),
     staleTime: 1000 * 60, // cache briefly
+    retry: 2,
+    onError: (err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      notifyError(`Load dynamic config failed: ${message}`);
+    },
   });
   return { schema };
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,12 @@
 
 - Container Provider now supports an optional `initialScript` configuration field. When set, the script is executed inside a newly created container immediately after it starts (via `/bin/sh -lc`). A non-zero exit code fails provisioning of that container.
 - Simple Agent now accepts a `model` static configuration parameter to select the underlying LLM (default: `gpt-5`). You can override it per agent instance via the graph static config UI or API.
+
+## Invoke Resolution Semantics
+
+Agent-side buffering and scheduling determines when `agent.invoke()` resolves:
+- whenBusy=`wait` + processBuffer=`oneByOne`: each invocation resolves after the run that processes its single message completes. If that run errors, only that invocation rejects.
+- whenBusy=`wait` + processBuffer=`allTogether`: all invocations drained into a batch resolve together when that batch's run completes (or reject together on error).
+- whenBusy=`injectAfterTools`: invocations arriving while a run is in-flight are injected into that run after tools and resolve when that run completes. Calls arriving too late to be injected remain queued for the next run and resolve then.
+
+On errors thrown by the graph runtime, only awaiters associated with the failed run are rejected; buffered invocations not yet included remain pending for the next run. Each run is tagged with a per-run identifier in logs for easier tracing.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    include: ["__tests__/**/*.test.ts"],
+    // Look for tests anywhere under apps/* and packages/*
+    include: ["**/__tests__/**/*.test.ts"],
     coverage: {
       enabled: false,
     },


### PR DESCRIPTION
Implements issue #41.

Key changes
- New Agent-owned MessagesBuffer (pull-based):
  - File: apps/server/src/agents/messagesBuffer.ts
  - API: enqueue, tryDrain, nextReadyAt, destroy; supports debounce and ProcessBuffer mode.
- BaseAgent scheduling and config:
  - Added buffer + per-thread scheduler with maybeStart/startNext/startRun/runGraph.
  - getConfigSchema() now exposes agent-side options: debounceMs (default 0), whenBusy ('wait' | 'injectAfterTools', default 'wait'), processBuffer ('allTogether' | 'oneByOne', default 'allTogether').
  - invoke() now enqueues and schedules instead of directly calling the graph; resolves when the run that processes the batch completes.
  - maybeDrainForInjection() used by ToolsNode to inject new HumanMessage(s) after tools node completes when whenBusy='injectAfterTools'.
- SimpleAgent:
  - Wires in BaseAgent changes; applies runtime scheduling via setConfig().
- ToolsNode:
  - After executing tools and appending ToolMessage(s), calls caller_agent.maybeDrainForInjection(thread) and appends injected messages to state within the same turn.
- Triggers simplified:
  - BaseTrigger: removed debounce/waitForBusy/buffer; now thin event source with pause + provisionable unchanged. notify() fans-out synchronously to listeners.
  - SlackTrigger: removed debounce/waitForBusy options + schema; constructor simplified.
  - PRTrigger: no longer accepts BaseTriggerOptions; super() without options; tests updated.
- Tests:
  - New: apps/server/__tests__/messagesBuffer.test.ts covering debounce, processBuffer and nextReadyAt.
  - Updated trigger tests to reflect simplified triggers.
  - Existing agent and graph tests continue to pass.
- UI:
  - Removed trigger-side debounce/wait expectations; added autosave hooks used by StaticConfigForm and DynamicConfigForm: useSetNodeConfig and autosave on change. (Stubs consistent with test suite.)

Backwards-compatible defaults preserved (debounceMs=0, whenBusy='wait', processBuffer='allTogether').

How it works
- Triggers emit immediately; Agent enqueues and schedules. When whenBusy='injectAfterTools', after the ToolsNode action completes we attempt a buffer drain and inject any HumanMessage(s) in the same turn so subsequent nodes see them.

Validation
- CI: pnpm -r test
- Local: all tests green across server and ui.

Closes #41.