### PR TITLE
Feat: keep tool_call spans attributed to Agent; add toolNodeId for Tool Activity

### DIFF
--- a/apps/server/__tests__/tools.node.nodeId.precedence.test.ts
+++ b/apps/server/__tests__/tools.node.nodeId.precedence.test.ts
@@ -33,8 +33,8 @@ class EchoTool extends BaseTool {
   }
 }
 
-describe('ToolsNode nodeId precedence for withToolCall', () => {
-  it('uses config.configurable.nodeId when provided (Tool node id)', async () => {
+describe('ToolsNode tool_call span attribution', () => {
+  it('stamps nodeId=agent and toolNodeId=tool when provided', async () => {
     const node = new ToolsNode([new EchoTool()], 'agent-node-id');
     const ai = new AIMessage({ content: '', tool_calls: [{ id: '1', name: 'echo', args: { x: 1 } }] } as any);
     const config = { configurable: { thread_id: 't1', nodeId: 'tool-node-id' } } as any;
@@ -43,10 +43,11 @@ describe('ToolsNode nodeId precedence for withToolCall', () => {
     const obs: any = await import('@hautech/obs-sdk');
     const captured = (obs as any).__test.captured as any[];
     expect(captured.length).toBeGreaterThan(0);
-    expect(captured[0].nodeId).toBe('tool-node-id');
+    expect(captured[0].nodeId).toBe('agent-node-id');
+    expect(captured[0].toolNodeId).toBe('tool-node-id');
   });
 
-  it('falls back to agent node id when config nodeId is absent', async () => {
+  it('stamps nodeId=agent and no toolNodeId when not provided', async () => {
     const obs: any = await import('@hautech/obs-sdk');
     (obs as any).__test.captured.length = 0; // reset captured
 
@@ -57,6 +58,6 @@ describe('ToolsNode nodeId precedence for withToolCall', () => {
     const captured = (obs as any).__test.captured as any[];
     expect(captured.length).toBeGreaterThan(0);
     expect(captured[0].nodeId).toBe('agent-node-id');
+    expect('toolNodeId' in captured[0]).toBe(false);
   });
 });
-

--- a/apps/ui/src/components/graph/NodeObsSidebar.tsx
+++ b/apps/ui/src/components/graph/NodeObsSidebar.tsx
@@ -20,9 +20,13 @@ function spanMatchesContext(span: SpanDoc, node: Node<BuilderPanelNodeData>, kin
   const kindAttr = String(attrs['kind'] || '');
   const label = span.label || '';
   const nodeIdAttr = (attrs['nodeId'] as string | undefined) || span.nodeId;
+  const toolNodeIdAttr = attrs['toolNodeId'] as string | undefined;
   const kindOk = kind === 'agent' ? (kindAttr === 'agent' || label === 'agent') : (kindAttr === 'tool_call' || label.startsWith('tool:'));
   if (!kindOk) return false;
-  // Strict: require nodeId match; do not fallback to kind-only
+  // Agent: filter by nodeId (agent id)
+  if (kind === 'agent') return nodeIdAttr === node.id;
+  // Tool: prefer attributes.toolNodeId (new), fallback to nodeId match for legacy spans
+  if (toolNodeIdAttr) return toolNodeIdAttr === node.id;
   return nodeIdAttr === node.id;
 }
 

--- a/apps/ui/src/components/graph/__tests__/NodeObsSidebar.filtering.test.tsx
+++ b/apps/ui/src/components/graph/__tests__/NodeObsSidebar.filtering.test.tsx
@@ -1,0 +1,48 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { NodeObsSidebar } from '../NodeObsSidebar';
+
+vi.mock('../../../lib/graph/templates.provider', () => ({
+  useTemplatesCache: () => ({ getTemplate: (_name: string) => ({ kind: 'tool' }) }),
+}));
+
+vi.mock('../../../lib/graph/hooks', () => ({
+  useNodeReminders: () => ({ isLoading: false, data: { items: [] } }),
+}));
+
+const spans: any[] = [];
+
+vi.mock('../../../lib/obs/api', () => ({
+  fetchSpansInRange: async () => ({ items: spans }),
+}));
+vi.mock('../../../lib/obs/socket', () => ({
+  obsRealtime: { onSpanUpsert: (_fn: any) => () => {} },
+}));
+
+describe('NodeObsSidebar filtering for tool spans', () => {
+  const node: any = { id: 'tool-1', data: { template: 'someTool' } };
+
+  beforeEach(() => { spans.length = 0; });
+
+  it('shows spans where attributes.toolNodeId matches', async () => {
+    spans.push({ traceId: 't1', spanId: 's1', label: 'tool:x', status: 'ok', startTime: 'n', completed: true, lastUpdate: 'n', attributes: { kind: 'tool_call', toolNodeId: 'tool-1' } });
+    spans.push({ traceId: 't2', spanId: 's2', label: 'tool:y', status: 'ok', startTime: 'n', completed: true, lastUpdate: 'n', attributes: { kind: 'tool_call', toolNodeId: 'tool-2' } });
+    render(<NodeObsSidebar node={node} />);
+    await waitFor(() => expect(screen.queryByText('No spans yet.')).not.toBeInTheDocument());
+    // Expect two id monos visible - one for s1
+    expect(screen.getByText('s1')).toBeInTheDocument();
+    expect(screen.queryByText('s2')).not.toBeInTheDocument();
+  });
+
+  it('falls back to legacy nodeId when toolNodeId is absent', async () => {
+    spans.push({ traceId: 't3', spanId: 's3', label: 'tool:x', status: 'ok', startTime: 'n', completed: true, lastUpdate: 'n', attributes: { kind: 'tool_call' }, nodeId: 'tool-1' });
+    spans.push({ traceId: 't4', spanId: 's4', label: 'tool:y', status: 'ok', startTime: 'n', completed: true, lastUpdate: 'n', attributes: { kind: 'tool_call' }, nodeId: 'tool-2' });
+    render(<NodeObsSidebar node={node} />);
+    await waitFor(() => expect(screen.queryByText('No spans yet.')).not.toBeInTheDocument());
+    expect(screen.getByText('s3')).toBeInTheDocument();
+    expect(screen.queryByText('s4')).not.toBeInTheDocument();
+  });
+});
+

--- a/apps/ui/src/lib/obs/__tests__/runningStore.test.ts
+++ b/apps/ui/src/lib/obs/__tests__/runningStore.test.ts
@@ -54,16 +54,16 @@ describe('runningStore transitions', () => {
     const { result } = renderHook(() => useRunningCount(nodeId, 'tool'));
     expect(result.current).toBe(0);
     act(() => {
-      upsert({ traceId: 't2', spanId: 's2', label: 'tool:x', status: 'running', startTime: now(), completed: false, lastUpdate: now(), attributes: { kind: 'tool_call', nodeId }, nodeId });
+      upsert({ traceId: 't2', spanId: 's2', label: 'tool:x', status: 'running', startTime: now(), completed: false, lastUpdate: now(), attributes: { kind: 'tool_call', nodeId, toolNodeId: nodeId }, nodeId });
     });
     expect(result.current).toBe(1);
     act(() => {
-      upsert({ traceId: 't2', spanId: 's2', label: 'tool:x', status: 'error', startTime: now(), completed: true, lastUpdate: now(), attributes: { kind: 'tool_call', nodeId }, nodeId });
+      upsert({ traceId: 't2', spanId: 's2', label: 'tool:x', status: 'error', startTime: now(), completed: true, lastUpdate: now(), attributes: { kind: 'tool_call', nodeId, toolNodeId: nodeId }, nodeId });
     });
     expect(result.current).toBe(0);
     act(() => {
-      upsert({ traceId: 't3', spanId: 's3', label: 'tool:x', status: 'running', startTime: now(), completed: false, lastUpdate: now(), attributes: { kind: 'tool_call', nodeId }, nodeId });
-      upsert({ traceId: 't3', spanId: 's3', label: 'tool:x', status: 'cancelled', startTime: now(), completed: true, lastUpdate: now(), attributes: { kind: 'tool_call', nodeId }, nodeId });
+      upsert({ traceId: 't3', spanId: 's3', label: 'tool:x', status: 'running', startTime: now(), completed: false, lastUpdate: now(), attributes: { kind: 'tool_call', nodeId, toolNodeId: nodeId }, nodeId });
+      upsert({ traceId: 't3', spanId: 's3', label: 'tool:x', status: 'cancelled', startTime: now(), completed: true, lastUpdate: now(), attributes: { kind: 'tool_call', nodeId, toolNodeId: nodeId }, nodeId });
     });
     expect(result.current).toBe(0);
   });
@@ -84,6 +84,19 @@ describe('runningStore transitions', () => {
       upsert({ traceId: 'te', spanId: 'e0', label: 'agent', status: 'ok', startTime: now(), completed: true, lastUpdate: now(), attributes: { kind: 'agent', nodeId }, nodeId });
     });
     expect(result.current).toBe(N - 1);
+  });
+
+  it('tool bucket falls back to legacy nodeId when toolNodeId missing', async () => {
+    const { result } = renderHook(() => useRunningCount(nodeId, 'tool'));
+    expect(result.current).toBe(0);
+    act(() => {
+      upsert({ traceId: 'tf', spanId: 'sf', label: 'tool:legacy', status: 'running', startTime: now(), completed: false, lastUpdate: now(), attributes: { kind: 'tool_call' }, nodeId });
+    });
+    expect(result.current).toBe(1);
+    act(() => {
+      upsert({ traceId: 'tf', spanId: 'sf', label: 'tool:legacy', status: 'ok', startTime: now(), completed: true, lastUpdate: now(), attributes: { kind: 'tool_call' }, nodeId });
+    });
+    expect(result.current).toBe(0);
   });
 });
 /* @vitest-environment jsdom */

--- a/apps/ui/src/lib/obs/runningStore.ts
+++ b/apps/ui/src/lib/obs/runningStore.ts
@@ -20,8 +20,14 @@ function detectBucket(span: SpanDoc): Bucket | undefined {
 }
 
 function getNodeIdFromSpan(span: SpanDoc): string | undefined {
-  // Strictly require nodeId presence; do not infer
-  const nodeId = span.nodeId || (span.attributes?.nodeId as string | undefined) || undefined;
+  // For tool spans, prefer attributes.toolNodeId (Tool id), fallback to nodeId for legacy
+  const attrs = span.attributes || {};
+  const kind = (attrs.kind as string | undefined) || span.label?.startsWith('tool:') ? 'tool_call' : undefined;
+  if (kind === 'tool_call') {
+    const toolNodeId = (attrs['toolNodeId'] as string | undefined) || undefined;
+    if (toolNodeId) return toolNodeId;
+  }
+  const nodeId = span.nodeId || (attrs['nodeId'] as string | undefined) || undefined;
   if (typeof nodeId === 'string' && nodeId.length > 0) return nodeId;
   return undefined;
 }

--- a/apps/ui/vitest.config.ts
+++ b/apps/ui/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
   },
 });

--- a/packages/obs-sdk/src/index.ts
+++ b/packages/obs-sdk/src/index.ts
@@ -385,16 +385,16 @@ export function withLLM<T>(
 }
 
 export function withToolCall<TOutput = unknown, TRaw = unknown>(
-  attributes: { toolCallId: string; name: string; input: unknown; nodeId?: string; [k: string]: unknown },
+  attributes: { toolCallId: string; name: string; input: unknown; nodeId?: string; toolNodeId?: string; [k: string]: unknown },
   fn: () => Promise<ToolCallResponse<TRaw, TOutput>> | ToolCallResponse<TRaw, TOutput>,
 ): Promise<TRaw> {
-  const { toolCallId, name, input, nodeId, ...rest } = attributes;
+  const { toolCallId, name, input, nodeId, toolNodeId, ...rest } = attributes;
   return withSpan(
     {
       label: `tool:${name}`,
       kind: 'tool_call',
       nodeId,
-      attributes: { kind: 'tool_call', toolCallId, name, input, ...(nodeId ? { nodeId } : {}), ...rest },
+      attributes: { kind: 'tool_call', toolCallId, name, input, ...(nodeId ? { nodeId } : {}), ...(toolNodeId ? { toolNodeId } : {}), ...rest },
     },
     fn,
     (result, err) => {


### PR DESCRIPTION
Summary
- Server: Tool call spans now keep nodeId attributed to the Agent while emitting attributes.toolNodeId with the Tool id for UI filtering.
- UI: Activity sidebar and running count logic filter Tool activity using attributes.toolNodeId (with legacy fallback to nodeId). Agent filtering unchanged.
- SDK: Typing extended to allow optional toolNodeId attribute in withToolCall, passed through to span attributes.
- Tests: Updated server tests to assert nodeId=agent and toolNodeId presence; added UI tests for filtering and running counts including legacy fallback.

Back-compat
- UI includes fallback paths so older spans where nodeId==Tool id continue to show up under Tool nodes.

Implementation details
- Server (apps/server/src/lgnodes/tools.lgnode.ts): withToolCall now always uses this.nodeId for span.nodeId. If config.configurable.nodeId/node_id is set, we add attributes.toolNodeId to the span. Comments added documenting the attribution model.
- UI (apps/ui/src/components/graph/NodeObsSidebar.tsx): Tool node filter prefers attributes.toolNodeId === toolId; falls back to nodeId === toolId. Agent filter remains nodeId === agentId.
- UI (apps/ui/src/lib/obs/runningStore.ts): Tool bucket uses attributes.toolNodeId first, then nodeId; Agent bucket unchanged.
- SDK (packages/obs-sdk/src/index.ts): withToolCall attributes accept optional toolNodeId?: string; forwarded into spans as attributes.
- Tests:
  - Server: apps/server/__tests__/tools.node.nodeId.precedence.test.ts updated to new attribution model.
  - UI: Added apps/ui/src/components/graph/__tests__/NodeObsSidebar.filtering.test.tsx; extended apps/ui/src/lib/obs/__tests__/runningStore.test.ts for legacy fallback.

Known test environment note
- Two MongoMemoryServer-dependent suites can fail on CPUs without AVX; they are now guarded to skip when mongodb-memory-server cannot start.

Closes #167