### PR TITLE
feat(server): Slack-only autostart of SlackTrigger at boot (refs #94)

### DIFF
--- a/PR_UPDATE_NOTES.txt
+++ b/PR_UPDATE_NOTES.txt
@@ -1,1 +1,17 @@
-Update: Removed Docker compose and Dockerfile for obs-server; server runs from sources via pnpm scripts. Added @hautech/obs-examples package with PoC script. Switched builds to esbuild + tsc for types; updated exports and start scripts.
+Issue #94: Restore automatic start for SlackTrigger only on server boot.
+
+Changes
+- apps/server/src/autostart.ts: new Slack-only autostart that provisions `slackTrigger` nodes at boot; idempotent and gated by `AUTO_START_SLACK_TRIGGER` (default true). Logs include Autostart[SlackTrigger] prefix.
+- apps/server/src/index.ts: call autostart after runtime is ready and readiness watcher is set up.
+- apps/server/src/__tests__/autostart/slack.autostart.test.ts: unit tests covering autostart selection and env gate.
+- apps/server/README.md: document behavior and env toggle.
+
+Verification
+- Set SLACK_BOT_TOKEN, SLACK_APP_TOKEN, MONGODB_URL.
+- Persist a graph with a SlackTrigger wired to an agent.
+- Start server; observe logs for Autostart[SlackTrigger]; within ~10s `GET /graph/nodes/:id/status` should report ready.
+- Send Slack message to validate events are received.
+
+Notes
+- Manual provision/deprovision via UI/API remains unchanged.
+- Provision is idempotent; SlackService.start is already idempotent.

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -2,6 +2,12 @@
 
 Runtime for graph-driven agents, tool adapters, triggers, and memory. See docs for architecture.
 
+Slack Autostart
+- On server boot, if a persisted graph contains a `slackTrigger` node, the server will automatically provision it so it reaches ready state without manual UI action.
+- Gate via env `AUTO_START_SLACK_TRIGGER` (default `true`). Set to `false` to disable autostart.
+- Logs: look for `Autostart[SlackTrigger]` messages around startup.
+- Idempotent: repeated boots or applies will not create duplicate connections; provision is skipped when already `ready`/`provisioning`.
+
 Enabling Memory
 - Default connector config: placement=after_system, content=tree, maxChars=4000.
 - To wire memory into an agent's CallModel at runtime, add a `memoryNode` and connect its `$self` source port to the agent's `callModel`/`setMemoryConnector` target port (or use template API to create a connector).

--- a/apps/server/src/__tests__/autostart/slack.autostart.test.ts
+++ b/apps/server/src/__tests__/autostart/slack.autostart.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { autostartSlackTriggerNodes } from '../../autostart';
+
+class MockLogger {
+  info = vi.fn();
+  debug = vi.fn();
+  error = vi.fn();
+}
+
+const mkRuntime = (nodes: Array<{ id: string; template: string; state: 'not_ready'|'provisioning'|'ready' }>) => {
+  const statuses = new Map(nodes.map(n => [n.id, { provisionStatus: { state: n.state } }]));
+  return {
+    getNodes: () => nodes,
+    getNodeStatus: (id: string) => statuses.get(id) as any,
+    provisionNode: vi.fn(async (id: string) => { statuses.set(id, { provisionStatus: { state: 'provisioning' } }); }),
+  } as any;
+};
+
+class MockWatcher {
+  started: string[] = [];
+  start = (id: string) => { this.started.push(id); };
+}
+
+describe('Slack autostart', () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it('provisions only SlackTrigger nodes that are not ready', async () => {
+    const runtime = mkRuntime([
+      { id: 'a', template: 'slackTrigger', state: 'not_ready' },
+      { id: 'b', template: 'slackTrigger', state: 'ready' },
+      { id: 'c', template: 'simpleAgent', state: 'not_ready' },
+    ]);
+    const logger = new MockLogger() as any;
+    const watcher = new MockWatcher() as any;
+    await autostartSlackTriggerNodes(runtime, logger, watcher);
+    expect(runtime.provisionNode).toHaveBeenCalledTimes(1);
+    expect(runtime.provisionNode).toHaveBeenCalledWith('a');
+    expect(watcher.started).toEqual(['a']);
+  });
+
+  it('respects AUTO_START_SLACK_TRIGGER gate', async () => {
+    process.env.AUTO_START_SLACK_TRIGGER = 'false';
+    const runtime = mkRuntime([{ id: 'a', template: 'slackTrigger', state: 'not_ready' }]);
+    const logger = new MockLogger() as any;
+    const watcher = new MockWatcher() as any;
+    await autostartSlackTriggerNodes(runtime, logger, watcher);
+    expect(runtime.provisionNode).not.toHaveBeenCalled();
+    process.env.AUTO_START_SLACK_TRIGGER = undefined;
+  });
+});

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -22,6 +22,7 @@ import { GraphDefinition, PersistedGraphUpsertRequest } from './graph/types.js';
 import { ContainerService } from './services/container.service.js';
 import { SlackService } from './services/slack.service.js';
 import { ReadinessWatcher } from './utils/readinessWatcher.js';
+import { autostartSlackTriggerNodes } from './autostart.js';
 
 const logger = new LoggerService();
 const config = ConfigService.fromEnv();
@@ -226,6 +227,13 @@ async function bootstrap() {
 
   // Watcher that emits a follow-up node_status once node becomes ready after provision/start.
   readinessWatcher = new ReadinessWatcher(runtime, emitStatus, logger);
+
+  // Autostart SlackTrigger nodes (scoped to Slack only)
+  try {
+    await autostartSlackTriggerNodes(runtime, logger, readinessWatcher);
+  } catch (e) {
+    logger.error('Autostart[SlackTrigger]: unexpected error', e);
+  }
 
   const shutdown = async () => {
     logger.info('Shutting down...');


### PR DESCRIPTION
This PR implements Slack-only autostart of SlackTrigger on server boot, per issue #94.

What changed
- Introduced a small autostart helper that, after the persisted graph is applied and readiness watcher is set up, scans live nodes and provisions only `slackTrigger` nodes.
- Idempotent: skips if provisionStatus is `ready` or `provisioning`. Relies on Provisionable semantics and SlackService.start idempotency.
- Clear logs prefixed `Autostart[SlackTrigger]` to track gate state, queue, attempts, and outcomes.
- Optional env toggle `AUTO_START_SLACK_TRIGGER` (default true) for operational safety.
- Tests: unit tests for the autostart helper covering selection and env gating.
- Docs: added a short Slack Autostart section to apps/server/README.md.

Why
- Regression required manual provisioning for SlackTrigger after server restarts; this restores expected behavior while keeping scope limited to Slack only.

Verification steps
- Configure env: SLACK_BOT_TOKEN, SLACK_APP_TOKEN, MONGODB_URL
- Persist a graph with a `slackTrigger` node wired to an agent
- Start the server
  - Observe logs for `Autostart[SlackTrigger]` gate, queueing, provisioning, and SlackService start
  - GET /graph/nodes/:id/status should report provisionStatus.state=ready within ~10s
  - Send a Slack message and verify handling

Notes
- Manual provision/deprovision via UI/API remains functional; autostart only runs at boot.
- Scope intentionally limited to SlackTrigger; no generalized autostart for other triggers in this PR.

Refs #94