### PR TITLE
feat: RemindMe tool (async) + trigger message types

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Quick links
 - Server: [apps/server](apps/server) — runtime, triggers, tools, MCP, graph persistence
 - UI: [apps/ui](apps/ui) — graph builder and checkpoint stream viewer
 - Docs: [docs/README.md](docs/README.md) — technical overview, contributing, MCP design
+- Tools: [docs/tools/remind_me.md](docs/tools/remind_me.md) — RemindMe tool behavior and usage
 
 Getting started
 - Architecture and setup: [docs/technical-overview.md](docs/technical-overview.md)

--- a/apps/server/src/__tests__/tools.remind_me.test.ts
+++ b/apps/server/src/__tests__/tools.remind_me.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RemindMeTool } from '../tools/remind_me.tool';
+import { LoggerService } from '../services/logger.service';
+
+// Helper to extract callable tool
+function getToolInstance() {
+  const logger = new LoggerService();
+  const tool = new RemindMeTool(logger).init();
+  return tool;
+}
+
+describe('RemindMeTool', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('schedules reminder and invokes caller_agent after delay', async () => {
+    const tool = getToolInstance();
+
+    const invokeSpy = vi.fn(async () => undefined);
+    const caller_agent = { invoke: invokeSpy } as any;
+    const thread_id = 't-123';
+
+    const res = await tool.invoke(
+      { delayMs: 1000, note: 'Ping' },
+      { configurable: { thread_id, caller_agent } } as any,
+    );
+
+    // Immediate ack
+    const parsed = typeof res === 'string' ? JSON.parse(res) : res;
+    expect(parsed.status).toBe('scheduled');
+    expect(parsed.etaMs).toBe(1000);
+    expect(typeof parsed.at).toBe('string');
+
+    // Advance timers and ensure invoke called once with system message
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(invokeSpy).toHaveBeenCalledTimes(1);
+    expect(invokeSpy.mock.calls[0][0]).toBe(thread_id);
+    expect(invokeSpy.mock.calls[0][1]).toEqual([
+      { kind: 'system', content: 'Ping', info: { reason: 'reminded' } },
+    ]);
+  });
+
+  it('returns error when thread_id missing', async () => {
+    const tool = getToolInstance();
+    const caller_agent = { invoke: vi.fn() } as any;
+    const res = await tool.invoke({ delayMs: 1, note: 'x' }, { configurable: { caller_agent } } as any);
+    expect(typeof res).toBe('string');
+    expect(String(res)).toContain('missing thread_id');
+  });
+
+  it('returns error when caller_agent missing', async () => {
+    const tool = getToolInstance();
+    const res = await tool.invoke({ delayMs: 1, note: 'x' }, { configurable: { thread_id: 't' } } as any);
+    expect(typeof res).toBe('string');
+    expect(String(res)).toContain('missing caller_agent');
+  });
+});

--- a/apps/server/src/__tests__/tools.remind_me.test.ts
+++ b/apps/server/src/__tests__/tools.remind_me.test.ts
@@ -71,6 +71,63 @@ describe('RemindMeTool', () => {
     ]);
   });
 
