### PR TITLE
chore(logging): improve error serialization and user-facing messages (refs #97)

### DIFF
--- a/apps/server/__tests__/logger.serializer.test.ts
+++ b/apps/server/__tests__/logger.serializer.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { LoggerService } from '../src/services/logger.service';
+
+// Access private via any for lightweight test without changing API
+const logger = new LoggerService() as any;
+
+describe('LoggerService.serialize', () => {
+  it('expands Error objects', () => {
+    const err = new Error('boom');
+    const json = logger.serialize([err]);
+    const parsed = JSON.parse(json)[0];
+    expect(parsed.name).toBe('Error');
+    expect(parsed.message).toBe('boom');
+    expect(typeof parsed.stack).toBe('string');
+  });
+
+  it('handles circular refs and redacts tokens', () => {
+    const o: any = { accessToken: 'SECRET_TOKEN', nested: {} };
+    o.self = o; // circular
+    o.nested.password = 'pw';
+    const json = logger.serialize([o]);
+    const parsed = JSON.parse(json)[0];
+    expect(parsed.accessToken).toBe('[REDACTED]');
+    expect(parsed.nested.password).toBe('[REDACTED]');
+    expect(parsed.self).toBe('[Circular]');
+  });
+
+  it('includes error cause if present', () => {
+    const cause = new Error('root');
+    const err = new Error('outer', { cause });
+    const parsed = JSON.parse(logger.serialize([err]))[0];
+    expect(parsed.cause.name).toBe('Error');
+    expect(parsed.cause.message).toBe('root');
+  });
+});

--- a/apps/server/__tests__/logger.serializer.test.ts
+++ b/apps/server/__tests__/logger.serializer.test.ts
@@ -32,4 +32,54 @@ describe('LoggerService.serialize', () => {
     expect(parsed.cause.name).toBe('Error');
     expect(parsed.cause.message).toBe('root');
   });
+
+  it('redacts Authorization Bearer tokens in error message/stack', () => {
+    const err = new Error('failed with Authorization: Bearer abc123XYZtoken');
+    // Override stack to include a github personal access token
+    (err as any).stack = 'Trace: ghp_ABCDEFGHIJKLMNOPQRSTUVWX123456';
+    const parsed = JSON.parse(logger.serialize([err]))[0];
+    expect(parsed.message).toContain('Bearer [REDACTED]');
+    expect(parsed.message).not.toContain('abc123XYZtoken');
+    expect(parsed.stack).not.toContain('ghp_');
+    expect(parsed.stack).toContain('[REDACTED]');
+  });
+
+  it('redacts token-like substrings in plain strings', () => {
+    const s = 'leak github_pat_ABC_def_12345678901234567890 and ghp_ABCDEFGHIJKLMNOPQRST1234';
+    const parsed = JSON.parse(logger.serialize([s]))[0];
+    expect(parsed).not.toContain('github_pat_');
+    expect(parsed).not.toContain('ghp_');
+    expect(parsed).toContain('[REDACTED]');
+  });
+
+  it('truncates long strings and limits object breadth', () => {
+    const long = 'x'.repeat(2500);
+    const wide: any = {};
+    for (let i = 0; i < 120; i++) wide['k' + i] = i;
+    const parsed = JSON.parse(logger.serialize([long, wide]));
+    // long string should be truncated marker present
+    expect(typeof parsed[0]).toBe('string');
+    expect(parsed[0].length).toBeLessThan(2100);
+    // wide object should have __truncated__ marker
+    expect(parsed[1].__truncated__).toBeDefined();
+  });
+
+  it('limits nested error cause expansion depth', () => {
+    const e3 = new Error('lvl3');
+    const e2: any = new Error('lvl2', { cause: e3 });
+    // Attach a deeper non-Error cause chain to test object recursion
+    (e3 as any).cause = { level: 4, cause: { level: 5 } };
+    const e1 = new Error('lvl1', { cause: e2 });
+    const parsed = JSON.parse(logger.serialize([e1]))[0];
+    // cause should exist but be truncated at some depth
+    const c2 = parsed.cause;
+    expect(c2.name).toBe('Error');
+    // Either nested cause becomes an object or a truncated marker
+    if (c2.cause && typeof c2.cause === 'object') {
+      // Next level may be truncated string marker
+      if (typeof c2.cause.cause === 'string') {
+        expect(c2.cause.cause).toContain('Truncated');
+      }
+    }
+  });
 });

