### PR TITLE
feat: Vault-backed ReferenceField for Slack app_token and bot_token (Trigger + Send Tool)

### DIFF
--- a/apps/server/__tests__/send_slack_message.tool.test.ts
+++ b/apps/server/__tests__/send_slack_message.tool.test.ts
@@ -17,7 +17,7 @@ describe('SendSlackMessageTool', () => {
   const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
 
   it('sends message using provided bot_token and channel (literal)', async () => {
-    const tool = new SendSlackMessageTool(undefined as any, logger);
+    const tool = new SendSlackMessageTool(logger, undefined as any);
     await tool.setConfig({ bot_token: 'xoxb-valid', default_channel: 'C1' });
     const t = tool.init();
     const res = await t.invoke({ text: 'hi', channel: 'C2' } as any);
@@ -25,7 +25,7 @@ describe('SendSlackMessageTool', () => {
   });
 
   it('sends ephemeral when ephemeral_user set', async () => {
-    const tool = new SendSlackMessageTool(undefined as any, logger);
+    const tool = new SendSlackMessageTool(logger, undefined as any);
     await tool.setConfig({ bot_token: 'xoxb-valid', default_channel: 'C1' });
     const t = tool.init();
     const res = await t.invoke({ text: 'hi', channel: 'C1', ephemeral_user: 'U1' } as any);
@@ -33,7 +33,7 @@ describe('SendSlackMessageTool', () => {
   });
 
   it('uses default_channel when channel omitted', async () => {
-    const tool = new SendSlackMessageTool(undefined as any, logger);
+    const tool = new SendSlackMessageTool(logger, undefined as any);
     await tool.setConfig({ bot_token: 'xoxb-valid', default_channel: 'CDEF' });
     const t = tool.init();
     const res = await t.invoke({ text: 'hello' } as any);
@@ -41,13 +41,13 @@ describe('SendSlackMessageTool', () => {
   });
 
   it('fails fast on vault ref when vault disabled', async () => {
-    const tool = new SendSlackMessageTool(undefined as any, logger);
+    const tool = new SendSlackMessageTool(logger, undefined as any);
     await expect(tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' } } as any)).rejects.toThrow();
   });
 
   it('resolves bot token via vault and sends', async () => {
     const vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'xoxb-from-vault') } as any;
-    const tool = new SendSlackMessageTool(vault, logger);
+    const tool = new SendSlackMessageTool(logger, vault);
     await tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
     const t = tool.init();
     const res = await t.invoke({ text: 'hi' } as any);
@@ -57,7 +57,7 @@ describe('SendSlackMessageTool', () => {
 
   it('returns error when vault secret missing', async () => {
     const vault = { isEnabled: () => true, getSecret: vi.fn(async () => undefined) } as any;
-    const tool = new SendSlackMessageTool(vault, logger);
+    const tool = new SendSlackMessageTool(logger, vault);
     await tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
     const t = tool.init();
     const res = await t.invoke({ text: 'hi' } as any);
@@ -66,7 +66,16 @@ describe('SendSlackMessageTool', () => {
 
   it('throws on invalid reference string during setConfig', async () => {
     const vault = { isEnabled: () => true, getSecret: vi.fn() } as any;
-    const tool = new SendSlackMessageTool(vault, logger);
+    const tool = new SendSlackMessageTool(logger, vault);
     await expect(tool.setConfig({ bot_token: { value: 'invalid', source: 'vault' } } as any)).rejects.toThrow();
+  });
+
+  it('errors when resolved bot token has wrong prefix', async () => {
+    const vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'xapp-wrong') } as any;
+    const tool = new SendSlackMessageTool(logger, vault);
+    await tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
+    const t = tool.init();
+    const res = await t.invoke({ text: 'hi' } as any);
+    expect(String(res)).toContain('Error sending Slack message');
   });
 });

--- a/apps/server/__tests__/send_slack_message.tool.test.ts
+++ b/apps/server/__tests__/send_slack_message.tool.test.ts
@@ -16,8 +16,8 @@ vi.mock('@slack/web-api', () => {
 describe('SendSlackMessageTool', () => {
   const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
 
-  it('sends message using provided bot_token and channel', async () => {
-    const tool = new SendSlackMessageTool(logger);
+  it('sends message using provided bot_token and channel (literal)', async () => {
+    const tool = new SendSlackMessageTool(undefined as any, logger);
     await tool.setConfig({ bot_token: 'xoxb-valid', default_channel: 'C1' });
     const t = tool.init();
     const res = await t.invoke({ text: 'hi', channel: 'C2' } as any);
@@ -25,7 +25,7 @@ describe('SendSlackMessageTool', () => {
   });
 
   it('sends ephemeral when ephemeral_user set', async () => {
-    const tool = new SendSlackMessageTool(logger);
+    const tool = new SendSlackMessageTool(undefined as any, logger);
     await tool.setConfig({ bot_token: 'xoxb-valid', default_channel: 'C1' });
     const t = tool.init();
     const res = await t.invoke({ text: 'hi', channel: 'C1', ephemeral_user: 'U1' } as any);
@@ -33,10 +33,40 @@ describe('SendSlackMessageTool', () => {
   });
 
   it('uses default_channel when channel omitted', async () => {
-    const tool = new SendSlackMessageTool(logger);
+    const tool = new SendSlackMessageTool(undefined as any, logger);
     await tool.setConfig({ bot_token: 'xoxb-valid', default_channel: 'CDEF' });
     const t = tool.init();
     const res = await t.invoke({ text: 'hello' } as any);
     expect(String(res)).toContain('ok');
+  });
+
+  it('fails fast on vault ref when vault disabled', async () => {
+    const tool = new SendSlackMessageTool(undefined as any, logger);
+    await expect(tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' } } as any)).rejects.toThrow();
+  });
+
+  it('resolves bot token via vault and sends', async () => {
+    const vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'xoxb-from-vault') } as any;
+    const tool = new SendSlackMessageTool(vault, logger);
+    await tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
+    const t = tool.init();
+    const res = await t.invoke({ text: 'hi' } as any);
+    expect(String(res)).toContain('ok');
+    expect(vault.getSecret).toHaveBeenCalled();
+  });
+
+  it('returns error when vault secret missing', async () => {
+    const vault = { isEnabled: () => true, getSecret: vi.fn(async () => undefined) } as any;
+    const tool = new SendSlackMessageTool(vault, logger);
+    await tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
+    const t = tool.init();
+    const res = await t.invoke({ text: 'hi' } as any);
+    expect(String(res)).toContain('Error sending Slack message');
+  });
+
+  it('throws on invalid reference string during setConfig', async () => {
+    const vault = { isEnabled: () => true, getSecret: vi.fn() } as any;
+    const tool = new SendSlackMessageTool(vault, logger);
+    await expect(tool.setConfig({ bot_token: { value: 'invalid', source: 'vault' } } as any)).rejects.toThrow();
   });
 });

--- a/apps/server/__tests__/slack.config.schemas.test.ts
+++ b/apps/server/__tests__/slack.config.schemas.test.ts
@@ -3,16 +3,16 @@ import { SendSlackMessageToolStaticConfigSchema } from '../src/tools/send_slack_
 import { SlackTriggerStaticConfigSchema } from '../src/triggers/slack.trigger';
 
 describe('Slack static config schemas', () => {
-  it('SendSlackMessageToolStaticConfigSchema: accepts xoxb- tokens, rejects others', () => {
+  it('SendSlackMessageToolStaticConfigSchema: accepts xoxb- tokens or reference field', () => {
     expect(() => SendSlackMessageToolStaticConfigSchema.parse({ bot_token: 'xoxb-123', default_channel: 'C1' })).not.toThrow();
-    expect(() => SendSlackMessageToolStaticConfigSchema.parse({ bot_token: 'xapp-123' })).toThrow();
-    expect(() => SendSlackMessageToolStaticConfigSchema.parse({ bot_token: '' })).toThrow();
+    expect(() => SendSlackMessageToolStaticConfigSchema.parse({ bot_token: { value: 'xoxb-abc', source: 'static' } })).not.toThrow();
+    // vault ref is allowed syntactically; deeper validation occurs in setConfig
+    expect(() => SendSlackMessageToolStaticConfigSchema.parse({ bot_token: { value: 'secret/path/KEY', source: 'vault' } })).not.toThrow();
   });
 
-  it('SlackTriggerStaticConfigSchema: accepts xapp- tokens, rejects others', () => {
+  it('SlackTriggerStaticConfigSchema: accepts xapp- tokens or reference field', () => {
     expect(() => SlackTriggerStaticConfigSchema.parse({ app_token: 'xapp-abc' })).not.toThrow();
-    expect(() => SlackTriggerStaticConfigSchema.parse({ app_token: 'xoxb-abc' })).toThrow();
-    expect(() => SlackTriggerStaticConfigSchema.parse({ app_token: '' })).toThrow();
+    expect(() => SlackTriggerStaticConfigSchema.parse({ app_token: { value: 'xapp-abc', source: 'static' } })).not.toThrow();
+    expect(() => SlackTriggerStaticConfigSchema.parse({ app_token: { value: 'secret/path/KEY', source: 'vault' } })).not.toThrow();
   });
 });
-

--- a/apps/server/__tests__/slack.trigger.events.test.ts
+++ b/apps/server/__tests__/slack.trigger.events.test.ts
@@ -45,4 +45,13 @@ describe('SlackTrigger events', () => {
     await trig.provision();
     expect((trig as any).client).toBeTruthy();
   });
+
+  it('fails when resolved app token has wrong prefix', async () => {
+    const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
+    const vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'xoxb-wrong') } as any;
+    const trig = new SlackTrigger(logger, vault);
+    await trig.setConfig({ app_token: { value: 'secret/slack/APP', source: 'vault' } } as any);
+    await trig.provision();
+    expect(trig.getProvisionStatus().state).toBe('error');
+  });
 });

--- a/apps/server/__tests__/slack.trigger.events.test.ts
+++ b/apps/server/__tests__/slack.trigger.events.test.ts
@@ -25,9 +25,24 @@ describe('SlackTrigger events', () => {
     await trig.subscribe({ invoke: async (_t, msgs) => { received.push(...msgs); } });
     await trig.provision();
     // Fire a mock events_api envelope
-    const client: any = (trig as any).client || (trig as any).ensureClient?.();
+    const client: any = (trig as any).client || (await (trig as any).ensureClient?.());
     const h = (client.handlers['events_api'] || [])[0];
     await h({ envelope_id: 'e1', payload: { event: { type: 'message', user: 'U', channel: 'C', text: 'hello', ts: '1.0' } } });
     expect(received.length).toBe(1);
+  });
+
+  it('fails fast when vault ref provided but vault disabled', async () => {
+    const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
+    const trig = new SlackTrigger(logger, undefined as any);
+    await expect(trig.setConfig({ app_token: { value: 'secret/slack/APP', source: 'vault' } } as any)).rejects.toThrow();
+  });
+
+  it('resolves app token via vault during provision', async () => {
+    const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
+    const vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'xapp-from-vault') } as any;
+    const trig = new SlackTrigger(logger, vault);
+    await trig.setConfig({ app_token: { value: 'secret/slack/APP', source: 'vault' } } as any);
+    await trig.provision();
+    expect((trig as any).client).toBeTruthy();
   });
 });

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -115,7 +115,7 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
       )
       .register(
         'sendSlackMessageTool',
-        () => new SendSlackMessageTool(vault, logger),
+        () => new SendSlackMessageTool(logger, vault),
         {
           targetPorts: { $self: { kind: 'instance' } },
         },

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -10,10 +10,10 @@ import { LoggerService } from './services/logger.service';
 import { VaultService, VaultConfigSchema } from './services/vault.service';
 import { CallAgentTool, CallAgentToolStaticConfigSchema } from './tools/call_agent.tool';
 import { GithubCloneRepoTool, GithubCloneRepoToolExposedStaticConfigSchema } from './tools/github_clone_repo';
-import { SendSlackMessageTool, SendSlackMessageToolStaticConfigSchema } from './tools/send_slack_message.tool';
+import { SendSlackMessageTool, SendSlackMessageToolExposedStaticConfigSchema } from './tools/send_slack_message.tool';
 import { ShellTool, ShellToolStaticConfigSchema } from './tools/shell_command';
 import { SlackTrigger } from './triggers';
-import { SlackTriggerStaticConfigSchema } from './triggers/slack.trigger';
+import { SlackTriggerExposedStaticConfigSchema } from './triggers/slack.trigger';
 import { RemindMeTool, RemindMeToolStaticConfigSchema } from './tools/remind_me.tool';
 import { DebugToolTrigger, DebugToolTriggerStaticConfigSchema } from './triggers/debugTool.trigger';
 import { LocalMcpServerStaticConfigSchema } from './mcp/localMcpServer';
@@ -115,7 +115,7 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
       )
       .register(
         'sendSlackMessageTool',
-        () => new SendSlackMessageTool(logger),
+        () => new SendSlackMessageTool(vault, logger),
         {
           targetPorts: { $self: { kind: 'instance' } },
         },
@@ -123,7 +123,7 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
           title: 'Send Slack message',
           kind: 'tool',
           capabilities: { staticConfigurable: true },
-          staticConfigSchema: toJSONSchema(SendSlackMessageToolStaticConfigSchema),
+          staticConfigSchema: toJSONSchema(SendSlackMessageToolExposedStaticConfigSchema),
         },
       )
       .register(
@@ -178,7 +178,7 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
       .register(
         'slackTrigger',
         () => {
-          const instance = new SlackTrigger(logger);
+          const instance = new SlackTrigger(logger, vault);
           void instance.start();
           return instance;
         },
@@ -192,7 +192,7 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
           title: 'Slack (Socket Mode)',
           kind: 'trigger',
           capabilities: { provisionable: true, pausable: true, staticConfigurable: true },
-          staticConfigSchema: toJSONSchema(SlackTriggerStaticConfigSchema),
+          staticConfigSchema: toJSONSchema(SlackTriggerExposedStaticConfigSchema),
         },
       )
       .register(

--- a/apps/server/src/tools/send_slack_message.tool.ts
+++ b/apps/server/src/tools/send_slack_message.tool.ts
@@ -2,6 +2,8 @@ import { tool, DynamicStructuredTool } from "@langchain/core/tools";
 import { z } from "zod";
 import { BaseTool } from "./base.tool";
 import { LoggerService } from "../services/logger.service";
+import { VaultService } from '../services/vault.service';
+import { parseVaultRef, ReferenceFieldSchema } from '../utils/refs';
 import { WebClient, type ChatPostMessageResponse, type ChatPostEphemeralResponse } from '@slack/web-api';
 
 const sendSlackMessageSchema = z.object({
@@ -20,16 +22,39 @@ const sendSlackMessageSchema = z.object({
     ),
 });
 
-// Static config schema for per-node Slack bot token and optional default channel
-export const SendSlackMessageToolStaticConfigSchema = z.object({
-  bot_token: z.string().min(1).startsWith('xoxb-', { message: 'Slack bot token must start with xoxb-' }).describe('Slack bot token (xoxb-...) for sending messages.'),
-  default_channel: z.string().optional().describe('Default Slack channel ID to use when not provided in the call.'),
-}).strict();
+// Internal static config schema: union of literal string and reference field
+export const SendSlackMessageToolStaticConfigSchema = z
+  .object({
+    bot_token: z.union([
+      z
+        .string()
+        .min(1)
+        .startsWith('xoxb-', { message: 'Slack bot token must start with xoxb-' })
+        .describe('Slack bot token (xoxb-...) for sending messages.'),
+      ReferenceFieldSchema,
+    ]),
+    default_channel: z.string().optional().describe('Default Slack channel ID to use when not provided in the call.'),
+  })
+  .strict();
+
+// Exposed schema for UI/templates: force ReferenceField renderer
+export const SendSlackMessageToolExposedStaticConfigSchema = z
+  .object({
+    bot_token: ReferenceFieldSchema.meta({
+      'ui:field': 'ReferenceField',
+      'ui:help': 'Use "vault" to reference a secret as mount/path/key.',
+    }),
+    default_channel: z.string().optional().describe('Default Slack channel ID to use when not provided in the call.'),
+  })
+  .strict();
+
+type TokenRef = { value: string; source: 'static' | 'vault' };
 
 export class SendSlackMessageTool extends BaseTool {
-  private cfg: z.infer<typeof SendSlackMessageToolStaticConfigSchema> | null = null;
+  private cfg: { bot_token: TokenRef; default_channel?: string } | null = null;
 
   constructor(
+    private vault: VaultService | undefined,
     logger: LoggerService,
   ) {
     super(logger);
@@ -46,7 +71,8 @@ export class SendSlackMessageTool extends BaseTool {
         this.logger.info("Tool called", "send_slack_message", { channel, hasThread: !!thread_ts, broadcast });
 
         try {
-          const client = new WebClient(cfg.bot_token, { logLevel: undefined });
+          const token = await this.resolveBotToken();
+          const client = new WebClient(token, { logLevel: undefined });
           if (ephemeral_user) {
             const resp: ChatPostEphemeralResponse = await client.chat.postEphemeral({ channel, user: ephemeral_user, text, thread_ts });
             if (!resp.ok) return `Failed to send message: ${resp.error}`;
@@ -77,9 +103,45 @@ export class SendSlackMessageTool extends BaseTool {
   }
 
   async setConfig(_cfg: Record<string, unknown>): Promise<void> {
-    // Validate and apply static config (bot_token & optional default_channel)
+    // Validate and apply static config
     const parsed = SendSlackMessageToolStaticConfigSchema.parse(_cfg || {});
-    // Do not log tokens; mask length only
-    this.cfg = { ...parsed, bot_token: parsed.bot_token };
+    let bot: TokenRef;
+    if (typeof parsed.bot_token === 'string') {
+      bot = { value: parsed.bot_token, source: 'static' };
+    } else {
+      const src = parsed.bot_token.source || 'static';
+      const value = parsed.bot_token.value;
+      if (src === 'vault') {
+        if (!this.vault || !this.vault.isEnabled()) {
+          throw new Error('Vault is disabled but a vault reference was provided for bot_token');
+        }
+        // Validate reference format early
+        parseVaultRef(value);
+      } else {
+        if (!value?.startsWith('xoxb-')) {
+          throw new Error('Slack bot token must start with xoxb-');
+        }
+      }
+      bot = { value, source: src };
+    }
+    this.cfg = { bot_token: bot, default_channel: parsed.default_channel };
+  }
+
+  // Resolve token based on source; validate pattern
+  private async resolveBotToken(): Promise<string> {
+    const cfg = this.cfg;
+    if (!cfg) throw new Error('SendSlackMessageTool not configured: bot_token is required');
+    const t = cfg.bot_token;
+    if (t.source === 'vault') {
+      const vlt = this.vault;
+      if (!vlt || !vlt.isEnabled()) throw new Error('Vault is disabled but a vault reference was provided for bot_token');
+      const vr = parseVaultRef(t.value);
+      const secret = await vlt.getSecret(vr);
+      if (!secret) throw new Error('Vault secret for bot_token not found');
+      if (!secret.startsWith('xoxb-')) throw new Error('Resolved Slack bot token is invalid (must start with xoxb-)');
+      return secret;
+    }
+    if (!t.value.startsWith('xoxb-')) throw new Error('Slack bot token must start with xoxb-');
+    return t.value;
   }
 }

--- a/docs/slack-migration.md
+++ b/docs/slack-migration.md
@@ -1,4 +1,4 @@
-# Slack integration migration (Issue #144)
+# Slack integration migration (Issue #144, #162)
 
 Summary
 - Global SLACK_* env and SlackService were removed.
@@ -6,11 +6,20 @@ Summary
 
 Nodes
 - SlackTrigger: static config
-  - { app_token: 'xapp-...' }
-  - app_token is required and must start with xapp- (Socket Mode token).
+  - app_token now supports a vault-backed reference via ReferenceField
+  - Internal schema accepts union: string | { value, source? }
+  - Exposed UI schema always renders ReferenceField with help text
+  - Examples:
+    - Literal: { app_token: 'xapp-...' }
+    - Vault: { app_token: { source: 'vault', value: 'secret/slack/APP_TOKEN' } }
+  - app_token must start with xapp- when literal or when resolved from Vault.
 - SendSlackMessageTool: static config
-  - { bot_token: 'xoxb-...', default_channel?: 'C...' }
-  - bot_token is required and must start with xoxb- (bot token). default_channel is optional and used when the tool call omits channel.
+  - bot_token now supports ReferenceField (string | { value, source? })
+  - default_channel unchanged
+  - Examples:
+    - Literal: { bot_token: 'xoxb-...', default_channel: 'C...' }
+    - Vault: { bot_token: { source: 'vault', value: 'secret/slack/BOT_TOKEN' }, default_channel: 'C...' }
+  - bot_token must start with xoxb- when literal or when resolved from Vault.
 
 Behavioral notes
 - SlackTrigger filters only human message events (ignores bot messages and message subtypes) and relays them to subscribers.
@@ -18,10 +27,11 @@ Behavioral notes
 
 Migration
 - Remove SLACK_APP_TOKEN and SLACK_BOT_TOKEN from any .env files; they are no longer read globally.
-- When creating nodes via the templates API/UI, supply staticConfig:
-  - SlackTrigger: { app_token: 'xapp-...' }
-  - SendSlackMessageTool: { bot_token: 'xoxb-...', default_channel?: 'C...' }
+- When creating nodes via the templates API/UI, supply staticConfig using the new ReferenceField:
+  - SlackTrigger: { app_token: 'xapp-...' } or { app_token: { source: 'vault', value: 'mount/path/key' } }
+  - SendSlackMessageTool: { bot_token: 'xoxb-...' } or { bot_token: { source: 'vault', value: 'mount/path/key' }, default_channel?: 'C...' }
+  - Backward compatibility: literal strings for tokens continue to work.
 
 Security
 - Tokens are not logged. Do not include tokens in logs or error messages.
-
+- When a vault reference is provided but Vault is disabled, configuration fails fast with a clear error.


### PR DESCRIPTION
Implements #162.

- Switches Slack Trigger app_token and Send Slack Message tool bot_token to use Vault-backed ReferenceField in the UI.
- Backward compatible: accepts legacy literal strings; recommends vault references.
- Runtime resolution via VaultService with validation and fail-fast behavior when vault is disabled.
- Updated templates to expose UI schemas and inject Vault.
- Added unit tests for schema parsing, validation, and vault resolution.
- Updated docs with examples and migration notes.

One issue → one branch → one PR.
