### PR TITLE
Phase 2: Global configure rename; Agent as Node — start/stop/delete (no back-compat)

### DIFF
--- a/apps/server/__tests__/agents.simple.buffer.behavior.test.ts
+++ b/apps/server/__tests__/agents.simple.buffer.behavior.test.ts
@@ -66,7 +66,7 @@ describe('SimpleAgent buffer behavior', () => {
     });
     const logger = { info: vi.fn(), debug: vi.fn(), error: vi.fn() } as unknown as LoggerService;
     const agent = new SimpleAgent(cfg, logger as any, new CheckpointerService(new LoggerService()) as any, 'agent-deb');
-    agent.setConfig({ debounceMs: 50, processBuffer: 'allTogether' });
+    agent.configure({ debounceMs: 50, processBuffer: 'allTogether' });
 
     const p1 = agent.invoke('td', { content: 'a', info: {} });
     // Enqueue another within debounce window; should batch into the same run
@@ -91,7 +91,7 @@ describe('SimpleAgent buffer behavior', () => {
     });
     const logger = { info: vi.fn(), debug: vi.fn(), error: vi.fn() } as unknown as LoggerService;
     const agent = new SimpleAgent(cfg, logger as any, new CheckpointerService(new LoggerService()) as any, 'agent-one');
-    agent.setConfig({ processBuffer: 'oneByOne' });
+    agent.configure({ processBuffer: 'oneByOne' });
     const msgs: TriggerMessage[] = [
       { content: 'a', info: {} },
       { content: 'b', info: {} },
@@ -110,7 +110,7 @@ describe('SimpleAgent buffer behavior', () => {
     });
     const logger = { info: vi.fn(), debug: vi.fn(), error: vi.fn() } as unknown as LoggerService;
     const agent = new SimpleAgent(cfg, logger as any, new CheckpointerService(new LoggerService()), 'agent-all');
-    agent.setConfig({ processBuffer: 'allTogether', debounceMs: 0 });
+    agent.configure({ processBuffer: 'allTogether', debounceMs: 0 });
     const msgs: TriggerMessage[] = [
       { content: 'a', info: {} },
       { content: 'b', info: {} },
@@ -124,7 +124,7 @@ describe('SimpleAgent buffer behavior', () => {
 
   it("whenBusy='injectAfterTools' injects messages during in-flight run", async () => {
     const agent = makeAgent();
-    agent.setConfig({ whenBusy: 'injectAfterTools', debounceMs: 0 });
+    agent.configure({ whenBusy: 'injectAfterTools', debounceMs: 0 });
     // Kick off a run with one message
     const p = agent.invoke('t2', { content: 'start', info: {} });
     // Immediately enqueue another which should be injected into the current run

--- a/apps/server/__tests__/agents.simple.buffer.config.test.ts
+++ b/apps/server/__tests__/agents.simple.buffer.config.test.ts
@@ -22,21 +22,21 @@ describe('SimpleAgent buffer handling config schema', () => {
     expect(parsed.processBuffer).toBe('oneByOne');
   });
 
-  it('setConfig continues to apply runtime scheduling config', () => {
+  it('configure continues to apply runtime scheduling config', () => {
     const a = makeAgent();
     const anyA: any = a as any;
     // Spy on applyRuntimeConfig to ensure it is invoked
     const spy = vi.spyOn(anyA, 'applyRuntimeConfig');
-    a.setConfig({ debounceMs: 123, whenBusy: 'wait', processBuffer: 'allTogether' });
+    a.configure({ debounceMs: 123, whenBusy: 'wait', processBuffer: 'allTogether' });
     expect(spy).toHaveBeenCalled();
     // Optional legacy mapping is commented (no-op), so just ensure no throw
   });
 
-  it('rejects invalid enum values in schema and setConfig', () => {
+  it('rejects invalid enum values in schema and configure', () => {
     const res = SimpleAgentStaticConfigSchema.safeParse({ whenBusy: 'bogus' });
     expect(res.success).toBe(false);
     const a = makeAgent();
-    expect(() => a.setConfig({ whenBusy: 'bogus' })).toThrowError();
+    expect(() => a.configure({ whenBusy: 'bogus' })).toThrowError();
   });
 
   it('rejects negative summarizationKeepTokens/maxTokens', () => {
@@ -45,7 +45,7 @@ describe('SimpleAgent buffer handling config schema', () => {
     expect(res1.success).toBe(false);
     expect(res2.success).toBe(false);
     const a = makeAgent();
-    expect(() => a.setConfig({ summarizationKeepTokens: -1 })).toThrowError();
-    expect(() => a.setConfig({ summarizationMaxTokens: 0 })).toThrowError();
+    expect(() => a.configure({ summarizationKeepTokens: -1 })).toThrowError();
+    expect(() => a.configure({ summarizationMaxTokens: 0 })).toThrowError();
   });
 });

--- a/apps/server/__tests__/agents.simple.schema.test.ts
+++ b/apps/server/__tests__/agents.simple.schema.test.ts
@@ -9,7 +9,7 @@ class MockCheckpointerService { getCheckpointer = vi.fn(() => ({} as any)); }
 // Minimal stub: SimpleAgent requires an agentId to init
 const makeAgent = () => new SimpleAgent(new MockConfigService() as any, new MockLoggerService() as any, new MockCheckpointerService() as any, 'agent-1');
 
-describe('BaseAgent.getConfigSchema / SimpleAgent.setConfig', () => {
+describe('BaseAgent.getConfigSchema / SimpleAgent.configure', () => {
   it('returns expected JSON schema', () => {
     const a = makeAgent();
     const schema = (a as unknown as BaseAgent).getConfigSchema() as any;
@@ -19,25 +19,25 @@ describe('BaseAgent.getConfigSchema / SimpleAgent.setConfig', () => {
     expect(schema.properties.summarizationMaxTokens).toMatchObject({ type: 'integer', minimum: 1 });
   });
 
-  it('setConfig applies systemPrompt and summarization fields', () => {
+  it('configure applies systemPrompt and summarization fields', () => {
     const a = makeAgent();
     // Spy on internal nodes via any access (we just validate calls not strict behavior)
     const anyA: any = a as any;
     anyA.callModelNode = { setSystemPrompt: vi.fn(), addTool: vi.fn(), removeTool: vi.fn() };
     anyA.summarizeNode = { setOptions: vi.fn() };
 
-    a.setConfig({ systemPrompt: 'You are helpful.' });
+    a.configure({ systemPrompt: 'You are helpful.' });
     expect(anyA.callModelNode.setSystemPrompt).toHaveBeenCalledWith('You are helpful.');
 
-    a.setConfig({ summarizationKeepLast: 5, summarizationMaxTokens: 100 });
+    a.configure({ summarizationKeepLast: 5, summarizationMaxTokens: 100 });
     expect(anyA.summarizeNode.setOptions).toHaveBeenCalledWith({ keepTokens: 5, maxTokens: 100 });
   });
 
-  it('supports model override via setConfig', () => {
+  it('supports model override via configure', () => {
     const a = makeAgent();
     const anyA: any = a as any;
   const originalLLM = (anyA.llm);
-  a.setConfig({ model: 'override-model' });
+  a.configure({ model: 'override-model' });
   // Expect underlying llm object mutated, not replaced with a new node
   expect(anyA.llm).toBe(originalLLM);
   expect((anyA.llm as any).model).toBe('override-model');

--- a/apps/server/__tests__/call_agent.tool.test.ts
+++ b/apps/server/__tests__/call_agent.tool.test.ts
@@ -20,7 +20,7 @@ class FakeAgent extends BaseAgent {
     this._graph = { invoke: vi.fn() } as any;
     this._config = { configurable: {} } as any;
   }
-  async setConfig(_: Record<string, unknown>): Promise<void> {}
+  async configure(_: Record<string, unknown>): Promise<void> {}
   async invoke(thread: string, messages: Msg[]): Promise<AIMessage> {
     if (this.responder) return this.responder(thread, messages);
     return new AIMessage('OK');
@@ -34,7 +34,7 @@ class FakeParentAgent extends BaseAgent {
     this._graph = { invoke: vi.fn() } as any;
     this._config = { configurable: {} } as any;
   }
-  async setConfig(_: Record<string, unknown>): Promise<void> {}
+  async configure(_: Record<string, unknown>): Promise<void> {}
   async invoke(thread: string, messages: Msg[]): Promise<AIMessage> {
     this.calls.push({ thread, messages });
     return new AIMessage('ACK');
@@ -44,7 +44,7 @@ class FakeParentAgent extends BaseAgent {
 describe('CallAgentTool unit', () => {
   it('returns error when no agent attached', async () => {
     const tool = new CallAgentTool(new LoggerService());
-    await expect(tool.setConfig({ description: 'desc' })).resolves.toBeUndefined();
+    await expect(tool.configure({ description: 'desc' })).resolves.toBeUndefined();
     const dynamic: DynamicStructuredTool = tool.init();
     const out = await dynamic.invoke(
       { input: 'hi', childThreadId: 'x' },
@@ -55,7 +55,7 @@ describe('CallAgentTool unit', () => {
 
   it('calls attached agent and returns its response.text', async () => {
     const tool = new CallAgentTool(new LoggerService());
-    await tool.setConfig({ description: 'desc' });
+    await tool.configure({ description: 'desc' });
     const agent = new FakeAgent(new LoggerService(), async (thread, _msgs) => {
       expect(thread).toBe('t2__sub');
       return new AIMessage('OK');
@@ -71,7 +71,7 @@ describe('CallAgentTool unit', () => {
 
   it('passes context through info', async () => {
     const tool = new CallAgentTool(new LoggerService());
-    await tool.setConfig({ description: 'desc' });
+    await tool.configure({ description: 'desc' });
     const agent = new FakeAgent(new LoggerService(), async (_thread, msgs) => {
       expect(msgs[0]?.info?.deep).toBe(42);
       return new AIMessage('OK');
@@ -87,7 +87,7 @@ describe('CallAgentTool unit', () => {
 
   it('uses provided description in tool metadata', async () => {
     const tool = new CallAgentTool(new LoggerService());
-    await tool.setConfig({ description: 'My desc' });
+    await tool.configure({ description: 'My desc' });
     const dynamic = tool.init();
     expect(dynamic.description).toBe('My desc');
     expect(dynamic.name).toBe('call_agent');
@@ -95,7 +95,7 @@ describe('CallAgentTool unit', () => {
 
   it('concatenates childThreadId with parent thread_id when provided', async () => {
     const tool = new CallAgentTool(new LoggerService());
-    await tool.setConfig({ description: 'desc' });
+    await tool.configure({ description: 'desc' });
     const agent = new FakeAgent(new LoggerService(), async (thread, _msgs) => {
       expect(thread).toBe('parent__sub');
       return new AIMessage('OK');
@@ -111,7 +111,7 @@ describe('CallAgentTool unit', () => {
 
   it('async mode returns sent immediately and later triggers parent with child result', async () => {
     const tool = new CallAgentTool(new LoggerService());
-    await tool.setConfig({ description: 'desc', response: 'async' });
+    await tool.configure({ description: 'desc', response: 'async' });
     const child = new FakeAgent(new LoggerService(), async (thread, msgs) => {
       expect(thread).toBe('p__c1');
       expect(msgs[0]?.content).toBe('do work');
@@ -135,7 +135,7 @@ describe('CallAgentTool unit', () => {
 
   it('ignore mode returns sent and does not trigger parent', async () => {
     const tool = new CallAgentTool(new LoggerService());
-    await tool.setConfig({ description: 'desc', response: 'ignore' });
+    await tool.configure({ description: 'desc', response: 'ignore' });
     const child = new FakeAgent(new LoggerService(), async () => {
       await sleep(5);
       return new AIMessage('ignored');

--- a/apps/server/__tests__/call_agent_multiple_instances.test.ts
+++ b/apps/server/__tests__/call_agent_multiple_instances.test.ts
@@ -14,12 +14,12 @@ describe('CallAgentTool configurable name', () => {
     const logger = new LoggerService();
 
     const toolDocs = new CallAgentTool(logger);
-    await toolDocs.setConfig({ description: 'docs', name: 'call_agent_docs' });
+    await toolDocs.configure({ description: 'docs', name: 'call_agent_docs' });
     toolDocs.setAgent(new FakeAgent() as any);
     const dynDocs = toolDocs.init();
 
     const toolOps = new CallAgentTool(logger);
-    await toolOps.setConfig({ description: 'ops', name: 'call_agent_ops' });
+    await toolOps.configure({ description: 'ops', name: 'call_agent_ops' });
     toolOps.setAgent(new FakeAgent() as any);
     const dynOps = toolOps.init();
 

--- a/apps/server/__tests__/config.simpleAgent.restriction.test.ts
+++ b/apps/server/__tests__/config.simpleAgent.restriction.test.ts
@@ -12,17 +12,17 @@ vi.mock('../src/services/checkpointer.service', async (importOriginal) => {
 });
 
 describe('SimpleAgent config restrictions', () => {
-  it('setConfig preserves systemPrompt and toggles restriction flags without concatenation', async () => {
+  it('configure preserves systemPrompt and toggles restriction flags without concatenation', async () => {
     const cfg = new ConfigService({
       githubAppId: '1', githubAppPrivateKey: 'k', githubInstallationId: 'i', openaiApiKey: 'x', githubToken: 't', mongodbUrl: 'm',
     } as any);
     const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'a1');
     // Update system prompt
-    agent.setConfig({ systemPrompt: 'Base system' });
+    agent.configure({ systemPrompt: 'Base system' });
     // Toggle restriction flags
-    agent.setConfig({ restrictOutput: true, restrictionMessage: 'Please call tools', restrictionMaxInjections: 2 });
+    agent.configure({ restrictOutput: true, restrictionMessage: 'Please call tools', restrictionMaxInjections: 2 });
     // Update again to ensure no concatenation side effects
-    agent.setConfig({ systemPrompt: 'Base system 2' });
+    agent.configure({ systemPrompt: 'Base system 2' });
     // There is no direct getter; we ensure invocation does not throw and behavior is isolated
     const res = await agent.invoke('t', { content: 'hi', info: {} } as any);
     expect(res).toBeDefined();

--- a/apps/server/__tests__/containerProvider.entity.platform.test.ts
+++ b/apps/server/__tests__/containerProvider.entity.platform.test.ts
@@ -35,7 +35,7 @@ describe('ContainerProviderEntity platform reuse logic', () => {
     (svc.getContainerLabels as unknown as vi.Mock).mockResolvedValue({ [PLATFORM_LABEL]: 'linux/amd64' });
 
     const provider = new ContainerProviderEntity(svc as unknown as ContainerService, {}, idLabels);
-    provider.setConfig({ platform: 'linux/arm64' }); // DinD disabled by default
+    provider.configure({ platform: 'linux/arm64' }); // DinD disabled by default
     const c = await provider.provide('t1');
 
     // ensure lookup used the thread-scoped label and role=workspace
@@ -67,7 +67,7 @@ describe('ContainerProviderEntity platform reuse logic', () => {
 
     const provider = new ContainerProviderEntity(svc as unknown as ContainerService, {}, idLabels);
     // DinD disabled in this test, but even if enabled, provider should not pick dind as workspace
-    provider.setConfig({ enableDinD: false });
+    provider.configure({ enableDinD: false });
     const c = await provider.provide('t-dind');
 
     // Should have started a fresh workspace container, not reused dind
@@ -82,7 +82,7 @@ describe('ContainerProviderEntity platform reuse logic', () => {
     (svc.getContainerLabels as unknown as vi.Mock).mockResolvedValue({});
 
     const provider = new ContainerProviderEntity(svc as unknown as ContainerService, {}, idLabels);
-    provider.setConfig({ platform: 'linux/arm64' }); // DinD disabled by default
+    provider.configure({ platform: 'linux/arm64' }); // DinD disabled by default
     const c = await provider.provide('t2');
 
     expect(existing.stop).toHaveBeenCalled();
@@ -128,7 +128,7 @@ describe('ContainerProviderEntity platform reuse logic', () => {
     const startImpl = async (_opts: Parameters<ContainerService['start']>[0]) => new MockContainer('cid123', svc);
     (svc.start as vi.Mock).mockImplementationOnce(startImpl);
     const provider = new ContainerProviderEntity(svc as unknown as ContainerService, {}, idLabels);
-    provider.setConfig({});
+    provider.configure({});
     const c = await provider.provide('tdis');
     expect(c).toBeInstanceOf(MockContainer);
     // verify DOCKER_HOST is NOT injected when DinD disabled
@@ -141,7 +141,7 @@ describe('ContainerProviderEntity platform reuse logic', () => {
     (svc.start as vi.Mock).mockImplementationOnce(startImpl);
     // DinD readiness already mocked in beforeEach via execContainer
     const provider = new ContainerProviderEntity(svc as unknown as ContainerService, {}, idLabels);
-    provider.setConfig({ enableDinD: true });
+    provider.configure({ enableDinD: true });
     const c = await provider.provide('ten');
     expect(c).toBeInstanceOf(MockContainer);
     const call = (svc.start as vi.Mock).mock.calls[0];

--- a/apps/server/__tests__/graph.git.service.test.ts
+++ b/apps/server/__tests__/graph.git.service.test.ts
@@ -24,7 +24,7 @@ describe('GitGraphService', () => {
     // Provide explicit ports so edges using sourceHandle 'out' and targetHandle 'in' validate
     registry.register(
       'noop',
-      async () => ({ setConfig: () => {} } as any),
+      async () => ({ configure: () => {} } as any),
       { sourcePorts: { out: { kind: 'instance' } }, targetPorts: { in: { kind: 'instance' } } },
       { title: 'Noop', kind: 'tool' },
     );

--- a/apps/server/__tests__/live.graph.runtime.test.ts
+++ b/apps/server/__tests__/live.graph.runtime.test.ts
@@ -9,7 +9,7 @@ import { LoggerService } from '../src/services/logger.service';
 // Simple fixtures
 class A {
   value = 0;
-  setConfig(cfg: any) {
+  configure(cfg: any) {
     this.value = cfg.value;
   }
   attach(b: any) {
@@ -21,7 +21,7 @@ class A {
 }
 class B {
   count = 0;
-  setConfig(cfg: any) {
+  configure(cfg: any) {
     this.count = cfg.count;
   }
   subscribe(t: any) {

--- a/apps/server/__tests__/localMcpServer.heartbeat.test.ts
+++ b/apps/server/__tests__/localMcpServer.heartbeat.test.ts
@@ -84,7 +84,7 @@ describe('LocalMCPServer heartbeat behavior', () => {
 
     const server = new LocalMCPServer(containerService, logger);
     server.setContainerProvider({ provide: async (t: string) => ({ id: `cid-${t}` }) } as any);
-    await server.setConfig({ namespace: 'mock', command: 'ignored', heartbeatIntervalMs: 100 } as any);
+    await server.configure({ namespace: 'mock', command: 'ignored', heartbeatIntervalMs: 100 } as any);
 
     const touchSpy = vi.spyOn(containerService, 'touchLastUsed').mockResolvedValue(undefined as any);
 

--- a/apps/server/__tests__/localMcpServer.test.ts
+++ b/apps/server/__tests__/localMcpServer.test.ts
@@ -134,7 +134,7 @@ describe('LocalMCPServer (mock)', () => {
     };
     (server as any).setContainerProvider(mockProvider);
     const cfg: McpServerConfig = { namespace: 'mock', command: 'ignored' } as any;
-    await server.setConfig(cfg);
+    await server.configure(cfg);
     await server.start();
   }, 10000);
 

--- a/apps/server/__tests__/mcp-lifecycle-changes.test.ts
+++ b/apps/server/__tests__/mcp-lifecycle-changes.test.ts
@@ -21,7 +21,7 @@ describe('MCP Lifecycle Changes', () => {
     };
     
     server.setContainerProvider(mockProvider as any);
-    await server.setConfig({ namespace: 'test' } as McpServerConfig);
+    await server.configure({ namespace: 'test' } as McpServerConfig);
     
     // This would fail if threadId wasn't supported in the interface
     try {

--- a/apps/server/__tests__/mcp.dynamic.sync.test.ts
+++ b/apps/server/__tests__/mcp.dynamic.sync.test.ts
@@ -24,7 +24,7 @@ describe('MCP dynamic tool enable/disable sync', () => {
     logger = new MockLogger();
     server = new LocalMCPServer(new MockContainerService() as any, logger as any);
     (server as any).setContainerProvider(mockProvider as any);
-  await server.setConfig({ namespace: 'ns', command: 'cmd' } as any);
+  await server.configure({ namespace: 'ns', command: 'cmd' } as any);
 
     // Stub discovery with two tools
     (server as any).discoverTools = vi.fn(async () => {

--- a/apps/server/__tests__/mcp.provision.dynamic.test.ts
+++ b/apps/server/__tests__/mcp.provision.dynamic.test.ts
@@ -28,7 +28,7 @@ describe('LocalMCPServer Provisionable + DynamicConfigurable', () => {
       (server as any).toolsDiscovered = true;
       return tools;
     });
-    await server.setConfig({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
+    await server.configure({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
 
     const transitions: string[] = [];
     server.onProvisionStatusChange((s) => transitions.push(s.state));
@@ -41,7 +41,7 @@ describe('LocalMCPServer Provisionable + DynamicConfigurable', () => {
 
   it('provision error path sets error with details', async () => {
     (server as any).discoverTools = vi.fn(async () => { throw new Error('disc boom'); });
-    await server.setConfig({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
+    await server.configure({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
 
     const transitions: string[] = [];
     server.onProvisionStatusChange((s) => transitions.push(s.state));
@@ -65,7 +65,7 @@ describe('LocalMCPServer Provisionable + DynamicConfigurable', () => {
       (server as any).toolsDiscovered = true;
       return [];
     });
-    await server.setConfig({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
+    await server.configure({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
     await server.provision();
     await server.deprovision();
     expect(server.getProvisionStatus().state).toBe('not_ready');
@@ -77,7 +77,7 @@ describe('LocalMCPServer Provisionable + DynamicConfigurable', () => {
       (server as any).toolsDiscovered = true;
       return (server as any).toolsCache;
     });
-    await server.setConfig({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
+    await server.configure({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
     expect(server.isDynamicConfigReady()).toBe(false);
     await server.provision();
     expect(server.isDynamicConfigReady()).toBe(true);
@@ -92,7 +92,7 @@ describe('LocalMCPServer Provisionable + DynamicConfigurable', () => {
       (server as any).toolsDiscovered = true;
       return (server as any).toolsCache;
     });
-    await server.setConfig({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
+    await server.configure({ namespace: 'ns', command: 'cmd' } as McpServerConfig);
     await server.provision();
     let tools = await server.listTools();
     expect(tools.map(t => t.name).sort()).toEqual(['toolA', 'toolB']);

--- a/apps/server/__tests__/runtime.api.helpers.test.ts
+++ b/apps/server/__tests__/runtime.api.helpers.test.ts
@@ -28,7 +28,7 @@ describe('Runtime helpers and GraphService API surfaces', () => {
       private status: ProvisionStatus = { state: 'not_ready' };
       private dynReady = false;
       private listeners: Array<(s: ProvisionStatus)=>void> = [];
-      setConfig = vi.fn(async (_cfg: Record<string, unknown>) => {});
+      configure = vi.fn(async (_cfg: Record<string, unknown>) => {});
       pause() { this.paused = true; }
       resume() { this.paused = false; }
       isPaused() { return this.paused; }
@@ -66,7 +66,7 @@ describe('Runtime helpers and GraphService API surfaces', () => {
     const { registry, runtime } = makeRuntimeAndRegistry();
 
     // Expand template with capabilities and static schema
-    registry.register('dyn', async () => ({ setConfig: async () => {} } as any), { sourcePorts: {}, targetPorts: {} }, {
+    registry.register('dyn', async () => ({ configure: async () => {} } as any), { sourcePorts: {}, targetPorts: {} }, {
       title: 'Dyn', kind: 'tool', capabilities: { pausable: true, provisionable: true, dynamicConfigurable: true, staticConfigurable: false },
       staticConfigSchema: { type: 'object', properties: {} } as any,
     });
@@ -76,7 +76,7 @@ describe('Runtime helpers and GraphService API surfaces', () => {
       isDynamicConfigReady() { return true; }
       getDynamicConfigSchema() { return { type: 'object', properties: { a: { type: 'boolean' } } } as any; }
       setDynamicConfig = vi.fn((_cfg: Record<string, unknown>) => {});
-      setConfig = vi.fn(async (_cfg: Record<string, unknown>) => {});
+      configure = vi.fn(async (_cfg: Record<string, unknown>) => {});
     }
     registry.register('dyn2', async () => new DynNode() as any, { sourcePorts: {}, targetPorts: {} }, { title: 'Dyn2', kind: 'tool' });
 
@@ -103,8 +103,8 @@ describe('Runtime helpers and GraphService API surfaces', () => {
     expect(instB.setDynamicConfig).toHaveBeenCalledWith({ a: true });
 
     // setNodeConfig on instance directly
-    instB.setConfig = vi.fn();
-    await instB.setConfig({ x: 1 });
-    expect(instB.setConfig).toHaveBeenCalledWith({ x: 1 });
+    instB.configure = vi.fn();
+    await instB.configure({ x: 1 });
+    expect(instB.configure).toHaveBeenCalledWith({ x: 1 });
   });
 });

--- a/apps/server/__tests__/runtime.dynamicConfig.apply.test.ts
+++ b/apps/server/__tests__/runtime.dynamicConfig.apply.test.ts
@@ -14,7 +14,7 @@ describe('Runtime dynamicConfig first-class support', () => {
     const instSetDynamic = vi.fn();
     const dynStore: any[] = [];
     registry.register('dynNode', async () => ({
-      setConfig: vi.fn(),
+      configure: vi.fn(),
       setDynamicConfig: (cfg: Record<string, unknown>) => { instSetDynamic(cfg); dynStore.push(cfg); },
       isDynamicConfigReady: () => true,
       getDynamicConfigSchema: () => ({ type: 'object', properties: { a: { type: 'boolean' } } }),

--- a/apps/server/__tests__/send_slack_message.tool.test.ts
+++ b/apps/server/__tests__/send_slack_message.tool.test.ts
@@ -18,7 +18,7 @@ describe('SendSlackMessageTool', () => {
 
   it('sends message using provided bot_token and channel (literal)', async () => {
     const tool = new SendSlackMessageTool(logger, undefined as any);
-    await tool.setConfig({ bot_token: 'xoxb-valid', default_channel: 'C1' });
+    await tool.configure({ bot_token: 'xoxb-valid', default_channel: 'C1' });
     const t = tool.init();
     const res = await t.invoke({ text: 'hi', channel: 'C2' } as any);
     expect(String(res)).toContain('ok');
@@ -26,7 +26,7 @@ describe('SendSlackMessageTool', () => {
 
   it('sends ephemeral when ephemeral_user set', async () => {
     const tool = new SendSlackMessageTool(logger, undefined as any);
-    await tool.setConfig({ bot_token: 'xoxb-valid', default_channel: 'C1' });
+    await tool.configure({ bot_token: 'xoxb-valid', default_channel: 'C1' });
     const t = tool.init();
     const res = await t.invoke({ text: 'hi', channel: 'C1', ephemeral_user: 'U1' } as any);
     expect(String(res)).toContain('ephemeral');
@@ -34,7 +34,7 @@ describe('SendSlackMessageTool', () => {
 
   it('uses default_channel when channel omitted', async () => {
     const tool = new SendSlackMessageTool(logger, undefined as any);
-    await tool.setConfig({ bot_token: 'xoxb-valid', default_channel: 'CDEF' });
+    await tool.configure({ bot_token: 'xoxb-valid', default_channel: 'CDEF' });
     const t = tool.init();
     const res = await t.invoke({ text: 'hello' } as any);
     expect(String(res)).toContain('ok');
@@ -42,13 +42,13 @@ describe('SendSlackMessageTool', () => {
 
   it('fails fast on vault ref when vault disabled', async () => {
     const tool = new SendSlackMessageTool(logger, undefined as any);
-    await expect(tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' } } as any)).rejects.toThrow();
+    await expect(tool.configure({ bot_token: { value: 'secret/slack/BOT', source: 'vault' } } as any)).rejects.toThrow();
   });
 
   it('resolves bot token via vault and sends', async () => {
     const vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'xoxb-from-vault') } as any;
     const tool = new SendSlackMessageTool(logger, vault);
-    await tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
+    await tool.configure({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
     const t = tool.init();
     const res = await t.invoke({ text: 'hi' } as any);
     expect(String(res)).toContain('ok');
@@ -58,22 +58,22 @@ describe('SendSlackMessageTool', () => {
   it('returns error when vault secret missing', async () => {
     const vault = { isEnabled: () => true, getSecret: vi.fn(async () => undefined) } as any;
     const tool = new SendSlackMessageTool(logger, vault);
-    await tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
+    await tool.configure({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
     const t = tool.init();
     const res = await t.invoke({ text: 'hi' } as any);
     expect(String(res)).toContain('Error sending Slack message');
   });
 
-  it('throws on invalid reference string during setConfig', async () => {
+  it('throws on invalid reference string during configure', async () => {
     const vault = { isEnabled: () => true, getSecret: vi.fn() } as any;
     const tool = new SendSlackMessageTool(logger, vault);
-    await expect(tool.setConfig({ bot_token: { value: 'invalid', source: 'vault' } } as any)).rejects.toThrow();
+    await expect(tool.configure({ bot_token: { value: 'invalid', source: 'vault' } } as any)).rejects.toThrow();
   });
 
   it('errors when resolved bot token has wrong prefix', async () => {
     const vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'xapp-wrong') } as any;
     const tool = new SendSlackMessageTool(logger, vault);
-    await tool.setConfig({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
+    await tool.configure({ bot_token: { value: 'secret/slack/BOT', source: 'vault' }, default_channel: 'C1' } as any);
     const t = tool.init();
     const res = await t.invoke({ text: 'hi' } as any);
     expect(String(res)).toContain('Error sending Slack message');

--- a/apps/server/__tests__/simpleAgent.restriction.graph.test.ts
+++ b/apps/server/__tests__/simpleAgent.restriction.graph.test.ts
@@ -81,14 +81,14 @@ describe('SimpleAgent restriction enforcement', () => {
 
   it('restrictOutput=false: call_model with no tool_calls leads to END (no enforce)', async () => {
     const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'a1');
-    agent.setConfig({ restrictOutput: false });
+    agent.configure({ restrictOutput: false });
     const res = await agent.invoke('t', { content: 'hi', info: {} } as any);
     expect(res).toBeDefined();
   });
 
   it('restrictOutput=true & restrictionMaxInjections=0: injects and loops until tool call', async () => {
     const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'a2');
-    agent.setConfig({ restrictOutput: true, restrictionMaxInjections: 0 });
+    agent.configure({ restrictOutput: true, restrictionMaxInjections: 0 });
     const res = await agent.invoke('t', { content: 'hi', info: {} } as any);
     expect(res).toBeDefined();
   });
@@ -104,7 +104,7 @@ describe('SimpleAgent restriction enforcement', () => {
     ;(openai as any).ChatOpenAI = NoToolLLM;
 
     const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'a3');
-    agent.setConfig({ restrictOutput: true, restrictionMaxInjections: 2 });
+    agent.configure({ restrictOutput: true, restrictionMaxInjections: 2 });
     const res = await agent.invoke('t', { content: 'hello', info: {} } as any);
     expect(res).toBeDefined();
   });

--- a/apps/server/__tests__/simpleAgent.summarization.graph.test.ts
+++ b/apps/server/__tests__/simpleAgent.summarization.graph.test.ts
@@ -62,7 +62,7 @@ describe('SimpleAgent summarization graph', () => {
       mongodbUrl: 'm',
     });
     const agent = new SimpleAgent(cfg, new LoggerService(), new CheckpointerService(new LoggerService()) as any, 'agent-1');
-    agent.setConfig({ summarizationKeepLast: 2, summarizationMaxTokens: 200 });
+    agent.configure({ summarizationKeepLast: 2, summarizationMaxTokens: 200 });
 
     // Use the agent wrapper to invoke
     const r1 = await agent.invoke('t', { content: 'hi', info: {} } as any);

--- a/apps/server/__tests__/slack.config.schemas.test.ts
+++ b/apps/server/__tests__/slack.config.schemas.test.ts
@@ -6,7 +6,7 @@ describe('Slack static config schemas', () => {
   it('SendSlackMessageToolStaticConfigSchema: accepts xoxb- tokens or reference field', () => {
     expect(() => SendSlackMessageToolStaticConfigSchema.parse({ bot_token: 'xoxb-123', default_channel: 'C1' })).not.toThrow();
     expect(() => SendSlackMessageToolStaticConfigSchema.parse({ bot_token: { value: 'xoxb-abc', source: 'static' } })).not.toThrow();
-    // vault ref is allowed syntactically; deeper validation occurs in setConfig
+    // vault ref is allowed syntactically; deeper validation occurs in configure
     expect(() => SendSlackMessageToolStaticConfigSchema.parse({ bot_token: { value: 'secret/path/KEY', source: 'vault' } })).not.toThrow();
   });
 

--- a/apps/server/__tests__/slack.pr.trigger.lifecycle.test.ts
+++ b/apps/server/__tests__/slack.pr.trigger.lifecycle.test.ts
@@ -41,7 +41,7 @@ describe('SlackTrigger and PRTrigger lifecycle', () => {
   it('SlackTrigger start/stop manages socket-mode lifecycle', async () => {
     const logger = new MockLogger() as any;
     const trigger = new SlackTrigger(logger);
-    await trigger.setConfig({ app_token: 'xapp-test' });
+    await trigger.configure({ app_token: 'xapp-test' });
     await trigger.start();
     await trigger.stop();
     expect(logger.info).toHaveBeenCalled();

--- a/apps/server/__tests__/slack.trigger.events.test.ts
+++ b/apps/server/__tests__/slack.trigger.events.test.ts
@@ -19,7 +19,7 @@ describe('SlackTrigger events', () => {
   it('relays message events from socket-mode client', async () => {
     const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
     const trig = new SlackTrigger(logger);
-    await trig.setConfig({ app_token: 'xapp-abc' });
+    await trig.configure({ app_token: 'xapp-abc' });
     // Subscribe a listener
     const received: any[] = [];
     await trig.subscribe({ invoke: async (_t, msgs) => { received.push(...msgs); } });
@@ -34,14 +34,14 @@ describe('SlackTrigger events', () => {
   it('fails fast when vault ref provided but vault disabled', async () => {
     const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
     const trig = new SlackTrigger(logger, undefined as any);
-    await expect(trig.setConfig({ app_token: { value: 'secret/slack/APP', source: 'vault' } } as any)).rejects.toThrow();
+    await expect(trig.configure({ app_token: { value: 'secret/slack/APP', source: 'vault' } } as any)).rejects.toThrow();
   });
 
   it('resolves app token via vault during provision', async () => {
     const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
     const vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'xapp-from-vault') } as any;
     const trig = new SlackTrigger(logger, vault);
-    await trig.setConfig({ app_token: { value: 'secret/slack/APP', source: 'vault' } } as any);
+    await trig.configure({ app_token: { value: 'secret/slack/APP', source: 'vault' } } as any);
     await trig.provision();
     expect((trig as any).client).toBeTruthy();
   });
@@ -50,7 +50,7 @@ describe('SlackTrigger events', () => {
     const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
     const vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'xoxb-wrong') } as any;
     const trig = new SlackTrigger(logger, vault);
-    await trig.setConfig({ app_token: { value: 'secret/slack/APP', source: 'vault' } } as any);
+    await trig.configure({ app_token: { value: 'secret/slack/APP', source: 'vault' } } as any);
     await trig.provision();
     expect(trig.getProvisionStatus().state).toBe('error');
   });

--- a/apps/server/__tests__/templateRegistry.schema.test.ts
+++ b/apps/server/__tests__/templateRegistry.schema.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { TemplateRegistry } from '../src/graph/templateRegistry';
 import type { TemplateNodeSchema, TemplateKind } from '../src/graph/types';
 
-const noopFactory = () => ({ setConfig: () => {} });
+const noopFactory = () => ({ configure: () => {} });
 
 const dummyPorts = {
   sourcePorts: { out: { kind: 'instance' as const } },

--- a/apps/server/__tests__/tools/memory.config_overrides.test.ts
+++ b/apps/server/__tests__/tools/memory.config_overrides.test.ts
@@ -14,13 +14,13 @@ describe('UnifiedMemoryTool config overrides and templates exposure', () => {
     expect(dynamic.description).toMatch(/Unified Memory tool/i);
 
     // override description only (back-compat default name)
-    await tool.setConfig({ description: 'Custom desc' });
+    await tool.configure({ description: 'Custom desc' });
     dynamic = tool.init();
     expect(dynamic.name).toBe('memory');
     expect(dynamic.description).toBe('Custom desc');
 
     // override name (valid)
-    await tool.setConfig({ name: 'mem_x' });
+    await tool.configure({ name: 'mem_x' });
     dynamic = tool.init();
     expect(dynamic.name).toBe('mem_x');
     expect(dynamic.description).toBe('Custom desc');
@@ -28,7 +28,7 @@ describe('UnifiedMemoryTool config overrides and templates exposure', () => {
 
   it('rejects invalid name via schema', async () => {
     const tool = new UnifiedMemoryTool(new LoggerService());
-    await expect(tool.setConfig({ name: 'Bad-Name' })).rejects.toThrow();
+    await expect(tool.configure({ name: 'Bad-Name' })).rejects.toThrow();
     // ensure defaults unchanged
     const dynamic = tool.init();
     expect(dynamic.name).toBe('memory');
@@ -40,4 +40,3 @@ describe('UnifiedMemoryTool config overrides and templates exposure', () => {
     expect(Object.keys(js.properties)).toEqual(expect.arrayContaining(['name','description','title']));
   });
 });
-

--- a/apps/server/src/__tests__/containerProvider.env.test.ts
+++ b/apps/server/src/__tests__/containerProvider.env.test.ts
@@ -24,7 +24,7 @@ describe('ContainerProviderEntity parseVaultRef', () => {
     const svc = new FakeContainerService() as any;
     const vault = new FakeVault() as any;
     const ent = new ContainerProviderEntity(svc, vault, {}, () => ({}));
-    ent.setConfig({ env: [ { key: 'A', value: 'x' }, { key: 'B', value: 'secret/path/key', source: 'vault' } ] });
+    ent.configure({ env: [ { key: 'A', value: 'x' }, { key: 'B', value: 'secret/path/key', source: 'vault' } ] });
     const container: any = await ent.provide('t');
     expect(container.env.A).toBe('x');
     expect(container.env.B).toBe('VAL');

--- a/apps/server/src/__tests__/containerProvider.registry.integration.test.ts
+++ b/apps/server/src/__tests__/containerProvider.registry.integration.test.ts
@@ -23,10 +23,9 @@ describe('ContainerProvider + registry hooks', () => {
     const reg = new FakeRegistry();
     svc.setRegistry(reg);
     const provider = new ContainerProviderEntity(svc, {} as any, {}, () => ({ 'hautech.ai/thread_id': 'node__t' }));
-    provider.setConfig({ ttlSeconds: 86400 });
+    provider.configure({ ttlSeconds: 86400 });
     const c = await provider.provide('t');
     expect(c.id).toBe('cid123');
     expect(reg.lastUsed).toContain('cid123');
   });
 });
-

--- a/apps/server/src/__tests__/github_clone_repo.token.test.ts
+++ b/apps/server/src/__tests__/github_clone_repo.token.test.ts
@@ -14,7 +14,7 @@ describe('GithubCloneRepoTool token resolution', () => {
   });
   it('prefers static token value', async () => {
     const tool = new GithubCloneRepoTool({ githubToken: 'FALLBACK' } as any, undefined, logger);
-    await tool.setConfig({ token: { value: 'DIRECT', source: 'static' } });
+    await tool.configure({ token: { value: 'DIRECT', source: 'static' } });
     // @ts-ignore access private method via cast
     const t = await (tool as any).resolveToken();
     expect(t).toBe('DIRECT');
@@ -22,14 +22,14 @@ describe('GithubCloneRepoTool token resolution', () => {
   it('falls back to env GH_TOKEN via legacy authRef', async () => {
     process.env.GH_TOKEN = 'FROM_ENV';
     const tool = new GithubCloneRepoTool({ githubToken: 'FALLBACK' } as any, undefined, logger);
-    await tool.setConfig({ authRef: { source: 'env', envVar: 'GH_TOKEN' } });
+    await tool.configure({ authRef: { source: 'env', envVar: 'GH_TOKEN' } });
     // @ts-ignore
     const t = await (tool as any).resolveToken();
     expect(t).toBe('FROM_ENV');
   });
   it('falls back to ConfigService when nothing provided', async () => {
     const tool = new GithubCloneRepoTool({ githubToken: 'FALLBACK' } as any, undefined, logger);
-    await tool.setConfig({});
+    await tool.configure({});
     // @ts-ignore
     const t = await (tool as any).resolveToken();
     expect(t).toBe('FALLBACK');
@@ -37,7 +37,7 @@ describe('GithubCloneRepoTool token resolution', () => {
   it('resolves from vault when token.source=vault', async () => {
     const vlt: Partial<VaultService> = { isEnabled: () => true, getSecret: vi.fn().mockResolvedValue('FROM_VAULT') };
     const tool = new GithubCloneRepoTool({ githubToken: 'FALLBACK' } as any, vlt as VaultService, logger);
-    await tool.setConfig({ token: { value: 'secret/github/GH_TOKEN', source: 'vault' } });
+    await tool.configure({ token: { value: 'secret/github/GH_TOKEN', source: 'vault' } });
     // @ts-ignore
     const t = await (tool as any).resolveToken();
     expect(t).toBe('FROM_VAULT');

--- a/apps/server/src/__tests__/mcp.env.overlay.test.ts
+++ b/apps/server/src/__tests__/mcp.env.overlay.test.ts
@@ -36,7 +36,7 @@ describe('LocalMCPServer env overlay and workdir', () => {
   it('passes resolved Env (incl. vault refs) for discovery and per-call, without persistence', async () => {
     // Inject a fake vault into server instance
     (server as any).vault = { isEnabled: () => true, getSecret: vi.fn(async () => 'VAULTED') };
-    await server.setConfig({ namespace: 'x', command: 'mcp start --stdio', env: [ { key: 'A', value: '1' }, { key: 'B', value: 'mount/path/key', source: 'vault' } ], workdir: '/w', startupTimeoutMs: 10 } as any);
+    await server.configure({ namespace: 'x', command: 'mcp start --stdio', env: [ { key: 'A', value: '1' }, { key: 'B', value: 'mount/path/key', source: 'vault' } ], workdir: '/w', startupTimeoutMs: 10 } as any);
     // Discovery
     try { await server.discoverTools(); } catch {}
     // Simulate discovered tool for call

--- a/apps/server/src/__tests__/mixed.shell.mcp.isolation.test.ts
+++ b/apps/server/src/__tests__/mixed.shell.mcp.isolation.test.ts
@@ -26,7 +26,7 @@ describe('Mixed Shell + MCP overlay isolation', () => {
     const provider: any = new SharedProvider();
 
     const shell = new ShellTool(undefined as any, logger); shell.setContainerProvider(provider);
-    await shell.setConfig({ env: [ { key: 'S_VAR', value: 's' } ] });
+    await shell.configure({ env: [ { key: 'S_VAR', value: 's' } ] });
 
     // Mock docker for MCP
     const captured: any[] = [];
@@ -39,7 +39,7 @@ describe('Mixed Shell + MCP overlay isolation', () => {
     const cs: any = { getDocker: () => docker };
     const mcp = new LocalMCPServer(cs, logger as any);
     (mcp as any).setContainerProvider(provider);
-    await mcp.setConfig({ namespace: 'n', command: 'mcp start --stdio', env: [ { key: 'M_VAR', value: 'm' } ], startupTimeoutMs: 10 } as any);
+    await mcp.configure({ namespace: 'n', command: 'mcp start --stdio', env: [ { key: 'M_VAR', value: 'm' } ], startupTimeoutMs: 10 } as any);
 
     // Shell exec
     const tool = shell.init();

--- a/apps/server/src/__tests__/tools/shell.env.overlay.test.ts
+++ b/apps/server/src/__tests__/tools/shell.env.overlay.test.ts
@@ -32,9 +32,9 @@ describe('ShellTool env/workdir isolation with vault-backed overlay', () => {
     const fakeVault = { isEnabled: () => true, getSecret: vi.fn(async () => 'VAULTED') } as any;
 
     const a = new ShellTool(fakeVault, logger); a.setContainerProvider(provider);
-    await a.setConfig({ env: [ { key: 'FOO', value: 'A' }, { key: 'BAR', value: 'secret/path/key', source: 'vault' } ], workdir: '/w/a' });
+    await a.configure({ env: [ { key: 'FOO', value: 'A' }, { key: 'BAR', value: 'secret/path/key', source: 'vault' } ], workdir: '/w/a' });
     const b = new ShellTool(undefined as any, logger); b.setContainerProvider(provider);
-    await b.setConfig({ env: [ { key: 'FOO', value: 'B' } ], workdir: '/w/b' });
+    await b.configure({ env: [ { key: 'FOO', value: 'B' } ], workdir: '/w/b' });
 
     const at = a.init();
     const bt = b.init();

--- a/apps/server/src/__tests__/tools/shell.timeout.behavior.test.ts
+++ b/apps/server/src/__tests__/tools/shell.timeout.behavior.test.ts
@@ -19,7 +19,7 @@ describe('ShellTool timeout error message', () => {
 
     const tool = new ShellTool(undefined as any, logger);
     tool.setContainerProvider(provider);
-    await tool.setConfig({});
+    await tool.configure({});
     const t = tool.init();
 
     await expect(
@@ -37,7 +37,7 @@ describe('ShellTool timeout error message', () => {
     const provider = { provide: vi.fn(async () => fakeContainer) } as any;
     const tool = new ShellTool(undefined as any, logger);
     tool.setContainerProvider(provider);
-    await tool.setConfig({});
+    await tool.configure({});
     const t = tool.init();
     await expect(
       t.invoke({ command: 'sleep 999999' }, { configurable: { thread_id: 't' } } as any),
@@ -51,7 +51,7 @@ describe('ShellTool timeout error message', () => {
     const provider = { provide: vi.fn(async () => fakeContainer) } as any;
     const tool = new ShellTool(undefined as any, logger);
     tool.setContainerProvider(provider);
-    await tool.setConfig({ idleTimeoutMs: 60000 });
+    await tool.configure({ idleTimeoutMs: 60000 });
     const t = tool.init();
     await expect(
       t.invoke({ command: 'sleep 999999' }, { configurable: { thread_id: 't' } } as any),
@@ -186,7 +186,7 @@ describe('ShellTool non-timeout error propagation', () => {
 
     const tool = new ShellTool(undefined as any, logger);
     tool.setContainerProvider(provider as any);
-    await tool.setConfig({});
+    await tool.configure({});
     const t = tool.init();
 
     await expect(

--- a/apps/server/src/__tests__/tools/shell.timeout.tail.inclusion.test.ts
+++ b/apps/server/src/__tests__/tools/shell.timeout.tail.inclusion.test.ts
@@ -24,7 +24,7 @@ describe('ShellTool timeout tail inclusion and ANSI stripping', () => {
     const provider = { provide: vi.fn(async () => fakeContainer) } as any;
     const tool = new ShellTool(undefined as any, logger);
     tool.setContainerProvider(provider);
-    await tool.setConfig({});
+    await tool.configure({});
     const t = tool.init();
 
     await expect(

--- a/apps/server/src/__tests__/tools/shell.timeout.tail.small.test.ts
+++ b/apps/server/src/__tests__/tools/shell.timeout.tail.small.test.ts
@@ -24,7 +24,7 @@ describe('ShellTool timeout full inclusion when <=10k', () => {
     const provider = { provide: vi.fn(async () => fakeContainer) } as any;
     const tool = new ShellTool(undefined as any, logger);
     tool.setContainerProvider(provider);
-    await tool.setConfig({});
+    await tool.configure({});
     const t = tool.init();
 
     try {
@@ -42,4 +42,3 @@ describe('ShellTool timeout full inclusion when <=10k', () => {
     }
   });
 });
-

--- a/apps/server/src/agents/base.agent.ts
+++ b/apps/server/src/agents/base.agent.ts
@@ -48,6 +48,8 @@ export abstract class BaseAgent implements TriggerListener, StaticConfigurable, 
       timer?: NodeJS.Timeout;
     }
   > = new Map();
+  // Abort controllers per in-flight runId
+  private aborters: Map<string, AbortController> = new Map();
 
   get graph() {
     if (!this._graph) {
@@ -258,6 +260,9 @@ export abstract class BaseAgent implements TriggerListener, StaticConfigurable, 
       // Ensure no stale parts remain for these tokens in the buffer
       if (affected.length) this.buffer.dropTokens(thread, affected);
     } finally {
+      // Cleanup abort controller
+      const ac = this.aborters.get(s.inFlight?.runId || runId);
+      if (ac) this.aborters.delete(s.inFlight?.runId || runId);
       s.inFlight = undefined;
       s.running = false;
       this.startNext(thread);
@@ -269,6 +274,9 @@ export abstract class BaseAgent implements TriggerListener, StaticConfigurable, 
     const items = batch.map((msg) =>
       isSystemTrigger(msg) ? new SystemMessage(JSON.stringify(msg)) : new HumanMessage(JSON.stringify(msg)),
     );
+    // Attach abort signal for this run
+    const controller = new AbortController();
+    this.aborters.set(runId, controller);
     const response = (await this.graph.invoke(
       { messages: { method: 'append', items } },
       {
@@ -279,6 +287,7 @@ export abstract class BaseAgent implements TriggerListener, StaticConfigurable, 
           caller_agent: this as InjectionProvider,
           run_id: runId,
         },
+        signal: (controller as any).signal,
       },
     )) as { messages: BaseMessage[] };
     return response.messages?.[response.messages.length - 1];
@@ -315,9 +324,43 @@ export abstract class BaseAgent implements TriggerListener, StaticConfigurable, 
       }
       s.tokens.clear();
     }
+    // Abort any in-flight runs without waiting
+    for (const [, ac] of this.aborters) {
+      try { ac.abort(); } catch {}
+    }
+    this.aborters.clear();
     this.buffer.destroy();
     this.threads.clear();
   }
 
-  abstract setConfig(_cfg: Record<string, unknown>): void | Promise<void>;
+  abstract configure(_cfg: Record<string, unknown>): void | Promise<void>;
+
+  // Helper for subclasses to implement stop semantics: abort in-flight runs and drop queued messages.
+  protected abortAllRuns(): void {
+    for (const [thread, s] of this.threads) {
+      // Abort current run (if any)
+      const rid = s.inFlight?.runId;
+      if (rid) {
+        const ac = this.aborters.get(rid);
+        try {
+          ac?.abort();
+        } catch {}
+        // Reject affected tokens for this run
+        const affected = Array.from(s.inFlight!.includedCounts.keys());
+        for (const tokenId of affected) {
+          const token = s.tokens.get(tokenId);
+          if (!token) continue;
+          try { token.reject(new Error('aborted')); } catch {}
+          s.tokens.delete(tokenId);
+        }
+      }
+      // Drop any queued messages for this thread
+      this.buffer.dropTokens(thread, Array.from(s.tokens.keys()));
+      // Clear any remaining tokens
+      s.tokens.clear();
+      s.inFlight = undefined;
+      s.running = false;
+      if (s.timer) { clearTimeout(s.timer); s.timer = undefined; }
+    }
+  }
 }

--- a/apps/server/src/entities/containerProvider.entity.ts
+++ b/apps/server/src/entities/containerProvider.entity.ts
@@ -134,7 +134,7 @@ export class ContainerProviderEntity {
   }
 
   // Accept static configuration (image/env/initialScript). Validation performed via zod schema.
-  setConfig(cfg: Record<string, unknown>): void {
+  configure(cfg: Record<string, unknown>): void {
     try {
       const parsed = ContainerProviderStaticConfigSchema.parse(cfg);
       this.cfg = parsed;

--- a/apps/server/src/graph/capabilities.ts
+++ b/apps/server/src/graph/capabilities.ts
@@ -10,7 +10,7 @@ export interface Pausable {
 }
 
 export interface StaticConfigurable {
-  setConfig(cfg: Record<string, unknown>): Promise<void> | void;
+  configure(cfg: Record<string, unknown>): Promise<void> | void;
   getConfigSchema(): JSONSchema.BaseSchema;
 }
 

--- a/apps/server/src/graph/errors.ts
+++ b/apps/server/src/graph/errors.ts
@@ -54,10 +54,10 @@ export const Errors = {
       message: `Factory for node ${nodeId} requested dependency ${depId} before it was created (ensure ordering)`,
       nodeId,
     }),
-  missingSetConfig: (nodeId: string) =>
+  missingConfigure: (nodeId: string) =>
     new GraphError({
-      code: 'MISSING_SET_CONFIG',
-      message: `Config provided for node ${nodeId} but instance has no setConfig method`,
+      code: 'MISSING_CONFIGURE',
+      message: `Config provided for node ${nodeId} but instance has no configure method`,
       nodeId,
     }),
 };

--- a/apps/server/src/graph/liveGraph.manager.ts
+++ b/apps/server/src/graph/liveGraph.manager.ts
@@ -170,7 +170,7 @@ export class LiveGraphRuntime {
       const live = this.state.nodes.get(nodeId);
       if (!live) continue;
       try {
-        const setter = (live.instance as any)['setConfig'];
+        const setter = (live.instance as any)['configure'];
         if (typeof setter === 'function') await (setter as Function).call(live.instance, nodeDef.data.config || {});
         live.config = nodeDef.data.config || {};
       } catch (e) {
@@ -293,7 +293,7 @@ export class LiveGraphRuntime {
     const live: LiveNode = { id: node.id, template: node.data.template, instance: created, config: node.data.config };
     this.state.nodes.set(node.id, live);
     if (node.data.config) {
-      const setter = (created as any)['setConfig'];
+      const setter = (created as any)['configure'];
       if (typeof setter === 'function') await (setter as Function).call(created, node.data.config);
     }
     if (node.data.dynamicConfig) { // New block for dynamic config

--- a/apps/server/src/graph/types.ts
+++ b/apps/server/src/graph/types.ts
@@ -10,7 +10,7 @@ export interface NodeDef {
   id: string;
   data: {
     template: string; // template name registered in TemplateRegistry
-    config?: Record<string, unknown>; // optional configuration passed via instance.setConfig
+    config?: Record<string, unknown>; // optional configuration passed via instance.configure
     dynamicConfig?: Record<string, unknown>; // optional dynamic configuration passed via instance.setDynamicConfig
   };
 }
@@ -34,9 +34,9 @@ export interface FactoryContext {
   nodeId: string; // id of the node currently being instantiated (for namespacing / awareness)
 }
 
-// All factories must return a Configurable instance that implements setConfig
+// All factories must return a Configurable instance that implements configure
 export interface Configurable {
-  setConfig(cfg: Record<string, unknown>): void | Promise<void>;
+  configure(cfg: Record<string, unknown>): void | Promise<void>;
 }
 
 export type FactoryFn = (ctx: FactoryContext) => Configurable | Promise<Configurable>;
@@ -73,7 +73,7 @@ export type Endpoint = MethodEndpoint | PropertyEndpoint | SelfEndpoint;
 
 export interface GraphBuilderOptions {
   continueOnError?: boolean; // if true collects errors and proceeds, else fail-fast
-  warnOnMissingSetConfig?: boolean; // log / collect a warning when config provided but setConfig missing
+  warnOnMissingConfigure?: boolean; // log / collect a warning when config provided but configure missing
 }
 
 export interface GraphErrorDetails {

--- a/apps/server/src/mcp/localMcpServer.ts
+++ b/apps/server/src/mcp/localMcpServer.ts
@@ -135,7 +135,7 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
    * This is called during agent registration to discover available tools.
    */
   async discoverTools(): Promise<McpTool[]> {
-    if (!this.cfg) throw new Error('LocalMCPServer: config not yet set via setConfig');
+    if (!this.cfg) throw new Error('LocalMCPServer: config not yet set via configure');
     if (!this.containerProvider) throw new Error('LocalMCPServer: no containerProvider set; cannot discover tools');
     if (!this.cfg.command) throw new Error('LocalMCPServer: config.command is required for tool discovery');
 
@@ -276,7 +276,7 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
   }
 
   /** Update runtime configuration (only env/workdir/command currently applied to next restart). */
-  async setConfig(cfg: Record<string, unknown>): Promise<void> {
+  async configure(cfg: Record<string, unknown>): Promise<void> {
     const parsed = LocalMcpServerStaticConfigSchema.safeParse(cfg);
     if (!parsed.success) {
       this.logger.error(
@@ -302,7 +302,7 @@ export class LocalMCPServer implements McpServer, Provisionable, DynamicConfigur
     args: any,
     options?: { timeoutMs?: number; threadId?: string },
   ): Promise<McpToolCallResult> {
-    if (!this.cfg) throw new Error('LocalMCPServer: config not yet set via setConfig');
+    if (!this.cfg) throw new Error('LocalMCPServer: config not yet set via configure');
     if (!this.containerProvider) throw new Error('LocalMCPServer: no containerProvider set; cannot call tool');
 
     const threadId = options?.threadId;

--- a/apps/server/src/nodes/memory.connector.node.ts
+++ b/apps/server/src/nodes/memory.connector.node.ts
@@ -37,7 +37,7 @@ export class MemoryConnectorNode {
     this.setServiceFactory(source);
   }
 
-  setConfig(config: Partial<MemoryConnectorConfig> & Partial<MemoryConnectorStaticConfig>) {
+  configure(config: Partial<MemoryConnectorConfig> & Partial<MemoryConnectorStaticConfig>) {
     const next: Partial<MemoryConnectorConfig> = { ...this.config };
     if (config.placement !== undefined) next.placement = config.placement as any;
     if (config.content !== undefined) next.content = config.content as any;

--- a/apps/server/src/nodes/memory.node.ts
+++ b/apps/server/src/nodes/memory.node.ts
@@ -26,7 +26,7 @@ export class MemoryNode {
   constructor(private db: Db, private nodeId: string, private config: MemoryNodeConfig) {}
 
   // Accept either internal config shape or static schema shape; map 'thread' -> 'perThread'.
-  setConfig(config: Partial<MemoryNodeConfig> & Partial<MemoryNodeStaticConfig>) {
+  configure(config: Partial<MemoryNodeConfig> & Partial<MemoryNodeStaticConfig>) {
     const next: Partial<MemoryNodeConfig> = { ...this.config };
     if (config.scope !== undefined) {
       const scopeVal = (config as any).scope;

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -179,7 +179,7 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
         'slackTrigger',
         () => {
           const instance = new SlackTrigger(logger, vault);
-          void instance.start();
+          // Factories must not call lifecycle methods
           return instance;
         },
         {
@@ -233,7 +233,7 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
         'mcpServer',
         () => {
           const server = new LocalMCPServer(containerService, logger);
-          void server.start();
+          // Factories must not call lifecycle methods
           return server;
         },
         {

--- a/apps/server/src/tools/call_agent.tool.ts
+++ b/apps/server/src/tools/call_agent.tool.ts
@@ -47,7 +47,7 @@ export class CallAgentTool extends BaseTool {
     this.targetAgent = agent;
   }
 
-  async setConfig(cfg: Record<string, unknown>): Promise<void> {
+  async configure(cfg: Record<string, unknown>): Promise<void> {
     const parsed = CallAgentToolStaticConfigSchema.safeParse(cfg);
     if (!parsed.success) {
       throw new Error('Invalid CallAgentTool config');

--- a/apps/server/src/tools/github_clone_repo.ts
+++ b/apps/server/src/tools/github_clone_repo.ts
@@ -130,7 +130,7 @@ export class GithubCloneRepoTool extends BaseTool {
     );
   }
 
-  async setConfig(_cfg: Record<string, unknown>): Promise<void> {
+  async configure(_cfg: Record<string, unknown>): Promise<void> {
     const parsed = GithubCloneRepoToolStaticConfigSchema.parse(_cfg || {});
     this.authRef = parsed.authRef;
     this.token = parsed.token;

--- a/apps/server/src/tools/memory/memory.tool.ts
+++ b/apps/server/src/tools/memory/memory.tool.ts
@@ -44,7 +44,7 @@ export class UnifiedMemoryTool extends MemoryToolBase {
     super(logger);
   }
 
-  // Default metadata; can be overridden by setConfig
+  // Default metadata; can be overridden by configure
   private description: string = 'Unified Memory tool: read, list, append, update, delete';
   private name: string | undefined;
   // UI-only; stored for completeness
@@ -83,7 +83,7 @@ export class UnifiedMemoryTool extends MemoryToolBase {
     return { message, code };
   }
 
-  async setConfig(cfg: Record<string, unknown>): Promise<void> {
+  async configure(cfg: Record<string, unknown>): Promise<void> {
     const parsed = UnifiedMemoryToolNodeStaticConfigSchema.safeParse(cfg);
     if (!parsed.success) {
       throw new Error('Invalid Memory tool config');

--- a/apps/server/src/tools/send_slack_message.tool.ts
+++ b/apps/server/src/tools/send_slack_message.tool.ts
@@ -103,7 +103,7 @@ export class SendSlackMessageTool extends BaseTool {
     );
   }
 
-  async setConfig(_cfg: Record<string, unknown>): Promise<void> {
+  async configure(_cfg: Record<string, unknown>): Promise<void> {
     // Validate and apply static config
     const parsed = SendSlackMessageToolStaticConfigSchema.parse(_cfg || {});
     const bot = normalizeTokenRef(parsed.bot_token as any);

--- a/apps/server/src/tools/shell_command.ts
+++ b/apps/server/src/tools/shell_command.ts
@@ -125,7 +125,7 @@ export class ShellTool extends BaseTool {
     );
   }
 
-  async setConfig(_cfg: Record<string, unknown>): Promise<void> {
+  async configure(_cfg: Record<string, unknown>): Promise<void> {
     const parsed = ShellToolStaticConfigSchema.safeParse(_cfg);
     if (!parsed.success) throw new Error(`Invalid Shell tool config: ${parsed.error.message}`);
     this.cfg = parsed.data;

--- a/apps/server/src/triggers/debugTool.trigger.ts
+++ b/apps/server/src/triggers/debugTool.trigger.ts
@@ -24,7 +24,7 @@ export class DebugToolTrigger extends BaseTrigger {
     this.tool = tool || null;
   }
 
-  async setConfig(cfg: Record<string, unknown>): Promise<void> {
+  async configure(cfg: Record<string, unknown>): Promise<void> {
     const parsed = DebugToolTriggerStaticConfigSchema.safeParse(cfg);
     if (!parsed.success) throw new Error('Invalid DebugToolTrigger config');
     this.cfg = parsed.data;

--- a/apps/server/src/triggers/slack.trigger.ts
+++ b/apps/server/src/triggers/slack.trigger.ts
@@ -46,7 +46,7 @@ export class SlackTrigger extends BaseTrigger {
     this.vault = vault;
   }
 
-  async setConfig(cfg: Record<string, unknown>): Promise<void> {
+  async configure(cfg: Record<string, unknown>): Promise<void> {
     const parsed = SlackTriggerStaticConfigSchema.parse(cfg || {});
     // Normalize to { value, source }
     const appToken = normalizeTokenRef(parsed.app_token as any);

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
     - whenBusy: 'wait' queues new messages; 'injectAfterTools' injects them into the current run after the tools stage.
     - processBuffer: 'allTogether' drains all queued messages; 'oneByOne' processes one message per run.
   - Defaults: `debounceMs=0`, `whenBusy='wait'`, `processBuffer='allTogether'`.
-  - Changes made via `setConfig({...})` apply immediately at runtime without a restart; the agent updates scheduling and summarization behavior in-place.
+  - Changes made via `configure({...})` apply immediately at runtime without a restart; the agent updates scheduling and summarization behavior in-place.
 
 ## Invoke Resolution Semantics
 

--- a/docs/graph/status-updates.md
+++ b/docs/graph/status-updates.md
@@ -41,7 +41,7 @@ Each template now advertises its capabilities and optional static configuration 
 
 - `capabilities.pausable`: Node supports pause/resume (triggers, agents).
 - `capabilities.provisionable`: Node exposes provision/deprovision lifecycle (Slack trigger, MCP server).
-- `capabilities.staticConfigurable`: Node accepts an initial static config that is applied through `setConfig` (agent, container provider, call_agent tool, MCP server).
+- `capabilities.staticConfigurable`: Node accepts an initial static config that is applied through `configure` (agent, container provider, call_agent tool, MCP server).
 - `capabilities.dynamicConfigurable`: Node exposes a dynamic runtime config surface (MCP server tool enable/disable) once `dynamicConfigReady` is true.
 
 Static config schemas (all templates now expose one – some are currently empty placeholders to allow forward-compatible UI forms):
@@ -52,6 +52,6 @@ Static config schemas (all templates now expose one – some are currently empty
 - `shellTool`: (empty object for now).
 - `githubCloneRepoTool`: (empty object for now).
 - `sendSlackMessageTool`: (empty object for now).
-- `slackTrigger`: debounceMs, waitForBusy (note: presently setConfig is a no-op; values must be supplied at creation time until runtime reconfiguration is implemented).
+- `slackTrigger`: debounceMs, waitForBusy (note: presently configure is a no-op; values must be supplied at creation time until runtime reconfiguration is implemented).
 
 Dynamic config (currently only MCP server) becomes available after initial tool discovery; UI should check `dynamicConfigReady` before rendering its form.

--- a/docs/summarization.md
+++ b/docs/summarization.md
@@ -23,7 +23,7 @@ Budgeting and trimming
 - countTokens() uses llm.getNumTokens() and is used by shouldSummarize() to determine whether to summarize.
 
 Configuration
-- SimpleAgent.setConfig accepts:
+- SimpleAgent.configure accepts:
   - summarizationKeepLast: integer >= 0
   - summarizationMaxTokens: integer > 0
 - When both are set, SummarizationNode performs summarization and stores trimmed context into state.messages.
@@ -31,7 +31,7 @@ Configuration
 
 Examples
 - Configure at runtime:
-  agent.setConfig({ summarizationKeepLast: 4, summarizationMaxTokens: 4096 });
+  agent.configure({ summarizationKeepLast: 4, summarizationMaxTokens: 4096 });
 
 Notes
 - Summary is stored in the agent state, default ''.


### PR DESCRIPTION
Implements Phase 2 of the refactor epic.\n\nChanges\n- Global rename setConfig→configure across server tests/docs and runtime usage.\n- Runtime continues to call configure only.\n- SimpleAgent conforms to Node lifecycle: start (build/compile after wiring), stop (abort in-flight runs), delete (detach MCP servers and memory connectors, then cleanup).\n- Factories remain pure; no lifecycle calls in templates.\n\nNotes\n- No back-compat, no aliases, no fallbacks.\n- Please run full CI; I will iterate on failures in this branch.\n\nRefs\n- Epic branch: refactoring\n- Issue: #178