--- a/apps/server/src/agents/simple.agent.ts
+++ b/apps/server/src/agents/simple.agent.ts
@@ -151,7 +151,7 @@ export class SimpleAgent extends BaseAgent {
       },
       this.configuration(),
     )
-      .addNode('summarize', async (state: any) => {
+      .addNode('summarize', async (state: { messages: BaseMessage[]; summary?: string }) => {
         const res = await this.summarizeNode.action(state);
         // Reset restriction counters per new turn
         return { ...res, restrictionInjectionCount: 0, restrictionInjected: false };
@@ -246,7 +246,7 @@ export class SimpleAgent extends BaseAgent {
     // duplicate discovery flows (removes eager listTools() call which previously raced with start()).
     const registerTools = async () => {
       try {
-        const tools: McpTool[] = await server.listTools();
+        const tools = await server.listTools();
         if (!tools.length) {
           this.loggerService.info(`No MCP tools discovered for namespace ${namespace}`);
         }
@@ -260,10 +260,10 @@ export class SimpleAgent extends BaseAgent {
               );
               const threadId = config?.configurable?.thread_id;
               const res = await server.callTool(t.name, raw, { threadId });
-                    if (res.isError) {
-                      const { message, cause } = buildMcpToolError(res);
-                      throw new Error(message, { cause });
-                    }
+              if (res.isError) {
+                const { message, cause } = buildMcpToolError(res);
+                throw new Error(message, { cause });
+              }
               if (res.structuredContent) return toYaml(res.structuredContent);
               return res.content || '';
             },
@@ -291,14 +291,16 @@ export class SimpleAgent extends BaseAgent {
         const existing = this.mcpServerTools.get(server) || [];
         this.mcpServerTools.set(server, existing.concat(registered));
         initialRegistrationDone = true;
-      } catch (e: any) {
-        this.loggerService.error(`Failed to register MCP tools for ${namespace}: ${e.message}`);
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        this.loggerService.error(`Failed to register MCP tools for ${namespace}: ${err.message}`);
       }
     };
 
     server.on('ready', () => registerTools());
-    server.on('error', (err: any) => {
-      this.loggerService.error(`MCP server ${namespace} error before tool registration: ${err?.message || err}`);
+    server.on('error', (err: unknown) => {
+      const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+      this.loggerService.error(`MCP server ${namespace} error before tool registration: ${msg}`);
     });
 
     // Dynamic config synchronization: if server supports DynamicConfigurable, re-sync tool list
@@ -374,7 +376,7 @@ export class SimpleAgent extends BaseAgent {
             }
           }
         } catch (e) {
-          const err = e as Error;
+          const err = e instanceof Error ? e : new Error(String(e));
           this.loggerService.error(`Failed dynamic MCP tool sync for ${namespace}: ${err.message}`);
         }
       });
@@ -418,11 +420,10 @@ export class SimpleAgent extends BaseAgent {
 
     // Extend to accept summarization options
     // Accept both new (summarizationKeepTokens) and legacy (summarizationKeepLast) keys.
+    const cfgObj = config as Record<string, unknown>;
     const keepTokensRaw =
-      (config as any).summarizationKeepTokens !== undefined
-        ? (config as any).summarizationKeepTokens
-        : (config as any).summarizationKeepLast; // legacy fallback
-    const maxTokensRaw = (config as any).summarizationMaxTokens;
+      cfgObj.summarizationKeepTokens !== undefined ? cfgObj.summarizationKeepTokens : cfgObj.summarizationKeepLast; // legacy fallback
+    const maxTokensRaw = cfgObj.summarizationMaxTokens;
     const isInt = (v: unknown) => typeof v === 'number' && Number.isInteger(v);
 
     const updates: { keepTokens?: number; maxTokens?: number } = {};
@@ -472,7 +473,8 @@ export class SimpleAgent extends BaseAgent {
       if (typeof anyServer.destroy === 'function') await anyServer.destroy();
       else if (typeof anyServer.stop === 'function') await anyServer.stop();
     } catch (e) {
-      this.loggerService.error(`Error destroying MCP server ${server.namespace}: ${(e as any)?.message || e}`);
+      const msg = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
+      this.loggerService.error(`Error destroying MCP server ${server.namespace}: ${msg}`);
     }
   }
 }

--- a/apps/server/src/lgnodes/tools.lgnode.ts
+++ b/apps/server/src/lgnodes/tools.lgnode.ts
@@ -82,8 +82,18 @@ export class ToolsNode extends BaseNode {
               return createMessage(content);
             }
           } catch (e: unknown) {
-            const err = e instanceof Error ? e?.message : JSON.stringify(e);
-            return createMessage(`Error executing tool '${tc.name}': ${err}`, false);
+            // Prefer readable error strings to avoid "[object Object]"
+            let errStr = 'Unknown error';
+            if (e instanceof Error) {
+              errStr = `${e.name}: ${e.message}`;
+            } else {
+              try {
+                errStr = JSON.stringify(e);
+              } catch {
+                errStr = String(e);
+              }
+            }
+            return createMessage(`Error executing tool '${tc.name}': ${errStr}`, false);
           }
         });
       }),

