### PR TITLE
Workspace: add platform support (linux/amd64, linux/arm64) and enforce non-reuse on mismatch

### DIFF
--- a/apps/server/__tests__/container.service.platform.test.ts
+++ b/apps/server/__tests__/container.service.platform.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ContainerService } from '../src/services/container.service';
+import { LoggerService } from '../src/services/logger.service';
+
+function createMockDocker() {
+  const modem = {
+    followProgress: (_stream: any, onFinished: any, _onProgress: any) => {
+      setTimeout(() => onFinished(undefined), 0);
+    },
+    demuxStream: vi.fn(),
+  } as any;
+
+  const docker: any = {
+    modem,
+    pull: vi.fn((_image: string, _optsOrCb: any, _cb?: any) => {}),
+    getImage: vi.fn((image: string) => ({
+      inspect: vi.fn(async () => {
+        throw new Error('not found');
+      }),
+    })),
+    createContainer: vi.fn(async (opts: any) => ({
+      start: vi.fn(async () => {}),
+      inspect: vi.fn(async () => ({ Id: '1234567890abcdef', State: { Status: 'running' } })),
+    })),
+  };
+  return docker;
+}
+
+describe('ContainerService platform support', () => {
+  let svc: ContainerService;
+  let docker: any;
+
+  beforeEach(() => {
+    svc = new ContainerService(new LoggerService());
+    docker = svc.getDocker();
+    const mock = createMockDocker();
+    // Patch methods on the real docker instance
+    (docker as any).modem = mock.modem;
+    (docker as any).pull = mock.pull;
+    (docker as any).getImage = mock.getImage;
+    (docker as any).createContainer = mock.createContainer;
+  });
+
+  it('passes platform to pull/create and labels the container when platform is provided', async () => {
+    const image = 'node:20-alpine';
+    // Arrange pull to call our cb
+    (docker.pull as any).mockImplementation((img: string, optsOrCb: any, cb?: any) => {
+      const cbFn = typeof optsOrCb === 'function' ? optsOrCb : cb;
+      setTimeout(() => cbFn(undefined, {} as any), 0);
+    });
+
+    await svc.start({ image, cmd: ['sleep', '1'], platform: 'linux/arm64' });
+
+    // docker.pull called with platform option
+    expect(docker.pull).toHaveBeenCalled();
+    const pullArgs = (docker.pull as any).mock.calls[0];
+    expect(pullArgs[0]).toBe(image);
+    const pullOpts = typeof pullArgs[1] === 'function' ? undefined : pullArgs[1];
+    expect(pullOpts).toMatchObject({ platform: 'linux/arm64' });
+
+    // createContainer options include platform and label
+    expect(docker.createContainer).toHaveBeenCalled();
+    const createOpts = (docker.createContainer as any).mock.calls[0][0];
+    expect(createOpts.platform).toBe('linux/arm64');
+    expect(createOpts.Labels['hautech.ai/platform']).toBe('linux/arm64');
+  });
+
+  it('does not set platform when not provided', async () => {
+    const image = 'node:20-alpine';
+    (docker.pull as any).mockImplementation((img: string, optsOrCb: any, cb?: any) => {
+      const cbFn = typeof optsOrCb === 'function' ? optsOrCb : cb;
+      setTimeout(() => cbFn(undefined, {} as any), 0);
+    });
+
+    await svc.start({ image, cmd: ['sleep', '1'] });
+
+    // docker.pull called without options.platform
+    const pullArgs = (docker.pull as any).mock.calls[0];
+    const pullOpts = typeof pullArgs[1] === 'function' ? undefined : pullArgs[1];
+    if (pullOpts) {
+      expect(pullOpts.platform).toBeUndefined();
+    }
+
+    const createOpts = (docker.createContainer as any).mock.calls[0][0];
+    expect(createOpts.platform).toBeUndefined();
+    expect(createOpts.Labels?.['hautech.ai/platform']).toBeUndefined();
+  });
+});

