### PR TITLE
Server: emit node_status on ready after MCP restart (#66)

### DIFF
--- a/apps/server/__tests__/readinessWatcher.test.ts
+++ b/apps/server/__tests__/readinessWatcher.test.ts
@@ -48,17 +48,15 @@ describe('ReadinessWatcher', () => {
       { provisionStatus: { state: 'ready' }, dynamicConfigReady: false },
     ]);
 
+    // Start twice immediately to verify debounce of concurrent watchers
     watcher.start(nodeId);
+    watcher.start(nodeId);
+
     // wait enough time for polling
     await new Promise((r) => setTimeout(r, 50));
 
     expect(emit).toHaveBeenCalledTimes(1);
     expect(emit).toHaveBeenCalledWith(nodeId);
-
-    // ensure subsequent starts are debounced while active
-    watcher.start(nodeId);
-    await new Promise((r) => setTimeout(r, 20));
-    expect(emit).toHaveBeenCalledTimes(1);
 
     watcher.stopAll();
   });

--- a/apps/server/__tests__/readinessWatcher.test.ts
+++ b/apps/server/__tests__/readinessWatcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ReadinessWatcher } from '../utils/readinessWatcher.js';
+import { ReadinessWatcher } from '../src/utils/readinessWatcher.js';
 
 // Minimal stub runtime
 class RuntimeStub {

--- a/apps/server/src/__tests__/readinessWatcher.test.ts
+++ b/apps/server/src/__tests__/readinessWatcher.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ReadinessWatcher } from '../utils/readinessWatcher.js';
+
+// Minimal stub runtime
+class RuntimeStub {
+  private statuses: Record<string, any[]> = {};
+  private idx: Record<string, number> = {};
+  private instances = new Set<string>();
+
+  setSequence(nodeId: string, seq: any[]) {
+    this.statuses[nodeId] = seq;
+    this.idx[nodeId] = 0;
+    this.instances.add(nodeId);
+  }
+  remove(nodeId: string) {
+    this.instances.delete(nodeId);
+  }
+  getNodeInstance(id: string) {
+    return this.instances.has(id) ? {} : undefined;
+  }
+  getNodeStatus(id: string) {
+    const i = this.idx[id] ?? 0;
+    const arr = this.statuses[id] ?? [];
+    const v = arr[Math.min(i, arr.length - 1)] || {};
+    // advance index if not at end to simulate changes over time
+    if (i < arr.length - 1) this.idx[id] = i + 1;
+    return v;
+  }
+}
+
+describe('ReadinessWatcher', () => {
+  let runtime: any;
+  let emit: any;
+
+  beforeEach(() => {
+    runtime = new RuntimeStub();
+    emit = vi.fn();
+  });
+
+  it('emits once when node becomes ready', async () => {
+    const watcher = new ReadinessWatcher(runtime as any, emit, { error: () => {} } as any, {
+      pollIntervalMs: 5,
+      timeoutMs: 200,
+    });
+    const nodeId = 'n1';
+    runtime.setSequence(nodeId, [
+      { provisionStatus: { state: 'starting' }, dynamicConfigReady: false },
+      { provisionStatus: { state: 'ready' }, dynamicConfigReady: false },
+    ]);
+
+    watcher.start(nodeId);
+    // wait enough time for polling
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(nodeId);
+
+    // ensure subsequent starts are debounced while active
+    watcher.start(nodeId);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    watcher.stopAll();
+  });
+
+  it('does not emit if never ready within timeout', async () => {
+    const watcher = new ReadinessWatcher(runtime as any, emit, { error: () => {} } as any, {
+      pollIntervalMs: 5,
+      timeoutMs: 30,
+    });
+    const nodeId = 'n2';
+    runtime.setSequence(nodeId, [
+      { provisionStatus: { state: 'starting' }, dynamicConfigReady: false },
+      { provisionStatus: { state: 'starting' }, dynamicConfigReady: false },
+      { provisionStatus: { state: 'starting' }, dynamicConfigReady: false },
+    ]);
+
+    watcher.start(nodeId);
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(emit).not.toHaveBeenCalled();
+
+    watcher.stopAll();
+  });
+
+  it('cancels when node disappears', async () => {
+    const watcher = new ReadinessWatcher(runtime as any, emit, { error: () => {} } as any, {
+      pollIntervalMs: 5,
+      timeoutMs: 100,
+    });
+    const nodeId = 'n3';
+    runtime.setSequence(nodeId, [
+      { provisionStatus: { state: 'starting' }, dynamicConfigReady: false },
+      { provisionStatus: { state: 'starting' }, dynamicConfigReady: false },
+    ]);
+
+    watcher.start(nodeId);
+    await new Promise((r) => setTimeout(r, 10));
+    runtime.remove(nodeId);
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(emit).not.toHaveBeenCalled();
+
+    watcher.stopAll();
+  });
+});

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -17,6 +17,7 @@ import { GraphService } from './services/graph.service.js';
 import { GraphDefinition, PersistedGraphUpsertRequest } from './graph/types.js';
 import { ContainerService } from './services/container.service.js';
 import { SlackService } from './services/slack.service.js';
