### PR TITLE
feat(workspace): add Docker platform support and enforce non-reuse on mismatch

### DIFF
--- a/apps/server/__tests__/container.service.platform.test.ts
+++ b/apps/server/__tests__/container.service.platform.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ContainerService } from '../src/services/container.service.js';
+import { LoggerService } from '../src/services/logger.service.js';
+
+function setupDockerStubs() {
+  const logger = new LoggerService();
+  const service = new ContainerService(logger);
+  const docker: any = service.getDocker();
+  // pull: accept image and optional opts
+  docker.getImage = vi.fn().mockReturnValue({ inspect: vi.fn().mockRejectedValue(new Error('missing')) });
+  docker.pull = vi.fn((_image: string, _opts: any, cb: any) => {
+    if (typeof _opts === 'function') {
+      cb = _opts;
+    }
+    // simulate stream
+    const stream: any = {
+      on: vi.fn(),
+    };
+    cb(undefined, stream);
+  });
+  docker.modem = docker.modem || {};
+  docker.modem.followProgress = vi.fn((_stream: any, done: any) => done(undefined));
+  docker.createContainer = vi.fn().mockResolvedValue({
+    start: vi.fn().mockResolvedValue(undefined),
+    inspect: vi.fn().mockResolvedValue({ Id: 'abcdef1234567890', State: { Status: 'running' } }),
+  });
+  return { service, docker };
+}
+
+describe('ContainerService platform plumbing', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes platform to pull and createContainer when set', async () => {
+    const { service, docker } = setupDockerStubs();
+    await service.start({ image: 'node:20-alpine', cmd: ['sleep', '1'], platform: 'linux/arm64' });
+    // pull called with opts having platform
+    const pullCall = docker.pull.mock.calls[0];
+    expect(pullCall[0]).toBe('node:20-alpine');
+    // args: image, opts, cb
+    expect(typeof pullCall[1]).toBe('object');
+    expect(pullCall[1].platform).toBe('linux/arm64');
+
+    // createContainer received platform as query param passthrough
+    const createCall = docker.createContainer.mock.calls[0][0];
+    expect(createCall.platform).toBe('linux/arm64');
+  });
+
+  it('omits platform when not set', async () => {
+    const { service, docker } = setupDockerStubs();
+    await service.start({ image: 'node:20-alpine', cmd: ['sleep', '1'] });
+    // pull called without platform opts
+    const pullCall = docker.pull.mock.calls[0];
+    // args: image, cb (no opts) or image, undefined, cb depending on our impl
+    // Our impl passes undefined when platform not set, so second arg may be undefined
+    expect(pullCall[1] === undefined || typeof pullCall[1] === 'function').toBeTruthy();
+
+    const createCall = docker.createContainer.mock.calls[0][0];
+    expect(createCall.platform).toBeUndefined();
+  });
+});

--- a/apps/server/__tests__/containerProvider.platform.test.ts
+++ b/apps/server/__tests__/containerProvider.platform.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ContainerService } from '../src/services/container.service.js';
+import { ContainerProviderEntity } from '../src/entities/containerProvider.entity.js';
+import { LoggerService } from '../src/services/logger.service.js';
+
+function setupProvider(platform?: string) {
+  const logger = new LoggerService();
+  const svc = new ContainerService(logger);
+  const provider = new ContainerProviderEntity(
+    svc,
+    { cmd: ['sleep', 'infinity'], workingDir: '/w' },
+    (id: string) => ({ tid: id })
+  );
+  provider.setConfig({ platform });
+  return { svc, provider };
+}
+
+describe('ContainerProviderEntity platform forwarding and reuse', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('forwards platform to ContainerService.start when set in static config', async () => {
+    const { svc, provider } = setupProvider('linux/amd64');
+    vi.spyOn(svc, 'findContainerByLabels').mockResolvedValue(undefined as any);
+    const startSpy = vi.spyOn(svc, 'start').mockResolvedValue({ id: 'cid', exec: async () => ({ exitCode: 0 }) } as any);
+    await provider.provide('t1');
+    expect(startSpy).toHaveBeenCalled();
+    const arg = startSpy.mock.calls[0][0];
+    expect(arg?.platform).toBe('linux/amd64');
+  });
+
+  it('does not set platform when absent', async () => {
+    const { svc, provider } = setupProvider(undefined);
+    vi.spyOn(svc, 'findContainerByLabels').mockResolvedValue(undefined as any);
+    const startSpy = vi.spyOn(svc, 'start').mockResolvedValue({ id: 'cid', exec: async () => ({ exitCode: 0 }) } as any);
+    await provider.provide('t1');
+    const arg = startSpy.mock.calls[0][0];
+    expect(arg?.platform).toBeUndefined();
+  });
+
+  it('skips reuse when existing container platform mismatches', async () => {
+    const { svc, provider } = setupProvider('linux/arm64');
+    const existing = { id: 'existing' } as any;
+    vi.spyOn(svc, 'findContainerByLabels').mockResolvedValue(existing);
+    vi.spyOn(svc, 'getContainerPlatform').mockResolvedValue('linux/amd64');
+    const startSpy = vi.spyOn(svc, 'start').mockResolvedValue({ id: 'newcid', exec: async () => ({ exitCode: 0 }) } as any);
+    await provider.provide('t2');
+    expect(startSpy).toHaveBeenCalled();
+  });
+
+  it('reuses when platforms match', async () => {
+    const { svc, provider } = setupProvider('linux/arm64');
+    const existing = { id: 'existing' } as any;
+    vi.spyOn(svc, 'findContainerByLabels').mockResolvedValue(existing);
+    vi.spyOn(svc, 'getContainerPlatform').mockResolvedValue('linux/arm64');
+    const startSpy = vi.spyOn(svc, 'start').mockResolvedValue({ id: 'newcid', exec: async () => ({ exitCode: 0 }) } as any);
+    const reused = await provider.provide('t3');
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(reused?.id).toBe('existing');
+  });
+});

