### PR TITLE
feat: Socket.io-only Trigger Events (UI panel + server wiring)

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,2 +1,4 @@
 # Copy this file to .env and adjust values as needed
 MONGODB_URI=mongodb://root:example@localhost:27017/?authSource=admin
+# Max number of trigger events to retain per node (FIFO)
+TRIGGER_EVENTS_MAX=300

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,22 @@
+# Apps/Server
+
+Socket.io + Fastify server hosting the graph runtime and templates.
+
+Trigger Events (Socket-only)
+- In-memory store captures recent trigger events per node; no HTTP endpoints are exposed.
+- Configure pruning with env var `TRIGGER_EVENTS_MAX` (default 300).
+- Socket messages:
+  - Client -> Server: `trigger_init` { nodeId: string, threadId?: string }
+    - Server responds with `trigger_initial` { nodeId, items: TriggerEvent[] } where items are newest-first.
+  - Client -> Server: `trigger_update` { nodeId: string, threadId?: string }
+    - Server responds again with `trigger_initial` for the new filter.
+  - Client -> Server: `trigger_close` { nodeId: string }
+    - Server removes the subscription for that node for that socket.
+  - Server -> Client: `trigger_event` { nodeId, event }
+    - Delivered to subscribed socket when matching event occurs.
+
+Where events come from
+- Triggers (e.g., SlackTrigger) are bound to the in-memory store during template instantiation. As messages arrive, they are buffered with timestamp + threadId and re-emitted via Socket.io to interested clients.
+
+Notes
+- Existing checkpoint stream over sockets remains unchanged.

--- a/apps/server/__tests__/socket.service.triggers.test.ts
+++ b/apps/server/__tests__/socket.service.triggers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Server } from 'socket.io';
+import { createServer } from 'http';
+import { io as Client } from 'socket.io-client';
+import { LoggerService } from '../src/services/logger.service';
+import { CheckpointerService } from '../src/services/checkpointer.service';
+import { SocketService } from '../src/services/socket.service';
+import { TriggerEventsService } from '../src/services/trigger-events.service';
+
+function delay(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+describe('SocketService trigger events', () => {
+  it('init/update/close flow with filtering', async () => {
+    const httpServer = createServer();
+    const io = new Server(httpServer, { cors: { origin: '*' } });
+    await new Promise<void>((r) => httpServer.listen(() => r()));
+    const logger = new LoggerService();
+    const checkpointer = new CheckpointerService(logger);
+    // mock checkpointer watch to avoid Mongo
+    // @ts-ignore
+    checkpointer.fetchLatestWrites = vi.fn().mockResolvedValue([]);
+    // @ts-ignore
+    checkpointer.watchInserts = vi.fn().mockReturnValue({ on: vi.fn(), close: vi.fn() });
+    const triggerEvents = new TriggerEventsService(10);
+    const svc = new SocketService(io as any, logger, checkpointer as any, triggerEvents);
+    svc.register();
+
+    const port = (httpServer.address() as any).port;
+    const url = `http://localhost:${port}`;
+    const client = Client(url, { autoConnect: true, transports: ['websocket'] });
+    await new Promise<void>((resolve) => client.on('connect', () => resolve()));
+
+    const initial: any[] = [];
+    client.on('trigger_initial', (p) => initial.push(p));
+    const events: any[] = [];
+    client.on('trigger_event', (p) => events.push(p));
+
+    client.emit('trigger_init', { nodeId: 'n1' });
+    await delay(10);
+    // append two events
+    // manually emit via service binding
+    triggerEvents['append']?.('n1' as any, { ts: Date.now(), threadId: 'a', messages: [{ content: '1', info: {} }] } as any);
+    triggerEvents['append']?.('n1' as any, { ts: Date.now(), threadId: 'b', messages: [{ content: '2', info: {} }] } as any);
+    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'a', messages: [{ content: '1', info: {} }] } });
+    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'b', messages: [{ content: '2', info: {} }] } });
+    await delay(10);
+    expect(events.length).toBe(2);
+
+    // update filter to thread a
+    client.emit('trigger_update', { nodeId: 'n1', threadId: 'a' });
+    await delay(10);
+    // initial should include only thread a
+    expect(initial[initial.length - 1].items.every((it: any) => it.threadId === 'a')).toBe(true);
+
+    // emit another b (should be ignored) and a (should be delivered)
+    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'b', messages: [{ content: 'x', info: {} }] } });
+    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'a', messages: [{ content: 'y', info: {} }] } });
+    await delay(10);
+    expect(events[events.length - 1].event.threadId).toBe('a');
+
+    // close subscription
+    client.emit('trigger_close', { nodeId: 'n1' });
+    await delay(10);
+    const prev = events.length;
+    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'a', messages: [{ content: 'z', info: {} }] } });
+    await delay(10);
+    expect(events.length).toBe(prev);
+
+    client.close();
+    await new Promise<void>((r) => io.close(() => r()))
+    await new Promise<void>((r) => httpServer.close(() => r()))
+  });
+});