--- a/apps/server/src/lgnodes/tools.lgnode.ts
+++ b/apps/server/src/lgnodes/tools.lgnode.ts
@@ -82,16 +82,11 @@ export class ToolsNode extends BaseNode {
               return createMessage(content);
             }
           } catch (e: unknown) {
-            // Prefer readable error strings to avoid "[object Object]"
+            // Prefer readable error strings to avoid "[object Object]"; don't interpolate objects directly
             let errStr = 'Unknown error';
-            if (e instanceof Error) {
-              errStr = `${e.name}: ${e.message}`;
-            } else {
-              try {
-                errStr = JSON.stringify(e);
-              } catch {
-                errStr = String(e);
-              }
+            if (e instanceof Error) errStr = `${e.name}: ${e.message}`;
+            else {
+              try { errStr = JSON.stringify(e); } catch { errStr = String(e); }
             }
             return createMessage(`Error executing tool '${tc.name}': ${errStr}`, false);
           }

--- a/apps/server/src/mcp/errorUtils.ts
+++ b/apps/server/src/mcp/errorUtils.ts
@@ -1,0 +1,37 @@
+import { McpToolCallResult } from './types';
+
+// Construct a readable MCP error message consistently across call sites.
+// Prefer structuredContent.message/error/detail; include optional code/retriable; cap JSON fallback length.
+export function buildMcpToolError(res: McpToolCallResult): { message: string; cause: unknown } {
+  const MAX_JSON_LEN = 2000;
+  const sc: any = res?.structuredContent;
+  const content = res?.content;
+  let msgBase = 'MCP tool call failed';
+  let details = '';
+
+  if (sc && typeof sc === 'object') {
+    const m = typeof sc.message === 'string' ? sc.message : undefined;
+    const e = typeof sc.error === 'string' ? sc.error : undefined;
+    const d = typeof sc.detail === 'string' ? sc.detail : undefined;
+    msgBase = m || e || d || msgBase;
+    const code = sc.code ?? sc.errorCode ?? sc.statusCode;
+    const retriable = sc.retriable ?? sc.retryable;
+    const parts: string[] = [];
+    if (code != null) parts.push(`code=${String(code)}`);
+    if (retriable != null) parts.push(`retriable=${Boolean(retriable)}`);
+    if (parts.length) details = ` (${parts.join(' ')})`;
+  } else if (typeof content === 'string' && content.trim()) {
+    msgBase = content.trim();
+  } else if (res?.raw) {
+    try {
+      const rawStr = JSON.stringify(res.raw);
+      const trunc = rawStr.length > MAX_JSON_LEN ? rawStr.slice(0, MAX_JSON_LEN) + '…' : rawStr;
+      msgBase = `${msgBase}: ${trunc}`;
+    } catch {}
+  }
+
+  // Cause carries structured details or next best fallback (content/raw)
+  const cause = sc ?? content ?? res?.raw;
+  return { message: `${msgBase}${details}`, cause };
+}
+

--- a/apps/server/src/mcp/jsonSchemaToZod.ts
+++ b/apps/server/src/mcp/jsonSchemaToZod.ts
@@ -106,13 +106,13 @@ export function jsonSchemaToZod(schema: JSONSchema | undefined): ZodTypeAny {
   }
 
   if (schema.default !== undefined) {
-    try { base = (base as any).default(schema.default); } catch { /* ignore */ }
+  try { (base as any).default?.(schema.default); } catch { /* ignore */ }
   }
 
   return base;
 }
 