--- a/apps/server/__tests__/container.service.platform.test.ts
+++ b/apps/server/__tests__/container.service.platform.test.ts
@@ -4,24 +4,29 @@ import { LoggerService } from '../src/services/logger.service';
 
 function createMockDocker() {
   const modem = {
-    followProgress: (_stream: any, onFinished: any, _onProgress: any) => {
+    followProgress: (_stream: unknown, onFinished: (e?: unknown) => void) => {
       setTimeout(() => onFinished(undefined), 0);
     },
     demuxStream: vi.fn(),
-  } as any;
+  } as { followProgress: any; demuxStream: any };
 
-  const docker: any = {
+  const docker = {
     modem,
-    pull: vi.fn((_image: string, _optsOrCb: any, _cb?: any) => {}),
-    getImage: vi.fn((image: string) => ({
+    pull: vi.fn((_image: string, _optsOrCb?: unknown, _cb?: unknown) => {}),
+    getImage: vi.fn((_image: string) => ({
       inspect: vi.fn(async () => {
         throw new Error('not found');
       }),
     })),
-    createContainer: vi.fn(async (opts: any) => ({
+    createContainer: vi.fn(async (_opts: unknown) => ({
       start: vi.fn(async () => {}),
       inspect: vi.fn(async () => ({ Id: '1234567890abcdef', State: { Status: 'running' } })),
     })),
+  } as unknown as {
+    modem: { followProgress: any; demuxStream: any };
+    pull: any;
+    getImage: any;
+    createContainer: any;
   };
   return docker;
 }
@@ -44,8 +49,8 @@ describe('ContainerService platform support', () => {
   it('passes platform to pull/create and labels the container when platform is provided', async () => {
     const image = 'node:20-alpine';
     // Arrange pull to call our cb
-    (docker.pull as any).mockImplementation((img: string, optsOrCb: any, cb?: any) => {
-      const cbFn = typeof optsOrCb === 'function' ? optsOrCb : cb;
+    (docker.pull as any).mockImplementation((img: string, optsOrCb?: unknown, cb?: unknown) => {
+      const cbFn = typeof optsOrCb === 'function' ? (optsOrCb as Function) : (cb as Function);
       setTimeout(() => cbFn(undefined, {} as any), 0);
     });
 
@@ -56,7 +61,8 @@ describe('ContainerService platform support', () => {
     const pullArgs = (docker.pull as any).mock.calls[0];
     expect(pullArgs[0]).toBe(image);
     const pullOpts = typeof pullArgs[1] === 'function' ? undefined : pullArgs[1];
-    expect(pullOpts).toMatchObject({ platform: 'linux/arm64' });
+    expect(pullOpts).toBeDefined();
+    expect(pullOpts.platform).toBe('linux/arm64');
 
     // createContainer options include platform and label
     expect(docker.createContainer).toHaveBeenCalled();
@@ -67,8 +73,8 @@ describe('ContainerService platform support', () => {
 
   it('does not set platform when not provided', async () => {
     const image = 'node:20-alpine';
-    (docker.pull as any).mockImplementation((img: string, optsOrCb: any, cb?: any) => {
-      const cbFn = typeof optsOrCb === 'function' ? optsOrCb : cb;
+    (docker.pull as any).mockImplementation((img: string, optsOrCb?: unknown, cb?: unknown) => {
+      const cbFn = typeof optsOrCb === 'function' ? (optsOrCb as Function) : (cb as Function);
       setTimeout(() => cbFn(undefined, {} as any), 0);
     });
 
@@ -79,6 +85,8 @@ describe('ContainerService platform support', () => {
     const pullOpts = typeof pullArgs[1] === 'function' ? undefined : pullArgs[1];
     if (pullOpts) {
       expect(pullOpts.platform).toBeUndefined();
+    } else {
+      // If no options were passed, this test is also satisfied
     }
 
     const createOpts = (docker.createContainer as any).mock.calls[0][0];

--- a/apps/server/__tests__/containerProvider.entity.platform.test.ts
+++ b/apps/server/__tests__/containerProvider.entity.platform.test.ts
@@ -6,7 +6,7 @@ import { LoggerService } from '../src/services/logger.service';
 function setup() {
   const logger = new LoggerService();
   const svc = new ContainerService(logger);
-  const docker: any = svc.getDocker();
+  const docker = svc.getDocker() as any;
 
   // Mock findContainerByLabels to return a stubbed ContainerEntity-like object
   const foundContainer = {

--- a/apps/server/__tests__/containerProvider.entity.platform.test.ts
+++ b/apps/server/__tests__/containerProvider.entity.platform.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ContainerProviderEntity } from '../src/entities/containerProvider.entity';
+import { ContainerService } from '../src/services/container.service';
+import { LoggerService } from '../src/services/logger.service';
+
+function setup() {
+  const logger = new LoggerService();
+  const svc = new ContainerService(logger);
+  const docker: any = svc.getDocker();
+
+  // Mock findContainerByLabels to return a stubbed ContainerEntity-like object
+  const foundContainer = {
+    id: 'deadbeefcafebabe',
+    stop: vi.fn(async () => {}),
+    remove: vi.fn(async () => {}),
+  } as any;
+
+  // Default mocks
+  vi.spyOn(svc, 'findContainerByLabels').mockResolvedValue(undefined);
+  vi.spyOn(svc, 'start').mockResolvedValue({ id: 'newcontainerid', stop: vi.fn(), remove: vi.fn(), exec: vi.fn() } as any);
+
+  // Mock docker.inspect to return labels
+  docker.getContainer = vi.fn(() => ({
+    inspect: vi.fn(async () => ({ Config: { Labels: { 'hautech.ai/platform': 'linux/amd64' } } })),
+  }));
+
+  return { svc, docker, foundContainer };
+}
+
+describe('ContainerProviderEntity platform forwarding and non-reuse', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('forwards platform to containerService.start when set in static config', async () => {
+    const { svc } = setup();
+    const provider = new ContainerProviderEntity(svc, { cmd: ['sleep', '1'] }, (id) => ({ 'hautech.ai/thread_id': id }));
+    provider.setConfig({ platform: 'linux/arm64' });
+
+    await provider.provide('t1');
+
+    expect(svc.start).toHaveBeenCalled();
+    const call = (svc.start as any).mock.calls[0][0];
+    expect(call.platform).toBe('linux/arm64');
+  });
+
+  it('stops/removes existing container on platform mismatch and creates a new one', async () => {
+    const { svc, docker, foundContainer } = setup();
+    // First, simulate an existing container present
+    (svc.findContainerByLabels as any).mockResolvedValue(foundContainer);
+    // Existing container has linux/amd64 (from docker.getContainer().inspect mock above)
+
+    const provider = new ContainerProviderEntity(svc, { cmd: ['sleep', '1'] }, (id) => ({ 'hautech.ai/thread_id': id }));
+    provider.setConfig({ platform: 'linux/arm64' });
+
+    await provider.provide('t2');
+
+    // Should have inspected, then stopped+removed, then started new with requested platform
+    expect(foundContainer.stop).toHaveBeenCalled();
+    expect(foundContainer.remove).toHaveBeenCalled();
+
+    expect(svc.start).toHaveBeenCalled();
+    const call = (svc.start as any).mock.calls[0][0];
+    expect(call.platform).toBe('linux/arm64');
+  });
+});

--- a/apps/server/src/types.d.ts
+++ b/apps/server/src/types.d.ts
@@ -1,0 +1,17 @@
+// Local module augmentation for dockerode to type platform/name query options
+import 'dockerode';
+
+declare module 'dockerode' {
+  // docker.pull(image, [opts], cb)
+  interface ImageCreateOptions {
+    platform?: string;
+  }
+
+  // The createContainer call accepts top-level query params (name, platform)
+  interface ContainerCreateOptions {
+    /** Query param used by daemon; collected by dockerode from top-level options */
+    name?: string;
+    /** Query param for multi-arch selection */
+    platform?: string;
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,6 @@
 
 ## Recent Additions
 
-- Container Provider now supports an optional `initialScript` configuration field. When set, the script is executed inside a newly created container immediately after it starts (via `/bin/sh -lc`). A non-zero exit code fails provisioning of that container.
+- Workspace (containerProvider) supports an optional `platform` configuration with allowed values `linux/amd64` and `linux/arm64`. When specified, Docker pulls the correct architecture and creates the container with that platform, labels it as `hautech.ai/platform`, and enforces non-reuse if an existing container's platform differs.
+- Container Provider also supports an optional `initialScript` configuration field. When set, the script is executed inside a newly created container immediately after it starts (via `/bin/sh -lc`). A non-zero exit code fails provisioning of that container.
 - Simple Agent now accepts a `model` static configuration parameter to select the underlying LLM (default: `gpt-5`). You can override it per agent instance via the graph static config UI or API.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,0 +1,20 @@
+# Workspace (containerProvider)
+
+The Workspace node provisions a per-thread Docker container to run tools and MCP servers. It now supports an optional platform selector to choose the architecture of the container.
+
+- Allowed values: `linux/amd64`, `linux/arm64`
+- When set, the platform is forwarded to Docker in two places:
+  - Image pull: `docker.pull(image, { platform })`
+  - Container create: top-level `platform` query param
+- Containers created with a platform are labeled with `hautech.ai/platform` for reliable reuse checks.
+- If an existing container is found for a thread but its `hautech.ai/platform` label does not match the requested platform, the old container is stopped and removed, and a new one is created.
+
+Notes
+- Docker Desktop can emulate a non-native architecture, but performance may be reduced compared to native.
+- Only the two platforms above are supported at this time.
+
+Config schema (static)
+- `image?: string` — optional container image override
+- `env?: Record<string,string>` — environment variables
+- `platform?: 'linux/amd64' | 'linux/arm64'` — optional platform selector
+- `initialScript?: string` — optional script executed right after container start


### PR DESCRIPTION
Implements platform support for the Workspace (containerProvider) node and enforces non-reuse on platform mismatch.

Summary
- ContainerService
  - Add platform?: 'linux/amd64' | 'linux/arm64' to ContainerOpts
  - ensureImage(image, platform): pass platform to docker.pull(image, { platform })
  - start(opts): thread platform through ensureImage and docker.createContainer (top-level query param)
  - Label containers with 'hautech.ai/platform' when platform is provided
- ContainerProviderEntity
  - Schema: add platform enum (linux/amd64 | linux/arm64)
  - Config type updated; forward platform to ContainerService.start
  - Non-reuse: if existing container label 'hautech.ai/platform' mismatches requested, stop/remove and start new
- Templates: no logic change; schema reflection picks up new field
- Tests (Vitest)
  - container.service.platform.test.ts: validates pull/create options and labels with/without platform
  - containerProvider.entity.platform.test.ts: validates forwarding and non-reuse behavior
- Docs
  - docs/workspace.md: describe platform config and behavior
  - docs/README.md: add note in Recent Additions

Notes
- dockerode maps top-level createContainer option 'platform' to query param
- If types complain, we use an intersection type for the create options

Screenshots/UI schema field added in the config form will appear via reflected schema; see docs/workspace.md for details.

Closes: internal request; Slack thread linked here.