--- a/apps/server/__tests__/socket.service.triggers.test.ts
+++ b/apps/server/__tests__/socket.service.triggers.test.ts
@@ -6,8 +6,16 @@ import { LoggerService } from '../src/services/logger.service';
 import { CheckpointerService } from '../src/services/checkpointer.service';
 import { SocketService } from '../src/services/socket.service';
 import { TriggerEventsService } from '../src/services/trigger-events.service';
+import { BaseTrigger } from '../src/triggers/base.trigger';
 
 function delay(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+class TestTrigger extends BaseTrigger {
+  async push(thread: string, messages: any[]) {
+    // @ts-ignore
+    await this.notify(thread, messages);
+  }
+}
 
 describe('SocketService trigger events', () => {
   it('init/update/close flow with filtering', async () => {
@@ -25,6 +33,10 @@ describe('SocketService trigger events', () => {
     const svc = new SocketService(io as any, logger, checkpointer as any, triggerEvents);
     svc.register();
 
+    // Bind a test trigger to node n1
+    const trig = new TestTrigger();
+    triggerEvents.bind('n1', trig as any);
+
     const port = (httpServer.address() as any).port;
     const url = `http://localhost:${port}`;
     const client = Client(url, { autoConnect: true, transports: ['websocket'] });
@@ -37,12 +49,9 @@ describe('SocketService trigger events', () => {
 
     client.emit('trigger_init', { nodeId: 'n1' });
     await delay(10);
-    // append two events
-    // manually emit via service binding
-    triggerEvents['append']?.('n1' as any, { ts: Date.now(), threadId: 'a', messages: [{ content: '1', info: {} }] } as any);
-    triggerEvents['append']?.('n1' as any, { ts: Date.now(), threadId: 'b', messages: [{ content: '2', info: {} }] } as any);
-    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'a', messages: [{ content: '1', info: {} }] } });
-    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'b', messages: [{ content: '2', info: {} }] } });
+    // generate two events
+    await trig.push('a', [{ content: '1', info: {} }]);
+    await trig.push('b', [{ content: '2', info: {} }]);
     await delay(10);
     expect(events.length).toBe(2);
 
@@ -53,8 +62,8 @@ describe('SocketService trigger events', () => {
     expect(initial[initial.length - 1].items.every((it: any) => it.threadId === 'a')).toBe(true);
 
     // emit another b (should be ignored) and a (should be delivered)
-    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'b', messages: [{ content: 'x', info: {} }] } });
-    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'a', messages: [{ content: 'y', info: {} }] } });
+    await trig.push('b', [{ content: 'x', info: {} }]);
+    await trig.push('a', [{ content: 'y', info: {} }]);
     await delay(10);
     expect(events[events.length - 1].event.threadId).toBe('a');
 