+import { ReadinessWatcher } from './utils/readinessWatcher.js';
 
 const logger = new LoggerService();
 const config = ConfigService.fromEnv();
@@ -79,6 +80,9 @@ async function bootstrap() {
 
   const fastify = Fastify({ logger: false });
   await fastify.register(cors, { origin: true });
+
+  // Background watcher reference (initialized after socket is attached)
+  let readinessWatcher: ReadinessWatcher | null = null;
 
   // Existing endpoints (namespaced under /api)
   fastify.get('/api/templates', async () => templateRegistry.toSchema());
@@ -156,9 +160,13 @@ async function bootstrap() {
           break;
         case 'provision':
           await runtime.provisionNode(nodeId);
+          // Start background readiness watcher after provision
+          readinessWatcher?.start(nodeId);
           break;
         case 'deprovision':
           await runtime.deprovisionNode(nodeId);
+          // Stop any watcher if node is deprovisioned
+          readinessWatcher?.stop(nodeId);
           break;
         default:
           reply.code(400);
@@ -211,8 +219,12 @@ async function bootstrap() {
     io.emit('node_status', { nodeId, ...status, updatedAt: new Date().toISOString() });
   }
 
+  // Watcher that emits a follow-up node_status once node becomes ready after provision/start.
+  readinessWatcher = new ReadinessWatcher(runtime, emitStatus, logger);
+
   const shutdown = async () => {
     logger.info('Shutting down...');
+    readinessWatcher?.stopAll();
     await mongo.close();
     try {
       await fastify.close();

--- a/apps/server/src/utils/readinessWatcher.ts
+++ b/apps/server/src/utils/readinessWatcher.ts
@@ -1,0 +1,95 @@
+import type { LiveGraphRuntime } from '../graph/liveGraph.manager.js';
+import type { LoggerService } from '../services/logger.service.js';
+
+// Polls a node until it's ready and triggers a status emit once.
+// Debounces per-node to avoid concurrent watchers.
+export type EmitFn = (nodeId: string) => void;
+
+export interface ReadinessWatcherOptions {
+  pollIntervalMs?: number; // default 500
+  timeoutMs?: number; // default 30000
+}
+
+interface ActiveWatcher {
+  timer?: NodeJS.Timeout;
+  startedAt: number;
+  cancelled?: boolean;
+}
+
+export class ReadinessWatcher {
+  private active = new Map<string, ActiveWatcher>();
+  private readonly pollIntervalMs: number;
+  private readonly timeoutMs: number;
+
+  constructor(
+    private readonly runtime: LiveGraphRuntime,
+    private readonly emit: EmitFn,
+    private readonly logger: LoggerService,
+    opts?: ReadinessWatcherOptions,
+  ) {
+    this.pollIntervalMs = opts?.pollIntervalMs ?? 500;
+    this.timeoutMs = opts?.timeoutMs ?? 30_000;
+  }
+
+  // Start a fire-and-forget watcher for nodeId; coalesces if already running
+  start(nodeId: string) {
+    // If a watcher is already active, don't start another
+    if (this.active.has(nodeId)) return;
+
+    const startedAt = Date.now();
+    const state: ActiveWatcher = { startedAt };
+    this.active.set(nodeId, state);
+
+    const tick = () => {
+      if (state.cancelled) return;
+      const status = this.runtime.getNodeStatus(nodeId);
+
+      const isReady =
+        (status?.provisionStatus && status.provisionStatus.state === 'ready') ||
+        status?.dynamicConfigReady === true;
+
+      // If node disappeared (deprovisioned) we should cancel
+      const stillExists = !!(this.runtime as any).getNodeInstance?.(nodeId);
+
+      if (isReady && stillExists) {
+        try {
+          this.emit(nodeId);
+        } catch (e) {
+          // swallow
+          this.logger?.error?.('Readiness emit failed', nodeId, e as any);
+        }
+        this.stop(nodeId);
+        return;
+      }
+
+      if (!stillExists) {
+        this.stop(nodeId);
+        return;
+      }
+
+      if (Date.now() - startedAt >= this.timeoutMs) {
+        // timeout: do not emit; just stop
+        this.stop(nodeId);
+        return;
+      }
+
+      state.timer = setTimeout(tick, this.pollIntervalMs);
+    };
+
+    state.timer = setTimeout(tick, this.pollIntervalMs);
+  }
+
+  // Stop a watcher for a node (cleanup timer)
+  stop(nodeId: string) {
+    const state = this.active.get(nodeId);
+    if (!state) return;
+    state.cancelled = true;
+    if (state.timer) clearTimeout(state.timer);
+    this.active.delete(nodeId);
+  }
+
+  // Stop all watchers (e.g., on shutdown)
+  stopAll() {
+    for (const nodeId of Array.from(this.active.keys())) this.stop(nodeId);
+  }
+}

--- a/apps/ui/src/lib/graph/__tests__/api.test.ts
+++ b/apps/ui/src/lib/graph/__tests__/api.test.ts
@@ -14,6 +14,11 @@ describe('graph api client', () => {
       if (url.includes('/status')) {
         return new Response(JSON.stringify({ isPaused: false }));
       }
+      // dynamic config schema mock flows
+      if (url.includes('/dynamic-config-schema') || url.includes('/dynamic-config/schema')) {
+        // default mock brings empty object to validate normalization in individual tests that override fetch impl
+        return new Response(JSON.stringify({}));
+      }
       return new Response('', { status: 204 });
     }) as any;
   });
@@ -28,5 +33,31 @@ describe('graph api client', () => {
   it('getNodeStatus', async () => {
     const s = await api.getNodeStatus('n1');
     expect(s.isPaused).toBe(false);
+  });
+
+  it('getDynamicConfigSchema returns null for wrapper/empty', async () => {
+    // wrapper response
+    (g.fetch as any).mockImplementationOnce(async () => new Response(JSON.stringify({ ready: false })));
+    // fallback second call should not be used, but ensure it would be empty if called
+    (g.fetch as any).mockImplementationOnce(async () => new Response(JSON.stringify({})));
+    const r1 = await api.getDynamicConfigSchema('n1');
+    expect(r1).toBeNull();
+
+    // empty object
+    (g.fetch as any).mockImplementationOnce(async () => new Response(JSON.stringify({})));
+    const r2 = await api.getDynamicConfigSchema('n1');
+    expect(r2).toBeNull();
+  });
+
+  it('getDynamicConfigSchema returns schema when valid', async () => {
+    const schema = { type: 'object', properties: { a: { type: 'string' } } };
+    (g.fetch as any).mockImplementationOnce(async () => new Response(JSON.stringify(schema)));
+    const r = await api.getDynamicConfigSchema('n1');
+    expect(r).toEqual(schema);
+
+    // wrapped
+    (g.fetch as any).mockImplementationOnce(async () => new Response(JSON.stringify({ ready: true, schema })));
+    const r2 = await api.getDynamicConfigSchema('n1');
+    expect(r2).toEqual(schema);
   });
 });


### PR DESCRIPTION
Server-side enhancement for Issue #66: ensure a follow-up node_status is broadcast when an MCP node becomes ready after discovery.

What changed
- New ReadinessWatcher helper that polls runtime.getNodeStatus(nodeId) ~500ms until either provisionStatus.state === "ready" OR dynamicConfigReady === true, or timeout (~30s). On readiness it calls existing emitStatus(nodeId) to broadcast the latest status via socket.
- Debounce: Map-based guard to avoid multiple concurrent watchers per node; coalesces starts. Cleaned up on deprovision and server shutdown.
- Hooked into POST /graph/nodes/:nodeId/actions: start watcher on provision; stop on deprovision. Initial status still emitted immediately (existing behavior).

Tests
- Added unit tests for watcher behavior: emits once on ready; no emit on timeout; cancels when node disappears. Extracted watcher into utils for testability.

Why
- After LocalMCPServer finishes discovery, dynamicConfigReady can flip to true later. The UI caches node status and schema, so this follow-up broadcast prompts clients to re-fetch the dynamic config schema without a page reload.

Notes
- Minimal change footprint; no refactor of liveGraph.manager. Timeout and intervals are conservative, easy to tune.
- Safeguards: debounce, timeout, and stop on deprovision to prevent spam.