+  it('supports multiple concurrent reminders for the same thread (delayMs=0)', async () => {
+    const tool = getToolInstance();
+    const invokeSpy = vi.fn(async () => undefined);
+    const caller_agent: CallerAgentStub = { invoke: invokeSpy };
+    const cfg = { configurable: { thread_id: 't-x', caller_agent } };
+
+    // Schedule two reminders immediately
+    await tool.invoke({ delayMs: 0, note: 'A' }, cfg);
+    await tool.invoke({ delayMs: 0, note: 'B' }, cfg);
+
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(invokeSpy).toHaveBeenCalledTimes(2);
+    const calls = invokeSpy.mock.calls;
+    const payloads = calls.map((c) => c[1][0].content).sort();
+    expect(payloads).toEqual(['A', 'B']);
+    expect(calls[0][0]).toBe('t-x');
+    expect(calls[1][0]).toBe('t-x');
+  });
+
+  it('handles overlapping delays for the same thread', async () => {
+    const tool = getToolInstance();
+    const invokeSpy = vi.fn(async () => undefined);
+    const caller_agent: CallerAgentStub = { invoke: invokeSpy };
+    const cfg = { configurable: { thread_id: 't-ovl', caller_agent } };
+
+    await tool.invoke({ delayMs: 500, note: 'half' }, cfg); // A at 500ms
+    await tool.invoke({ delayMs: 1000, note: 'full' }, cfg); // B at 1000ms
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(invokeSpy).toHaveBeenCalledTimes(1);
+    expect(invokeSpy.mock.calls[0][1][0]).toMatchObject({ content: 'half' });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(invokeSpy).toHaveBeenCalledTimes(2);
+    expect(invokeSpy.mock.calls[1][1][0]).toMatchObject({ content: 'full' });
+  });
+
+  it('routes reminders to mixed threads correctly', async () => {
+    const tool = getToolInstance();
+    const invokeSpy = vi.fn(async () => undefined);
+    const caller_agent: CallerAgentStub = { invoke: invokeSpy };
+
+    await tool.invoke({ delayMs: 10, note: 'one' }, { configurable: { thread_id: 't-1', caller_agent } });
+    await tool.invoke({ delayMs: 20, note: 'two' }, { configurable: { thread_id: 't-2', caller_agent } });
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(invokeSpy).toHaveBeenCalledTimes(1);
+    expect(invokeSpy.mock.calls[0][0]).toBe('t-1');
+    expect(invokeSpy.mock.calls[0][1][0]).toMatchObject({ content: 'one' });
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(invokeSpy).toHaveBeenCalledTimes(2);
+    expect(invokeSpy.mock.calls[1][0]).toBe('t-2');
+    expect(invokeSpy.mock.calls[1][1][0]).toMatchObject({ content: 'two' });
+  });
+
   it('returns error when thread_id missing', async () => {
     const tool = getToolInstance();
     const caller_agent: CallerAgentStub = { invoke: vi.fn(async () => undefined) };

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -16,6 +16,7 @@ import { SlackTrigger } from './triggers';
 import { SlackTriggerStaticConfigSchema } from './triggers/slack.trigger';
 import { LocalMcpServerStaticConfigSchema } from './mcp/localMcpServer';
 import { FinishTool, FinishToolStaticConfigSchema } from './tools/finish.tool';
+import { RemindMeTool, RemindMeToolStaticConfigSchema } from './tools/remind_me.tool';
 
 export interface TemplateRegistryDeps {
   logger: LoggerService;
@@ -120,6 +121,17 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
         kind: 'tool',
         capabilities: { staticConfigurable: true },
         staticConfigSchema: toJSONSchema(CallAgentToolStaticConfigSchema),
+      },
+    )
+    .register(
+      'remindMeTool',
+      () => new RemindMeTool(logger),
+      { targetPorts: { $self: { kind: 'instance' } } },
+      {
+        title: 'Remind Me',
+        kind: 'tool',
+        capabilities: { staticConfigurable: true },
+        staticConfigSchema: toJSONSchema(RemindMeToolStaticConfigSchema),
       },
     )
     .register(

--- a/apps/server/src/tools/remind_me.tool.ts
+++ b/apps/server/src/tools/remind_me.tool.ts
@@ -1,0 +1,55 @@
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { BaseTool } from './base.tool';
+import { LoggerService } from '../services/logger.service';
+
+const remindMeSchema = z.object({ delayMs: z.number().int().min(0), note: z.string().min(1) });
+
+export class RemindMeTool extends BaseTool {
+  constructor(private logger: LoggerService) {
+    super();
+  }
+
+  init(): DynamicStructuredTool {
+    return tool(
+      async (raw, config) => {
+        const { delayMs, note } = remindMeSchema.parse(raw);
+        const threadId = (config?.configurable as any)?.thread_id as string | undefined;
+        const callerAgent = (config?.configurable as any)?.caller_agent as any | undefined;
+
+        if (!threadId) {
+          const msg = 'RemindMeTool error: missing thread_id in runtime config.';
+          this.logger.error(msg);
+          return msg;
+        }
+        if (!callerAgent || typeof callerAgent.invoke !== 'function') {
+          const msg = 'RemindMeTool error: missing caller_agent in runtime config.';
+          this.logger.error(msg);
+          return msg;
+        }
+
+        // Schedule async reminder; do not await or reject the original call.
+        setTimeout(async () => {
+          try {
+            await callerAgent.invoke(threadId, [
+              { kind: 'system', content: note, info: { reason: 'reminded' } },
+            ]);
+          } catch (e: any) {
+            this.logger.error('RemindMeTool scheduled invoke error', e);
+          }
+        }, delayMs);
+
+        const eta = new Date(Date.now() + delayMs).toISOString();
+        return { status: 'scheduled', etaMs: delayMs, at: eta };
+      },
+      {
+        name: 'remindMeTool',
+        description:
+          'Schedule a reminder message to self after a delay. Useful for time-based follow-ups. Async-only; returns immediately with schedule info.',
+        schema: remindMeSchema,
+      },
+    );
+  }
+}
+
+export const RemindMeToolStaticConfigSchema = z.object({}).strict();

--- a/apps/server/src/triggers/base.trigger.ts
+++ b/apps/server/src/triggers/base.trigger.ts
@@ -11,11 +11,8 @@ export type TriggerSystemMessage = TriggerMessage & { kind: 'system' };
 
 // Small centralized type guards for trigger messages
 export function isSystemTrigger(msg: TriggerMessage): msg is TriggerSystemMessage {
-  // Use loose check on discriminator without casting
+  // Check discriminator without leaking details of other variants
   return (msg as Partial<TriggerSystemMessage>).kind === 'system';
-}
-export function isHumanTrigger(msg: TriggerMessage): msg is TriggerHumanMessage {
-  return (msg as Partial<TriggerHumanMessage>).kind === 'human' || (msg as any).kind === undefined;
 }
 
 export interface TriggerListener {

--- a/apps/server/src/triggers/base.trigger.ts
+++ b/apps/server/src/triggers/base.trigger.ts
@@ -1,6 +1,13 @@
 import type { Pausable, ProvisionStatus, Provisionable } from '../graph/capabilities';
 
-export type TriggerMessage = { content: string; info: Record<string, unknown> };
+// Base trigger message. Backward-compatible: no 'kind' field required.
+export interface TriggerMessage {
+  content: string;
+  info: Record<string, unknown>;
+}
+// Explicitly-typed variants for clarity/forward-compatibility
+export type TriggerHumanMessage = TriggerMessage & { kind: 'human' };
+export type TriggerSystemMessage = TriggerMessage & { kind: 'system' };
 
 export interface TriggerListener {
   invoke(thread: string, messages: TriggerMessage[]): Promise<any>;

--- a/apps/server/src/triggers/base.trigger.ts
+++ b/apps/server/src/triggers/base.trigger.ts
@@ -9,6 +9,15 @@ export interface TriggerMessage {
 export type TriggerHumanMessage = TriggerMessage & { kind: 'human' };
 export type TriggerSystemMessage = TriggerMessage & { kind: 'system' };
 
+// Small centralized type guards for trigger messages
+export function isSystemTrigger(msg: TriggerMessage): msg is TriggerSystemMessage {
+  // Use loose check on discriminator without casting
+  return (msg as Partial<TriggerSystemMessage>).kind === 'system';
+}
+export function isHumanTrigger(msg: TriggerMessage): msg is TriggerHumanMessage {
+  return (msg as Partial<TriggerHumanMessage>).kind === 'human' || (msg as any).kind === undefined;
+}
+
 export interface TriggerListener {
   invoke(thread: string, messages: TriggerMessage[]): Promise<any>;
 }

--- a/apps/server/src/triggers/base.trigger.ts
+++ b/apps/server/src/triggers/base.trigger.ts
@@ -16,7 +16,7 @@ export function isSystemTrigger(msg: TriggerMessage): msg is TriggerSystemMessag
 }
 
 export interface TriggerListener {
-  invoke(thread: string, messages: TriggerMessage[]): Promise<any>;
+  invoke(thread: string, messages: TriggerMessage[]): Promise<unknown>;
 }
 
 /**

--- a/apps/server/src/triggers/slack.trigger.ts
+++ b/apps/server/src/triggers/slack.trigger.ts
@@ -36,14 +36,14 @@ export class SlackTrigger extends BaseTrigger {
       try {
         if (!event.text) return;
         const thread = `${event.user}_${event.thread_ts ?? event.ts}`;
+        const ch = (event as Record<string, unknown>).channel_type;
         const msg: TriggerHumanMessage = {
           kind: 'human',
           content: event.text,
           info: {
             user: event.user,
             channel: event.channel,
-            // access optional channel_type without unsafe casts
-            channel_type: typeof (event as Record<string, unknown>).channel_type === 'string' ? (event as any).channel_type : undefined,
+            channel_type: typeof ch === 'string' ? ch : undefined,
             thread_ts: event.thread_ts ?? event.ts,
           },
         };

--- a/apps/server/src/triggers/slack.trigger.ts
+++ b/apps/server/src/triggers/slack.trigger.ts
@@ -1,4 +1,4 @@
-import { BaseTrigger, BaseTriggerOptions } from './base.trigger';
+import { BaseTrigger, BaseTriggerOptions, TriggerHumanMessage } from './base.trigger';
 import { LoggerService } from '../services/logger.service';
 import { SlackService } from '../services/slack.service';
 import { z } from 'zod';
@@ -36,17 +36,17 @@ export class SlackTrigger extends BaseTrigger {
       try {
         if (!event.text) return;
         const thread = `${event.user}_${event.thread_ts ?? event.ts}`;
-        await this.notify(thread, [
-          {
-            content: event.text,
-            info: {
-              user: event.user,
-              channel: event.channel,
-              channel_type: (event as any).channel_type,
-              thread_ts: event.thread_ts ?? event.ts,
-            },
+        const msg: TriggerHumanMessage = {
+          kind: 'human',
+          content: event.text,
+          info: {
+            user: event.user,
+            channel: event.channel,
+            channel_type: (event as any).channel_type,
+            thread_ts: event.thread_ts ?? event.ts,
           },
-        ]);
+        };
+        await this.notify(thread, [msg]);
       } catch (err) {
         this.logger.error('SlackTrigger handler error', err);
       }

--- a/apps/server/src/triggers/slack.trigger.ts
+++ b/apps/server/src/triggers/slack.trigger.ts
@@ -42,7 +42,8 @@ export class SlackTrigger extends BaseTrigger {
           info: {
             user: event.user,
             channel: event.channel,
-            channel_type: (event as any).channel_type,
+            // access optional channel_type without unsafe casts
+            channel_type: typeof (event as Record<string, unknown>).channel_type === 'string' ? (event as any).channel_type : undefined,
             thread_ts: event.thread_ts ?? event.ts,
           },
         };

--- a/docs/tools/remind_me.md
+++ b/docs/tools/remind_me.md
@@ -1,0 +1,11 @@
+# RemindMe Tool
+
+Behavior
+- Supports multiple concurrent reminders for the same thread; each call schedules its own timer and none overwrite others.
+- Async-only: returns immediately with `{ status: 'scheduled', etaMs, at }`. The reminder fires later and posts a system message to the caller agent.
+- Persistence, cancel-by-id, and durable scheduling are out of scope for now.
+
+Usage
+- Tool name: `remindMeTool`
+- Input: `{ delayMs: number >= 0, note: string }`
+- Effect: schedules a system message `{ kind: 'system', content: note, info: { reason: 'reminded' } }` back to the originating agent/thread.


### PR DESCRIPTION
Implements consolidated issue #60

Key changes
- Trigger message model: add `kind` variants and keep backward compat
  - `TriggerMessage`, `TriggerHumanMessage`, `TriggerSystemMessage`
  - `TriggerListener.invoke` now accepts `TriggerMessage[]`
- BaseAgent.invoke mapping
  - Accepts `TriggerMessage | TriggerMessage[]`
  - Serializes entire message as JSON string and maps kind → `SystemMessage`/`HumanMessage` (missing `kind` defaults to human)
- New RemindMeTool (async-only)
  - Zod schema: `{ delayMs: number, note: string }`
  - Reads `thread_id` and `caller_agent` from runtime config
  - Schedules `caller_agent.invoke(thread_id, [{ kind: 'system', content: note, info: { reason: 'reminded' } }])`
  - Returns ack: `{ status: 'scheduled', etaMs, at }`
- Register tool in templates as `remindMeTool`
- SlackTrigger emits explicit `kind: 'human'` messages
- Tests: `apps/server/src/__tests__/tools.remind_me.test.ts` using fake timers

Notes
- No usage of `additional_kwargs`; payloads are JSON.stringify(msg)
- Out of scope: persistence/cancel/cron parsing

CI: All server tests pass locally via Vitest.