-export function inferArgsSchema(inputSchema: any): ZodTypeAny {
+export function inferArgsSchema(inputSchema: unknown): ZodTypeAny {
   try {
     return jsonSchemaToZod(inputSchema);
   } catch {

--- a/apps/server/src/mcp/localMcpServer.ts
+++ b/apps/server/src/mcp/localMcpServer.ts
@@ -188,21 +188,21 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
         }
       }
     } catch (err) {
-      this.logger.error(`[MCP:${this.namespace}] [disc:${discoveryId}] Tool discovery failed: ${err}`);
+      this.logger.error(`[MCP:${this.namespace}] [disc:${discoveryId}] Tool discovery failed`, err);
     } finally {
       // Clean up temporary resources
       if (tempClient) {
         try {
           await tempClient.close();
         } catch (e) {
-          this.logger.error(`[MCP:${this.namespace}] Error closing temp client: ${e}`);
+          this.logger.error(`[MCP:${this.namespace}] Error closing temp client`, e);
         }
       }
       if (tempTransport) {
         try {
           await tempTransport.close();
         } catch (e) {
-          this.logger.error(`[MCP:${this.namespace}] Error closing temp transport: ${e}`);
+          this.logger.error(`[MCP:${this.namespace}] Error closing temp transport`, e);
         }
       }
       // Stop the temporary container
@@ -544,7 +544,7 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
       try {
         l(cfg);
       } catch (e) {
-        this.logger.error(`[MCP:${this.namespace}] dynamic config listener error: ${e}`);
+        this.logger.error(`[MCP:${this.namespace}] dynamic config listener error`, e);
       }
     }
   }
@@ -577,7 +577,7 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
     if (err) {
       // Only emit 'error' if there are registered listeners to avoid unhandled error events
       if (this.emitter.listenerCount('error') > 0) this.emitter.emit('error', err);
-      else this.logger.error(`[MCP:${this.namespace}] Unhandled start error: ${err?.message || err}`);
+      else this.logger.error(`[MCP:${this.namespace}] Unhandled start error`, err);
     } else this.emitter.emit('ready');
   }
 

--- a/apps/server/src/mcp/localMcpServer.ts
+++ b/apps/server/src/mcp/localMcpServer.ts
@@ -344,14 +344,14 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
         try {
           await client.close();
         } catch (e) {
-          this.logger.error(`[MCP:${this.namespace}] Error closing client after tool call: ${e}`);
+          this.logger.error(`[MCP:${this.namespace}] Error closing client after tool call`, e);
         }
       }
       if (transport) {
         try {
           await transport.close();
         } catch (e) {
-          this.logger.error(`[MCP:${this.namespace}] Error closing transport after tool call: ${e}`);
+          this.logger.error(`[MCP:${this.namespace}] Error closing transport after tool call`, e);
         }
       }
     }