@@ -62,7 +71,7 @@ describe('SocketService trigger events', () => {
     client.emit('trigger_close', { nodeId: 'n1' });
     await delay(10);
     const prev = events.length;
-    triggerEvents['emitter']?.emit('event', { nodeId: 'n1', event: { ts: Date.now(), threadId: 'a', messages: [{ content: 'z', info: {} }] } });
+    await trig.push('a', [{ content: 'z', info: {} }]);
     await delay(10);
     expect(events.length).toBe(prev);
 

--- a/apps/server/__tests__/trigger-events.service.test.ts
+++ b/apps/server/__tests__/trigger-events.service.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TriggerEventsService } from '../src/services/trigger-events.service';
+import { BaseTrigger } from '../src/triggers/base.trigger';
+
+class TestTrigger extends BaseTrigger {
+  public async push(thread: string, messages: any[]) {
+    // @ts-ignore
+    await this.notify(thread, messages);
+  }
+}
+
+describe('TriggerEventsService', () => {
+  it('bind() records and prunes to max', async () => {
+    const svc = new TriggerEventsService(3);
+    const trig = new TestTrigger();
+    svc.bind('n1', trig);
+    await trig.push('t1', [{ content: 'a', info: {} }]);
+    await trig.push('t2', [{ content: 'b', info: {} }]);
+    await trig.push('t3', [{ content: 'c', info: {} }]);
+    await trig.push('t4', [{ content: 'd', info: {} }]);
+    const items = svc.list('n1');
+    expect(items.length).toBe(3);
+    // Newest first
+    expect(items[0].messages[0].content).toBe('d');
+    expect(items[2].messages[0].content).toBe('b');
+  });
+
+  it('list() filters by threadId', async () => {
+    const svc = new TriggerEventsService(10);
+    const trig = new TestTrigger();
+    svc.bind('n1', trig);
+    await trig.push('x', [{ content: '1', info: {} }]);
+    await trig.push('y', [{ content: '2', info: {} }]);
+    await trig.push('x', [{ content: '3', info: {} }]);
+    const all = svc.list('n1');
+    expect(all.length).toBe(3);
+    const onlyX = svc.list('n1', { threadId: 'x' });
+    expect(onlyX.length).toBe(2);
+    expect(onlyX[0].messages[0].content).toBe('3');
+  });
+});

--- a/apps/server/src/services/socket.service.ts
+++ b/apps/server/src/services/socket.service.ts
@@ -1,17 +1,23 @@
 import { Server, Socket } from 'socket.io';
 import { LoggerService } from './logger.service';
 import { CheckpointerService } from './checkpointer.service';
+import { TriggerEventsService, TriggerEvent } from './trigger-events.service';
 
 interface InitPayload {
   threadId?: string;
   agentId?: string;
 }
 
+interface TriggerInitPayload { nodeId: string; threadId?: string }
+interface TriggerUpdatePayload { nodeId: string; threadId?: string }
+interface TriggerClosePayload { nodeId: string }
+
 export class SocketService {
   constructor(
     private io: Server,
     private logger: LoggerService,
     private checkpointer: CheckpointerService,
+    private triggerEvents: TriggerEventsService,
   ) {}
 
   register() {
@@ -23,15 +29,29 @@ export class SocketService {
     let closed = false;
     let stream: any; // ChangeStream
 
+    // trigger events: per-socket subscriptions by nodeId -> filter
+    const subscriptions = new Map<string, { threadId?: string }>();
+    const emitFor = (env: { nodeId: string; event: TriggerEvent }) => {
+      const sub = subscriptions.get(env.nodeId);
+      if (!sub) return;
+      if (sub.threadId && env.event.threadId !== sub.threadId) return;
+      socket.emit('trigger_event', { nodeId: env.nodeId, event: env.event });
+    };
+    const off = this.triggerEvents.onEvent(emitFor);
+
     const cleanup = async () => {
       if (stream) {
         try { await stream.close(); } catch (e) { this.logger.error('Error closing change stream', e); }
       }
+      // remove trigger listener and clear subs
+      try { off(); } catch {}
+      subscriptions.clear();
       closed = true;
     };
 
     socket.on('disconnect', () => { cleanup(); });
 
+    // Existing checkpoint stream logic (unchanged)
     socket.on('init', async (payload: InitPayload) => {
       if (closed) return;
       try {
@@ -53,6 +73,31 @@ export class SocketService {
         this.logger.error('Init error', err);
         socket.emit('error', { message: 'init error' });
       }
+    });
+
+    // Trigger events: init/update/close
+    socket.on('trigger_init', (payload: TriggerInitPayload) => {
+      if (closed) return;
+      const { nodeId, threadId } = payload || ({} as any);
+      if (!nodeId) return;
+      subscriptions.set(nodeId, { threadId });
+      const items = this.triggerEvents.list(nodeId, { threadId, limit: 200 });
+      socket.emit('trigger_initial', { nodeId, items });
+    });
+
+    socket.on('trigger_update', (payload: TriggerUpdatePayload) => {
+      if (closed) return;
+      const { nodeId, threadId } = payload || ({} as any);
+      if (!nodeId) return;
+      if (subscriptions.has(nodeId)) subscriptions.set(nodeId, { threadId });
+      const items = this.triggerEvents.list(nodeId, { threadId, limit: 200 });
+      socket.emit('trigger_initial', { nodeId, items });
+    });
+
+    socket.on('trigger_close', (payload: TriggerClosePayload) => {
+      const { nodeId } = payload || ({} as any);
+      if (!nodeId) return;
+      subscriptions.delete(nodeId);
     });
   }
 }

--- a/apps/server/src/services/trigger-events.service.ts
+++ b/apps/server/src/services/trigger-events.service.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from 'events';
+import { BaseTrigger, TriggerListener, TriggerMessage } from '../triggers/base.trigger';
+
+export type TriggerEvent = {
+  ts: number; // epoch millis
+  threadId: string;
+  messages: TriggerMessage[];
+};
+
+export type TriggerEventEnvelope = { nodeId: string; event: TriggerEvent };
+
+export type TriggerEventFilter = { threadId?: string; limit?: number };
+
+/**
+ * In-memory store and emitter for Trigger events. Socket-only transport; no HTTP endpoints.
+ * Stores up to TRIGGER_EVENTS_MAX events per node (default 300) in FIFO order (oldest evicted).
+ */
+export class TriggerEventsService {
+  private readonly maxPerNode: number;
+  private readonly store = new Map<string, TriggerEvent[]>(); // nodeId -> events (oldest->newest)
+  private readonly emitter = new EventEmitter();
+
+  constructor(maxPerNode?: number) {
+    const fromEnv = Number(process.env.TRIGGER_EVENTS_MAX);
+    const resolved = Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : undefined;
+    this.maxPerNode = maxPerNode || resolved || 300;
+  }
+
+  /**
+   * Bind a trigger instance to a node id. Subsequent messages are recorded and re-emitted.
+   */
+  bind(nodeId: string, trigger: BaseTrigger): void {
+    const listener: TriggerListener = {
+      invoke: async (threadId, messages) => {
+        const ev: TriggerEvent = { ts: Date.now(), threadId, messages };
+        this.append(nodeId, ev);
+        this.emitter.emit('event', { nodeId, event: ev } as TriggerEventEnvelope);
+      },
+    };
+    // Best-effort; BaseTrigger.subscribe returns Promise<void>
+    void trigger.subscribe(listener);
+  }
+
+  /**
+   * Return events for a node. Newest-first; optionally filtered by threadId and limited.
+   */
+  list(nodeId: string, filter?: TriggerEventFilter): TriggerEvent[] {
+    const all = this.store.get(nodeId) || [];
+    const byThread = filter?.threadId ? all.filter((e) => e.threadId === filter.threadId) : all;
+    const newestFirst = [...byThread].reverse();
+    const limit = filter?.limit && filter.limit > 0 ? filter.limit : this.maxPerNode;
+    return newestFirst.slice(0, limit);
+  }
+
+  onEvent(cb: (env: TriggerEventEnvelope) => void): () => void {
+    this.emitter.on('event', cb);
+    return () => this.emitter.off('event', cb);
+  }
+
+  // Internal: append and prune per-node buffer
+  private append(nodeId: string, ev: TriggerEvent): void {
+    let list = this.store.get(nodeId);
+    if (!list) {
+      list = [];
+      this.store.set(nodeId, list);
+    }
+    list.push(ev);
+    if (list.length > this.maxPerNode) {
+      const excess = list.length - this.maxPerNode;
+      list.splice(0, excess); // drop oldest first
+    }
+  }
+}

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -31,6 +31,10 @@ Docs
   - Components: NodeDetailsPanel, StaticConfigForm, DynamicConfigForm
   - Socket.io status updates (no polling)
 
+Trigger Events Panel
+- For trigger nodes (e.g., Slack Trigger), the Right Properties panel shows "Trigger Events".
+- It streams via Socket.io only; supports optional `threadId` filter. No HTTP endpoints involved.
+
 Notes
 - Server emits JSON Schema 7 generated from Zod v4. UI uses RJSF with ajv8.
 - Actions are optimistic; authoritative socket events reconcile cache.

--- a/apps/ui/src/__tests__/useTriggerEvents.test.tsx
+++ b/apps/ui/src/__tests__/useTriggerEvents.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTriggerEvents } from '@/hooks/useTriggerEvents';
+import { graphSocket } from '@/lib/graph/socket';
+
+vi.mock('@/lib/graph/socket', () => {
+  const listeners: Record<string, Function[]> = {};
+  return {
+    graphSocket: {
+      connect: vi.fn(),
+      emitTriggerInit: vi.fn(),
+      emitTriggerUpdate: vi.fn(),
+      emitTriggerClose: vi.fn(),
+      onTriggerInitial: (cb: any) => {
+        (listeners['trigger_initial'] ||= []).push(cb);
+        return () => {
+          listeners['trigger_initial'] = (listeners['trigger_initial'] || []).filter((x) => x !== cb);
+        };
+      },
+      onTriggerEvent: (_nodeId: string, cb: any) => {
+        (listeners['trigger_event'] ||= []).push(cb);
+        return () => {
+          listeners['trigger_event'] = (listeners['trigger_event'] || []).filter((x) => x !== cb);
+        };
+      },
+      __emit: (name: string, payload: any) => {
+        for (const cb of listeners[name] || []) cb(payload);
+      },
+    },
+  };
+});
+
+describe('useTriggerEvents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handles initial payload, appends updates, and refetches on threadId change', async () => {
+    const { result } = renderHook(({ nodeId }) => useTriggerEvents(nodeId), {
+      initialProps: { nodeId: 'n1' },
+    });
+
+    // initial
+    act(() => {
+      (graphSocket as any).__emit('trigger_initial', { nodeId: 'n1', items: [
+        { ts: 1, threadId: 'a', messages: [{ content: 'm1', info: {} }] },
+      ] });
+    });
+    expect(result.current.items.length).toBe(1);
+
+    // live append
+    act(() => {
+      (graphSocket as any).__emit('trigger_event', { nodeId: 'n1', event: { ts: 2, threadId: 'a', messages: [{ content: 'm2', info: {} }] } });
+    });
+    expect(result.current.items[0].messages[0].content).toBe('m2');
+
+    // change threadId
+    act(() => {
+      result.current.setThreadId('b');
+    });
+
+    // simulate initial for new filter
+    act(() => {
+      (graphSocket as any).__emit('trigger_initial', { nodeId: 'n1', items: [
+        { ts: 3, threadId: 'b', messages: [{ content: 'm3', info: {} }] },
+      ] });
+    });
+    expect(result.current.items[0].threadId).toBe('b');
+  });
+});