--- a/apps/server/src/entities/containerProvider.entity.ts
+++ b/apps/server/src/entities/containerProvider.entity.ts
@@ -7,6 +7,11 @@ import { z } from 'zod';
 export const ContainerProviderStaticConfigSchema = z
   .object({
     image: z.string().min(1).optional().describe('Optional container image override.'),
+    platform: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Docker platform, e.g., linux/amd64 or linux/arm64'),
     env: z
       .record(z.string().min(1), z.string())
       .optional()
@@ -22,7 +27,7 @@ export const ContainerProviderStaticConfigSchema = z
 export type ContainerProviderStaticConfig = z.infer<typeof ContainerProviderStaticConfigSchema>;
 
 export class ContainerProviderEntity {
-  private cfg?: Pick<ContainerOpts, 'image' | 'env'> & { initialScript?: string };
+  private cfg?: Pick<ContainerOpts, 'image' | 'env' | 'platform'> & { initialScript?: string };
 
   constructor(
     private containerService: ContainerService,
@@ -44,12 +49,36 @@ export class ContainerProviderEntity {
   async provide(threadId: string) {
     const labels = this.idLabels(threadId);
     let container: ContainerEntity | undefined = await this.containerService.findContainerByLabels(labels);
+
+    // If platform is requested in static config and an existing container is found, verify platform matches
+    if (container && this.cfg?.platform) {
+      try {
+        const existingPlatform = await this.containerService.getContainerPlatform(container.id);
+        if (existingPlatform && !this.isPlatformCompatible(this.cfg.platform, existingPlatform)) {
+          // Do not reuse; create a new one
+          const shortId = container.id.substring(0, 12);
+          (this.containerService as any).logger?.debug?.(
+            `Existing container platform mismatch: requested=${this.cfg.platform} found=${existingPlatform}. Skipping reuse for cid=${shortId}`,
+          );
+          container = undefined;
+        }
+      } catch (e) {
+        // If we fail to determine platform, conservatively do not reuse when platform is explicitly requested
+        const shortId = container.id.substring(0, 12);
+        (this.containerService as any).logger?.debug?.(
+          `Failed to determine existing container platform for cid=${shortId}: ${(e as Error).message}. Skipping reuse`,
+        );
+        container = undefined;
+      }
+    }
+
     if (!container) {
       container = await this.containerService.start({
         ...this.opts,
         // Only merge image/env from cfg (initialScript is provider-level behavior, not a start option)
         image: this.cfg?.image ?? this.opts.image,
         env: { ...(this.opts.env || {}), ...(this.cfg?.env || {}) },
+        platform: this.cfg?.platform ?? this.opts.platform,
         labels: { ...(this.opts.labels || {}), ...labels },
       });
 
@@ -67,5 +96,45 @@ export class ContainerProviderEntity {
       }
     }
     return container;
+  }
+
+  // Platform detection lives in ContainerService for reuse; only normalization and comparison are kept here
+
+  private normalizeArch(arch: string): string {
+    // map common aliases
+    if (arch === 'x86_64') return 'amd64';
+    if (arch === 'aarch64') return 'arm64';
+    if (arch === 'armhf') return 'arm';
+    return arch || 'amd64';
+  }
+
+  private normalizeVariant(variant: string): string | undefined {
+    if (!variant) return undefined;
+    // Docker uses v7, v6, etc. Some metadata may be numeric
+    if (variant === '8') return 'v8';
+    if (variant === '7') return 'v7';
+    if (variant === '6') return 'v6';
+    if (variant === '5') return 'v5';
+    return variant.startsWith('v') ? variant : `v${variant}`;
+  }
+
+  // Compare requested vs existing image platform
+  private isPlatformCompatible(requested: string, existing: string): boolean {
+    const parse = (p: string) => {
+      const [os, arch, variant] = p.toLowerCase().split('/') as [string, string, string | undefined];
+      return { os, arch: this.normalizeArch(arch), variant: this.normalizeVariant(variant || '') };
+    };
+    const req = parse(requested);
+    const ex = parse(existing);
+    if (req.os && ex.os && req.os !== ex.os) return false;
+    if (req.arch && ex.arch && req.arch !== ex.arch) return false;
+    if (req.arch === 'arm' || ex.arch === 'arm') {
+      // For 32-bit ARM, match variants if both set
+      if (req.variant && ex.variant && req.variant !== ex.variant) return false;
+    } else if (req.arch === 'arm64' || ex.arch === 'arm64') {
+      // ARM64: variant exists sometimes (e.g., v8) - ensure equality when both set
+      if (req.variant && ex.variant && req.variant !== ex.variant) return false;
+    }
+    return true;
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,6 @@
 
 ## Recent Additions
 
-- Container Provider now supports an optional `initialScript` configuration field. When set, the script is executed inside a newly created container immediately after it starts (via `/bin/sh -lc`). A non-zero exit code fails provisioning of that container.
+- Workspace (containerProvider) now supports an optional `platform` config field (e.g., `linux/amd64`, `linux/arm64`). When set, the platform is passed to image pull and container creation; existing containers with a different platform are not reused. See workspace-platform.md for details.
+- Container Provider still supports `initialScript` to run a shell script after container creation (non-zero exit fails provisioning).
 - Simple Agent now accepts a `model` static configuration parameter to select the underlying LLM (default: `gpt-5`). You can override it per agent instance via the graph static config UI or API.

--- a/docs/workspace-platform.md
+++ b/docs/workspace-platform.md
@@ -1,0 +1,15 @@
+# Workspace Platform Support
+
+The Workspace (containerProvider) supports an optional `platform` field to select the Docker platform used for image pulls and container creation.
+
+- Field: `platform` (string), examples: `linux/amd64`, `linux/arm64`, or `linux/arm/v7`.
+- Default: unspecified (Docker chooses host/daemon defaults); behavior unchanged if omitted.
+- Effects:
+  - Passed as a query parameter to `docker pull` and `docker create` via dockerode.
+  - Ensures the correct platform image is pulled and the container is created for that platform.
+- Reuse rules: when `platform` is set and an existing container is found by labels, the provider checks the existing container's image platform. If it differs from the requested platform, the container is not reused and a new one is created.
+
+Notes
+- Docker Desktop can emulate non-native platforms using QEMU. This may impact performance.
+- If the daemon lacks the requested platform image, Docker will attempt to pull it.
+- Windows containers have additional OsVersion details which are ignored here.


### PR DESCRIPTION
This PR adds optional Docker platform support to the Workspace (containerProvider) and enforces non-reuse when the platform mismatches.

What changed
- Service: ContainerService
  - ContainerOpts gains `platform?: string`.
  - ensureImage(image, platform?) threads platform to `docker.pull`.
  - start(opts) threads platform through to ensureImage and includes it as a query param to `docker.createContainer` (dockerode forwards unknown keys like `platform`).
  - New helper getContainerPlatform(containerId) inspects the image to derive an os/arch[/variant] string for reuse checks.
- Provider: ContainerProviderEntity
  - Schema adds optional `platform` ("Docker platform, e.g., linux/amd64 or linux/arm64").
  - provide(threadId) forwards platform to containerService.start(...).
  - Reuse policy: if an existing container is found and a platform is configured, detect that container's image platform and compare. On mismatch, skip reuse; create a new container. Adds concise debug logging when skipping reuse or unable to determine platform.
- Tests (Vitest; no real Docker):
  - ContainerService unit tests verify platform passed to pull and createContainer when set, and omitted when not.
  - ContainerProviderEntity unit tests verify forwarding of platform and reuse decision logic using mocked getContainerPlatform.
- Docs: docs/workspace-platform.md adds a short section documenting the new field, defaults, examples, and caveats. docs/README.md updated with a brief note.

Acceptance
- Platform is optional and appears in Workspace node config.
- When set, platform is passed to docker.pull and docker.createContainer.
- Provider avoids reusing existing container when platform mismatches.
- Unit tests cover with/without platform paths and reuse decision logic.
- Docs updated.

Migration
- Optional field; defaults preserve current behavior when unset.