--- a/apps/server/src/mcp/localMcpServer.ts
+++ b/apps/server/src/mcp/localMcpServer.ts
@@ -214,7 +214,7 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
           `[MCP:${this.namespace}] [disc:${discoveryId}] Temporary discovery container stopped and removed (duration=${ms}ms)`,
         );
       } catch (e) {
-        this.logger.error(`[MCP:${this.namespace}] [disc:${discoveryId}] Error cleaning up temp container: ${e}`);
+        this.logger.error(`[MCP:${this.namespace}] [disc:${discoveryId}] Error cleaning up temp container`, e);
       }
     }
 

--- a/apps/server/src/mcp/localMcpServer.ts
+++ b/apps/server/src/mcp/localMcpServer.ts
@@ -337,7 +337,9 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
         raw: result,
       };
     } catch (e: any) {
-      throw new McpError(`Tool '${name}' failed: ${e.message}`, e.code || 'TOOL_CALL_ERROR');
+      const emsg = e && typeof e === 'object' && 'message' in e ? String(e.message) : String(e);
+      const ename = e && typeof e === 'object' && 'name' in e ? String(e.name) : 'Error';
+      throw new McpError(`Tool '${name}' failed: ${ename}: ${emsg}`.trim(), e?.code || 'TOOL_CALL_ERROR');
     } finally {
       // Clean up after tool call
       if (client) {
@@ -481,7 +483,7 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
         // New flat shape: tool names are top-level boolean properties
         normalized = this._dynamicConfigZodSchema.parse(cfg) as Record<string, boolean>;
       } catch (e) {
-        this.logger.error(`[MCP:${this.namespace}] Dynamic config validation failed: ${(e as Error).message}`);
+        this.logger.error(`[MCP:${this.namespace}] Dynamic config validation failed`, e as any);
       }
     }
     const enabled = new Set<string>();
@@ -651,7 +653,7 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
         this.logger.info(`[MCP:${this.namespace}] Started successfully with ${this.toolsCache?.length || 0} tools`);
         this.flushStartWaiters();
       } catch (e: any) {
-        this.logger.error(`[MCP:${this.namespace}] Start attempt failed: ${e.message}`);
+        this.logger.error(`[MCP:${this.namespace}] Start attempt failed`, e);
         this.restartAttempts++;
         // Immediately reject any pending starters so callers of provision() can observe the error
         this.flushStartWaiters(e);


### PR DESCRIPTION
This PR addresses #97 by improving how MCP tool errors are surfaced and logged.

Changes
- apps/server/src/agents/simple.agent.ts
  - When an MCP tool call returns isError, build a readable message from structuredContent (prefer message/error/detail), fall back to content, and attach the structuredContent (or content/raw) as the Error cause. Applied in both the initial registration path and the dynamic sync path.
- apps/server/src/lgnodes/tools.lgnode.ts
  - Improve error stringification in tool execution catch: include Error name and message; fallback to safe JSON.stringify with String() fallback. Also make output JSON stringify safe.
- apps/server/src/services/logger.service.ts
  - Enhance serialize() to expand Error objects ({ name, message, stack, cause }), handle circular refs with WeakSet, and redact sensitive keys (token/apiKey/authorization/password/secret).
- apps/server/src/mcp/localMcpServer.ts
  - Pass Error objects to logger.error instead of interpolating into strings for discovery/cleanup/post-call errors.
- apps/server/__tests__/logger.serializer.test.ts
  - Add Vitest tests validating Error expansion, circular handling with redaction, and cause propagation.

Why
- Prevent “[object Object]” in user-visible messages and logs when MCP tools fail.
- Improve observability with structured, sanitized error details.

Notes
- Backward compatible: message strings and logging interfaces remain stable. Tests are lightweight and self-contained. Node 18+/TS target supports Error.cause used here.

Closes: #97