--- a/apps/ui/src/builder/panels/RightPropertiesPanel.tsx
+++ b/apps/ui/src/builder/panels/RightPropertiesPanel.tsx
@@ -11,6 +11,8 @@ import { NodeActionButtons } from '@/components/graph/NodeActionButtons';
 import { useNodeAction, useNodeStatus } from '@/lib/graph/hooks';
 import { canPause, canProvision } from '@/lib/graph/capabilities';
 
+import { TriggerEventsPanel } from '@/components/stream/TriggerEventsPanel';
+
 interface BuilderPanelNodeData {
   template: string;
   name?: string;
@@ -78,6 +80,8 @@ export function RightPropertiesPanel({ node, onChange }: Props) {
     );
   }
 
+  const isTrigger = runtimeTemplate?.kind === 'trigger';
+
   return (
     <div className="space-y-4">
       {/* Runtime status & actions */}
@@ -85,6 +89,11 @@ export function RightPropertiesPanel({ node, onChange }: Props) {
         <div className="space-y-2">
           <div className="text-[10px] uppercase text-muted-foreground">Runtime Status</div>
           <RuntimeNodeSection nodeId={node.id} templateName={data.template} />
+        </div>
+      )}
+      {isTrigger && (
+        <div className="space-y-2">
+          <TriggerEventsPanel nodeId={node.id} />
         </div>
       )}
       {runtimeStaticCap && (

--- a/apps/ui/src/builder/panels/__tests__/RightPropertiesPanel.trigger.test.tsx
+++ b/apps/ui/src/builder/panels/__tests__/RightPropertiesPanel.trigger.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RightPropertiesPanel } from '../RightPropertiesPanel';
+
+vi.mock('@/lib/graph/hooks', () => ({
+  useNodeStatus: () => ({ data: { provisionStatus: { state: 'ready' }, isPaused: false } }),
+  useNodeAction: () => ({ mutate: () => {} }),
+}));
+
+vi.mock('@/lib/graph/templates.provider', async () => {
+  return {
+    useTemplatesCache: () => ({
+      getTemplate: (name: string) => ({ name, kind: name === 'slackTrigger' ? 'trigger' : 'tool', title: name }),
+    }),
+  };
+});
+
+vi.mock('@/components/graph', () => ({ StaticConfigForm: () => <div>Static</div>, DynamicConfigForm: () => <div>Dynamic</div> }));
+vi.mock('@/components/stream/TriggerEventsPanel', () => ({ TriggerEventsPanel: () => <div>Trigger Events</div> }));
+
+
+describe('RightPropertiesPanel trigger integration', () => {
+  it('renders TriggerEventsPanel for trigger nodes', () => {
+    const node: any = { id: 'n1', data: { template: 'slackTrigger', config: {}, dynamicConfig: {} } };
+    render(<RightPropertiesPanel node={node} onChange={() => {}} />);
+    expect(screen.getByText('Trigger Events')).toBeInTheDocument();
+  });
+
+  it('does not render TriggerEventsPanel for non-trigger nodes', () => {
+    const node: any = { id: 'n2', data: { template: 'sendSlackMessageTool', config: {}, dynamicConfig: {} } };
+    render(<RightPropertiesPanel node={node} onChange={() => {}} />);
+    expect(screen.queryByText('Trigger Events')).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/components/stream/TriggerEventsPanel.tsx
+++ b/apps/ui/src/components/stream/TriggerEventsPanel.tsx
@@ -1,0 +1,53 @@
+import React, { useMemo } from 'react';
+import { useTriggerEvents } from '@/hooks/useTriggerEvents';
+
+interface Props { nodeId: string }
+
+export function TriggerEventsPanel({ nodeId }: Props) {
+  const { items, threadId, setThreadId } = useTriggerEvents(nodeId);
+
+  return (
+    <div className="space-y-2">
+      <div className="text-[10px] uppercase text-muted-foreground">Trigger Events</div>
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-muted-foreground">threadId</label>
+        <input
+          className="flex-1 rounded border border-border bg-background p-1 text-xs"
+          placeholder="optional thread id filter"
+          value={threadId || ''}
+          onChange={(e) => setThreadId(e.target.value || undefined)}
+        />
+      </div>
+      <div className="space-y-2 max-h-80 overflow-auto border rounded p-2">
+        {items.length === 0 ? (
+          <div className="text-xs text-muted-foreground">No events yet.</div>
+        ) : (
+          items.map((item, idx) => <EventItem key={item.ts + ':' + idx} item={item} />)
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EventItem({ item }: { item: { ts: number; threadId: string; messages: Array<{ content: string; info: Record<string, unknown> }> } }) {
+  const first = item.messages[0];
+  const ts = useMemo(() => new Date(item.ts).toLocaleString(), [item.ts]);
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className="rounded border border-border p-2 text-xs">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-mono text-[10px] text-muted-foreground">{ts}</div>
+          <div className="font-mono text-[10px]">thread: {item.threadId}</div>
+          <div className="truncate">{first?.content}</div>
+        </div>
+        <button className="text-[10px] underline" onClick={() => setOpen((v) => !v)}>{open ? 'Hide' : 'Info'}</button>
+      </div>
+      {open ? (
+        <pre className="mt-2 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 text-[10px]">
+          {JSON.stringify(first?.info ?? {}, null, 2)}
+        </pre>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/useTriggerEvents.ts
+++ b/apps/ui/src/hooks/useTriggerEvents.ts
@@ -1,0 +1,47 @@
+import { useEffect, useMemo, useState } from 'react';
+import { graphSocket, TriggerEvent } from '@/lib/graph/socket';
+
+function useDebounced<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+export function useTriggerEvents(nodeId: string) {
+  const [items, setItems] = useState<TriggerEvent[]>([]);
+  const [threadId, setThreadId] = useState<string | undefined>(undefined);
+  const debouncedThreadId = useDebounced(threadId, 300);
+
+  // initial + updates
+  useEffect(() => {
+    if (!nodeId) return;
+    graphSocket.connect();
+    const onInitial = (payload: { nodeId: string; items: TriggerEvent[] }) => {
+      if (payload.nodeId !== nodeId) return;
+      setItems(payload.items || []);
+    };
+    const offInitial = graphSocket.onTriggerInitial(onInitial);
+    // per-node event listener
+    const offEvent = graphSocket.onTriggerEvent(nodeId, (payload) => {
+      if (payload.nodeId !== nodeId) return;
+      setItems((prev) => [payload.event, ...prev].slice(0, 200));
+    });
+    graphSocket.emitTriggerInit({ nodeId, threadId: debouncedThreadId });
+    return () => {
+      offInitial();
+      offEvent();
+      graphSocket.emitTriggerClose({ nodeId });
+    };
+  }, [nodeId]);
+
+  // refetch on thread filter change
+  useEffect(() => {
+    if (!nodeId) return;
+    graphSocket.emitTriggerUpdate({ nodeId, threadId: debouncedThreadId });
+  }, [nodeId, debouncedThreadId]);
+
+  return useMemo(() => ({ items, threadId, setThreadId }), [items, threadId]);
+}

--- a/apps/ui/src/lib/graph/socket.ts
+++ b/apps/ui/src/lib/graph/socket.ts
@@ -3,15 +3,18 @@ import type { NodeStatusEvent } from './types';
 
 type Listener = (ev: NodeStatusEvent) => void;
 
+export type TriggerEvent = { ts: number; threadId: string; messages: Array<{ content: string; info: Record<string, unknown> }> };
+
 class GraphSocket {
   private socket: Socket | null = null;
   private listeners = new Map<string, Set<Listener>>();
+  private triggerListeners = new Map<string, Set<(ev: { nodeId: string; event: TriggerEvent }) => void>>();
 
   connect(baseUrl?: string) {
     if (this.socket) return this.socket;
-  interface ViteEnv { VITE_GRAPH_API_BASE?: string }
-  const envHost = (typeof import.meta !== 'undefined' ? (import.meta as unknown as { env?: ViteEnv }).env?.VITE_GRAPH_API_BASE : undefined);
-  const host = baseUrl || envHost || 'http://localhost:3010';
+    interface ViteEnv { VITE_GRAPH_API_BASE?: string }
+    const envHost = (typeof import.meta !== 'undefined' ? (import.meta as unknown as { env?: ViteEnv }).env?.VITE_GRAPH_API_BASE : undefined);
+    const host = baseUrl || envHost || 'http://localhost:3010';
     this.socket = io(host, { path: '/socket.io', transports: ['websocket'], forceNew: false, autoConnect: true, timeout: 10000, reconnection: true, reconnectionAttempts: Infinity, reconnectionDelay: 1000, reconnectionDelayMax: 5000, withCredentials: true });
     this.socket.on('connect', () => {
       // noop
@@ -20,7 +23,16 @@ class GraphSocket {
       const set = this.listeners.get(payload.nodeId);
       if (set) for (const fn of set) fn(payload);
     });
+    this.socket.on('trigger_event', (payload: { nodeId: string; event: TriggerEvent }) => {
+      const set = this.triggerListeners.get(payload.nodeId);
+      if (set) for (const fn of set) fn(payload);
+    });
     return this.socket;
+  }
+
+  getSocket(): Socket {
+    if (!this.socket) this.connect();
+    return this.socket!;
   }
 
   onNodeStatus(nodeId: string, cb: Listener) {
@@ -33,6 +45,33 @@ class GraphSocket {
     return () => {
       set!.delete(cb);
       if (set!.size === 0) this.listeners.delete(nodeId);
+    };
+  }
+
+  // Trigger events API
+  emitTriggerInit(payload: { nodeId: string; threadId?: string }) {
+    this.getSocket().emit('trigger_init', payload);
+  }
+  emitTriggerUpdate(payload: { nodeId: string; threadId?: string }) {
+    this.getSocket().emit('trigger_update', payload);
+  }
+  emitTriggerClose(payload: { nodeId: string }) {
+    this.getSocket().emit('trigger_close', payload);
+  }
+  onTriggerInitial(cb: (payload: { nodeId: string; items: TriggerEvent[] }) => void) {
+    this.getSocket().on('trigger_initial', cb);
+    return () => this.getSocket().off('trigger_initial', cb);
+  }
+  onTriggerEvent(nodeId: string, cb: (payload: { nodeId: string; event: TriggerEvent }) => void) {
+    let set = this.triggerListeners.get(nodeId);
+    if (!set) {
+      set = new Set();
+      this.triggerListeners.set(nodeId, set);
+    }
+    set.add(cb);
+    return () => {
+      set!.delete(cb);
+      if (set!.size === 0) this.triggerListeners.delete(nodeId);
     };
   }
 }

--- a/docs/ui/graph/README.md
+++ b/docs/ui/graph/README.md
@@ -24,3 +24,12 @@ Socket updates
 - Event: node_status
 - Payload: { nodeId, isPaused?, provisionStatus?, dynamicConfigReady?, updatedAt? }
 - The UI subscribes per-node and reconciles socket events into React Query cache.
+
+Trigger events (socket-only)
+- For trigger nodes, UI uses Socket.io messages to stream events.
+- Messages:
+  - trigger_init { nodeId, threadId? } → server replies with trigger_initial { nodeId, items }
+  - trigger_update { nodeId, threadId? } → server replies with trigger_initial
+  - trigger_close { nodeId }
+  - trigger_event { nodeId, event }
+- No HTTP endpoints are exposed for trigger events.


### PR DESCRIPTION
Implements #59: Socket.io-only Trigger Events.

Summary
- Server: in-memory TriggerEventsService (FIFO per-node, env `TRIGGER_EVENTS_MAX`, default 300).
- Wiring: instantiate once in server bootstrap; pass into TemplateRegistry and SocketService.
- Templates: SlackTrigger binds to TriggerEventsService; events recorded and emitted.
- SocketService: new messages (`trigger_init`/`trigger_update`/`trigger_close`, `trigger_initial`/`trigger_event`), per-socket filters and cleanup.
- No HTTP endpoint for trigger events.

UI
- socket client extended to support trigger events, with subscribe API.
- new hook `useTriggerEvents(nodeId)`.
- new `TriggerEventsPanel` component with threadId filter and events list.
- integrated into RightPropertiesPanel when template kind === "trigger".

Tests
- Server: TriggerEventsService unit (bind/prune, list filter); SocketService flow (init/update/close, filtering).
- UI: hook test for useTriggerEvents; RightPropertiesPanel renders TriggerEventsPanel for trigger nodes.

Docs
- UI README: mention panel & socket-only approach.
- Server README: env var and socket message docs.
- docs/ui/graph/README: socket messages for trigger events.

Notes
- Checkpoint stream logic remains intact.
- Listeners cleaned up on socket disconnect.

Screenshots
- Attached in comments after CI.
