### PR TITLE
Phase 2: Node lifecycle for domain nodes (Memory + Connector); orchestrator integration

### DIFF
--- a/apps/server/__tests__/e2e/memory.tools.mongo.e2e.test.ts
+++ b/apps/server/__tests__/e2e/memory.tools.mongo.e2e.test.ts
@@ -32,7 +32,7 @@ describe.skipIf(!RUN_MONGOMS)('E2E: memory tools with real MongoDB (mongodb-memo
   describe('append', () => {
     it('should store data for new path', async () => {
       const db = client.db('test');
-      const memNode = new MemoryNode(db as any, 'node-1', { scope: 'global' });
+      const memNode = new MemoryNode(db as any, 'node-1');
 
       const unifiedInst = new UnifiedMemoryTool(logger);
       unifiedInst.setMemorySource(memNode);
@@ -49,7 +49,7 @@ describe.skipIf(!RUN_MONGOMS)('E2E: memory tools with real MongoDB (mongodb-memo
 
     it('should append and not overwrite existing data', async () => {
       const db = client.db('test');
-      const memNode = new MemoryNode(db as any, 'node-1', { scope: 'global' });
+      const memNode = new MemoryNode(db as any, 'node-1');
 
       const unifiedInst = new UnifiedMemoryTool(logger);
       unifiedInst.setMemorySource(memNode);
@@ -70,7 +70,7 @@ describe.skipIf(!RUN_MONGOMS)('E2E: memory tools with real MongoDB (mongodb-memo
   describe('list/read/update/delete', () => {
     it('should list directory entries after multiple appends', async () => {
       const db = client.db('test');
-      const memNode = new MemoryNode(db as any, 'node-lrud-1', { scope: 'global' });
+      const memNode = new MemoryNode(db as any, 'node-lrud-1');
 
       const unifiedInst = new UnifiedMemoryTool(logger); unifiedInst.setMemorySource(memNode); const unified = unifiedInst.init();
       const cfg = { configurable: { thread_id: 'debug' } } as any;
@@ -86,7 +86,7 @@ describe.skipIf(!RUN_MONGOMS)('E2E: memory tools with real MongoDB (mongodb-memo
 
     it('should read, update occurrences, and then delete a file', async () => {
       const db = client.db('test');
-      const memNode = new MemoryNode(db as any, 'node-lrud-2', { scope: 'global' });
+      const memNode = new MemoryNode(db as any, 'node-lrud-2');
       const unifiedInst = new UnifiedMemoryTool(logger); unifiedInst.setMemorySource(memNode); const unified = unifiedInst.init();
 
       const cfg = { configurable: { thread_id: 'debug' } } as any;

--- a/apps/server/__tests__/lifecycle.runtime.integration.test.ts
+++ b/apps/server/__tests__/lifecycle.runtime.integration.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TemplateRegistry } from '../src/graph/templateRegistry';
+import { LiveGraphRuntime } from '../src/graph/liveGraph.manager';
+import { LoggerService } from '../src/services/logger.service';
+import type { GraphDefinition } from '../src/graph/types';
+import type { NodeLifecycle } from '../src/nodes/types';
+
+class LifeNode implements NodeLifecycle<{ a?: number }> {
+  public calls: string[] = [];
+  configure(_cfg: { a?: number }) { this.calls.push('configure'); }
+  start() { this.calls.push('start'); }
+  stop() { this.calls.push('stop'); }
+  delete() { this.calls.push('delete'); }
+}
+
+describe('LiveGraphRuntime lifecycle integration', () => {
+  it('calls configure+start on create and stop+delete on removal', async () => {
+    const templates = new TemplateRegistry();
+    templates.register('Life', () => new LifeNode());
+    const runtime = new LiveGraphRuntime(new LoggerService(), templates);
+
+    const g1: GraphDefinition = { nodes: [{ id: 'n1', data: { template: 'Life', config: { a: 1 } } }], edges: [] };
+    await runtime.apply(g1);
+    const inst = runtime.getNodeInstance<LifeNode>('n1')!;
+    expect(inst.calls.slice(0,2)).toEqual(['configure','start']);
+
+    // Update (configure only)
+    await runtime.apply({ nodes: [{ id: 'n1', data: { template: 'Life', config: { a: 2 } } }], edges: [] });
+    expect(inst.calls).toContain('configure');
+
+    // Remove; should stop+delete
+    await runtime.apply({ nodes: [], edges: [] });
+    expect(inst.calls.includes('stop')).toBe(true);
+    expect(inst.calls.includes('delete')).toBe(true);
+  });
+});
+

--- a/apps/server/__tests__/memory.runtime.integration.test.ts
+++ b/apps/server/__tests__/memory.runtime.integration.test.ts
@@ -59,8 +59,9 @@ function makeRuntime(db: Db, placement: 'after_system'|'last_message') {
       const mod = await import('../src/nodes/memory.connector.node');
       const MemoryConnectorNode = mod.MemoryConnectorNode;
       const factory = (opts: { threadId?: string }) => new MemoryService(db, ctx.nodeId, opts.threadId ? 'perThread' : 'global', opts.threadId);
-      // Return the connector instance directly so it can be wired into CallModel.setMemoryConnector
-      return new MemoryConnectorNode(factory, { placement, content: 'tree', maxChars: 4000 }) as any;
+      const n = new MemoryConnectorNode(factory);
+      n.configure({ placement, content: 'tree', maxChars: 4000 });
+      return n as any;
     },
     { sourcePorts: { $self: { kind: 'instance' } } },
     { title: 'Memory', kind: 'tool' },
@@ -159,7 +160,9 @@ describe.skipIf(!RUN_MONGOMS)('Runtime integration: memory injection via LiveGra
         const mod = await import('../src/nodes/memory.connector.node');
         const MemoryConnectorNode = mod.MemoryConnectorNode;
         const factory = (opts: { threadId?: string }) => new MemoryService(db, ctx.nodeId, opts.threadId ? 'perThread' : 'global', opts.threadId);
-        return new MemoryConnectorNode(factory, { placement: 'after_system', content: 'full', maxChars: 20 }) as any;
+        const n = new MemoryConnectorNode(factory);
+        n.configure({ placement: 'after_system', content: 'full', maxChars: 20 });
+        return n as any;
       },
       { sourcePorts: { $self: { kind: 'instance' } } },
       { title: 'Memory', kind: 'tool' },

--- a/apps/server/src/nodes/index.ts
+++ b/apps/server/src/nodes/index.ts
@@ -1,2 +1,3 @@
 export * from './memory.node';
 export * from './memory.connector.node';
+export * from './types';

--- a/apps/server/src/nodes/memory.connector.node.ts
+++ b/apps/server/src/nodes/memory.connector.node.ts
@@ -54,7 +54,7 @@ export class MemoryConnectorNode implements NodeLifecycle<Partial<MemoryConnecto
 
   async start(): Promise<void> { /* no-op */ }
   async stop(): Promise<void> { /* no-op */ }
-  async destroy(): Promise<void> { /* no-op */ }
+  async delete(): Promise<void> { /* no-op */ }
 
   getPlacement(): MemoryConnectorConfig['placement'] {
     return this.config.placement;

--- a/apps/server/src/nodes/memory.node.ts
+++ b/apps/server/src/nodes/memory.node.ts
@@ -46,7 +46,7 @@ export class MemoryNode implements NodeLifecycle<Partial<MemoryNodeConfig> & Par
 
   async start(): Promise<void> { /* no-op */ }
   async stop(): Promise<void> { /* no-op */ }
-  async destroy(): Promise<void> { /* no-op */ }
+  async delete(): Promise<void> { /* no-op */ }
 
   getMemoryService(opts: { threadId?: string }): MemoryService {
     const threadId = this.config.scope === 'perThread' ? opts.threadId : undefined;

--- a/apps/server/src/nodes/memory.node.ts
+++ b/apps/server/src/nodes/memory.node.ts
@@ -1,6 +1,7 @@
 import { Db } from 'mongodb';
 import { z } from 'zod';
 import { MemoryService, MemoryScope } from '../services/memory.service';
+import type { NodeLifecycle } from './types';
 
 export interface MemoryNodeConfig {
   scope: MemoryScope; // 'global' | 'perThread'
@@ -22,11 +23,17 @@ export type MemoryNodeStaticConfig = z.infer<typeof MemoryNodeStaticConfigSchema
  * MemoryNode factory returns an accessor to build a MemoryService scoped to the node and thread.
  * Inject Db from MongoService.getDb() at template wiring time.
  */
-export class MemoryNode {
-  constructor(private db: Db, private nodeId: string, private config: MemoryNodeConfig) {}
+export class MemoryNode implements NodeLifecycle<Partial<MemoryNodeConfig> & Partial<MemoryNodeStaticConfig>> {
+  constructor(private db: Db, private nodeId: string) {}
+
+  private config: MemoryNodeConfig = { scope: 'global' };
 
   // Accept either internal config shape or static schema shape; map 'thread' -> 'perThread'.
   setConfig(config: Partial<MemoryNodeConfig> & Partial<MemoryNodeStaticConfig>) {
+    this.configure(config);
+  }
+
+  configure(config: Partial<MemoryNodeConfig> & Partial<MemoryNodeStaticConfig>) {
     const next: Partial<MemoryNodeConfig> = { ...this.config };
     if (config.scope !== undefined) {
       const scopeVal = (config as any).scope;
@@ -36,6 +43,10 @@ export class MemoryNode {
     // title is UI-only; accept and ignore for runtime behavior
     this.config = { ...this.config, ...next } as MemoryNodeConfig;
   }
+
+  async start(): Promise<void> { /* no-op */ }
+  async stop(): Promise<void> { /* no-op */ }
+  async destroy(): Promise<void> { /* no-op */ }
 
   getMemoryService(opts: { threadId?: string }): MemoryService {
     const threadId = this.config.scope === 'perThread' ? opts.threadId : undefined;

--- a/apps/server/src/nodes/types.ts
+++ b/apps/server/src/nodes/types.ts
@@ -6,9 +6,6 @@ export interface NodeLifecycle<Config = Record<string, unknown>> {
   delete(): Promise<void> | void;
 }
 
-export function isNodeLifecycle(obj: unknown): obj is NodeLifecycle<any> {
-  return !!obj && typeof (obj as any).configure === 'function';
-}
 
 export function isNodeLifecycle(obj: unknown): obj is NodeLifecycle<Record<string, unknown>> {
   if (!obj || typeof obj !== 'object') return false;

--- a/apps/server/src/nodes/types.ts
+++ b/apps/server/src/nodes/types.ts
@@ -1,0 +1,12 @@
+// NodeLifecycle interface and guard
+export interface NodeLifecycle<Config = Record<string, unknown>> {
+  configure(cfg: Config): Promise<void> | void;
+  start(): Promise<void> | void;
+  stop(): Promise<void> | void;
+  delete(): Promise<void> | void;
+}
+
+export function isNodeLifecycle(obj: unknown): obj is NodeLifecycle<any> {
+  return !!obj && typeof (obj as any).configure === 'function';
+}
+

--- a/apps/server/src/nodes/types.ts
+++ b/apps/server/src/nodes/types.ts
@@ -10,3 +10,13 @@ export function isNodeLifecycle(obj: unknown): obj is NodeLifecycle<any> {
   return !!obj && typeof (obj as any).configure === 'function';
 }
 
+export function isNodeLifecycle(obj: unknown): obj is NodeLifecycle<Record<string, unknown>> {
+  if (!obj || typeof obj !== 'object') return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    typeof o['configure'] === 'function' &&
+    typeof o['start'] === 'function' &&
+    typeof o['stop'] === 'function' &&
+    typeof o['delete'] === 'function'
+  );
+}

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -272,7 +272,7 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
         'memory',
         (ctx) => {
           const db = mongoService.getDb();
-          return new MemoryNode(db, ctx.nodeId, { scope: 'global' });
+          return new MemoryNode(db, ctx.nodeId);
         },
         {
           // Expose only $self for instance wiring
@@ -292,7 +292,6 @@ export function buildTemplateRegistry(deps: TemplateRegistryDeps): TemplateRegis
             () => {
               throw new Error('MemoryConnectorNode: memory factory not set');
             },
-            { placement: 'after_system', content: 'tree', maxChars: 4000 },
           ),
         {
           // Accept memory source (node or factory) from Memory node; expose self to Agent

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -48,3 +48,22 @@ Docs
 Docs
 - Custom ConfigViews use shadcn/ui primitives and a typed registry. See docs/ui/config-views.md
 - Actions are optimistic; authoritative socket events reconcile cache.
+
+Routing (Issue #285)
+- Client routing via react-router-dom; default redirect to /agents/graph and 404 fallback to /agents/graph.
+- Root layout includes persistent left sidebar on desktop (md+) and Drawer on mobile.
+- Collapse toggle and per-section open states persist in localStorage.
+  - Keys:
+    - ui.sidebar.collapsed
+    - ui.sidebar.section.agents.open
+    - ui.sidebar.section.tracing.open
+    - ui.sidebar.section.monitoring.open
+    - ui.sidebar.section.settings.open
+- Routes:
+  - Agents → Graph (/agents/graph) renders AgentBuilder
+  - Agents → Chat (/agents/chat) placeholder
+  - Tracing → Traces (/tracing/traces) placeholder
+  - Tracing → Errors (/tracing/errors) placeholder
+  - Monitoring → Containers (/monitoring/containers) placeholder
+  - Monitoring → Resources (/monitoring/resources) placeholder
+  - Settings → Secrets (/settings/secrets) placeholder

--- a/apps/ui/__tests__/components/builder/AgentBuilder.smoke.test.tsx
+++ b/apps/ui/__tests__/components/builder/AgentBuilder.smoke.test.tsx
@@ -42,7 +42,7 @@ describe('AgentBuilder smoke render', () => {
     );
 
     // Basic UI appears; if TDZ occurs, render would throw before this
-    await waitFor(() => expect(screen.getByTestId('add-node-button')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('builder-toolbar')).toBeInTheDocument());
     // Right panel header present (no selection initially)
     expect(screen.getByText('No Selection')).toBeInTheDocument();
 

--- a/apps/ui/__tests__/components/builder/Toolbar.popover.a11y.dnd.test.tsx
+++ b/apps/ui/__tests__/components/builder/Toolbar.popover.a11y.dnd.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { beforeAll, afterAll, afterEach, describe, it, expect } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server, TestProviders } from '../../integration/testUtils';
+import { TooltipProvider } from '@hautech/ui';
+import { AgentBuilder } from '../../../src/builder/AgentBuilder';
+
+describe('Builder toolbar + popover + DnD', () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  function mockApi() {
+    server.use(
+      http.get('/api/templates', () =>
+        HttpResponse.json([
+          { name: 'agent.basic', title: 'Agent', kind: 'agent', sourcePorts: [], targetPorts: [] },
+          { name: 'tool.basic', title: 'Tool', kind: 'tool', sourcePorts: [], targetPorts: [] },
+        ]),
+      ),
+      http.get('/api/graph', () =>
+        HttpResponse.json({ name: 'g', version: 1, nodes: [], edges: [] }),
+      ),
+      http.post('/api/graph', () => HttpResponse.json({ version: 2, updatedAt: new Date().toISOString() })),
+    );
+  }
+
+  it('renders floating toolbar and opens popover with animation state classes', async () => {
+    mockApi();
+    render(
+      <TestProviders>
+        <TooltipProvider>
+          <AgentBuilder />
+        </TooltipProvider>
+      </TestProviders>,
+    );
+    const toolbar = await screen.findByTestId('builder-toolbar');
+    expect(toolbar).toBeInTheDocument();
+    // Pointer-events overlay vs toolbar
+    const overlay = toolbar.parentElement as HTMLElement;
+    expect(overlay.className).toContain('pointer-events-none');
+    expect(toolbar.className).toContain('pointer-events-auto');
+
+    // Open popover
+    const addBtn = screen.getByTestId('add-node-button');
+    fireEvent.click(addBtn);
+
+    // Content appears with data-state attributes driving classes (from @hautech/ui wrapper)
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog.getAttribute('data-state')).toBe('open');
+  });
+
+  it('supports keyboard navigation and insert on Enter', async () => {
+    mockApi();
+    render(
+      <TestProviders>
+        <TooltipProvider>
+          <AgentBuilder />
+        </TooltipProvider>
+      </TestProviders>,
+    );
+    fireEvent.click(await screen.findByTestId('add-node-button'));
+    await screen.findByRole('dialog');
+    const options = await screen.findAllByRole('option');
+    // Ensure real focus is placed on the first option before keyboarding
+    const first = options[0] as HTMLElement;
+    first.focus();
+    expect(first).toHaveFocus();
+    // ArrowDown then Enter
+    fireEvent.keyDown(first, { key: 'ArrowDown' });
+    fireEvent.keyDown(first, { key: 'Enter' });
+    // After insert, popover transitions to closed state (forceMounted)
+    await waitFor(() => {
+      const dlg = screen.getByRole('dialog');
+      expect(dlg.getAttribute('data-state')).toBe('closed');
+    });
+    expect(screen.getByTestId('add-node-button')).toHaveFocus();
+  });
+
+  it('list items are DnD sources (data-testid present) and click insert works', async () => {
+    mockApi();
+    render(
+      <TestProviders>
+        <TooltipProvider>
+          <AgentBuilder />
+        </TooltipProvider>
+      </TestProviders>,
+    );
+    fireEvent.click(await screen.findByTestId('add-node-button'));
+    const item = await screen.findByTestId('template-agent.basic');
+    expect(item).toBeInTheDocument();
+    expect(item).toHaveAttribute('draggable', 'true');
+    fireEvent.click(item);
+    await waitFor(() => {
+      const dlg = screen.getByRole('dialog');
+      expect(dlg.getAttribute('data-state')).toBe('closed');
+    });
+  });
+});

--- a/apps/ui/__tests__/integration/testUtils.tsx
+++ b/apps/ui/__tests__/integration/testUtils.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TemplatesProvider } from '../../src/lib/graph/templates.provider';
 import * as socketModule from '../../src/lib/graph/socket';
 import type { NodeStatusEvent, TemplateSchema } from '../../src/lib/graph/types';
+import { TooltipProvider } from '@hautech/ui';
 
 // Mock socket emitter
 export const emitted: Array<NodeStatusEvent> = [];
@@ -68,7 +69,10 @@ export function TestProviders({ children }: { children: React.ReactNode }) {
   const qc = new QueryClient();
   return (
     <QueryClientProvider client={qc}>
-      <TemplatesProvider>{children}</TemplatesProvider>
+      {/* Match app root providers; ensure tooltip context exists in tests */}
+      <TooltipProvider delayDuration={0}>
+        <TemplatesProvider>{children}</TemplatesProvider>
+      </TooltipProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "react-router-dom": "^6.27.0",
     "@hautech/ui": "workspace:*",
     "date-fns": "^3.6.0",
     "@radix-ui/react-slot": "^1.2.3",

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -7,6 +7,14 @@ import { AgentBuilder } from './builder/AgentBuilder';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // Runtime graph templates provider (distinct from builder TemplatesProvider)
 import { TemplatesProvider as RuntimeTemplatesProvider } from './lib/graph/templates.provider';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { RootLayout } from './layout/RootLayout';
+import { AgentsChat } from './pages/AgentsChat';
+import { TracingTraces } from './pages/TracingTraces';
+import { TracingErrors } from './pages/TracingErrors';
+import { MonitoringContainers } from './pages/MonitoringContainers';
+import { MonitoringResources } from './pages/MonitoringResources';
+import { SettingsSecrets } from './pages/SettingsSecrets';
 
 const queryClient = new QueryClient();
 
@@ -14,7 +22,29 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <RuntimeTemplatesProvider>
-        <AgentBuilder />
+        <Routes>
+          {/* Index and 404 fallback redirect */}
+          <Route path="/" element={<Navigate to="/agents/graph" replace />} />
+          <Route path="*" element={<Navigate to="/agents/graph" replace />} />
+
+          {/* Root layout wraps all primary routes */}
+          <Route element={<RootLayout />}>
+            {/* Agents */}
+            <Route path="/agents/graph" element={<AgentBuilder />} />
+            <Route path="/agents/chat" element={<AgentsChat />} />
+
+            {/* Tracing */}
+            <Route path="/tracing/traces" element={<TracingTraces />} />
+            <Route path="/tracing/errors" element={<TracingErrors />} />
+
+            {/* Monitoring */}
+            <Route path="/monitoring/containers" element={<MonitoringContainers />} />
+            <Route path="/monitoring/resources" element={<MonitoringResources />} />
+
+            {/* Settings */}
+            <Route path="/settings/secrets" element={<SettingsSecrets />} />
+          </Route>
+        </Routes>
       </RuntimeTemplatesProvider>
     </QueryClientProvider>
   );

--- a/apps/ui/src/builder/AgentBuilder.tsx
+++ b/apps/ui/src/builder/AgentBuilder.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useMemo, useState, useEffect } from 'react';
+import { useCallback, useRef, useMemo, useState, useEffect, forwardRef } from 'react';
 import ReactFlow, {
   Background,
   Controls,
@@ -16,19 +16,20 @@ import 'reactflow/dist/style.css';
 import { DndProvider, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { DND_ITEM_NODE } from './dnd';
+import type { DragItem } from './dnd';
 import { makeNodeTypes } from './nodeTypes';
 import { TemplatesProvider } from './TemplatesProvider';
 import type { NodeTypes } from 'reactflow';
 import { NodeObsSidebar } from '@/components/graph/NodeObsSidebar';
 import { RightPropertiesPanel } from './panels/RightPropertiesPanel';
 import { useBuilderState } from './hooks/useBuilderState';
-import type { BuilderNodeKind } from './types';
 import type { TemplateNodeSchema } from 'shared';
 import { getDisplayTitle } from './lib/display';
 import { Button, Popover, PopoverTrigger, PopoverContent, ScrollArea, Card } from '@hautech/ui';
-import { Plus } from 'lucide-react';
+import { Plus, Bot, Wrench, Zap } from 'lucide-react';
 import { kindBadgeClasses, kindLabel } from './lib/display';
 import { SaveStatusIndicator } from './SaveStatusIndicator';
+import { useDrag } from 'react-dnd';
 
 interface CanvasAreaProps {
   nodes: RFNode[];
@@ -36,7 +37,7 @@ interface CanvasAreaProps {
   onNodesChange: (changes: NodeChange[]) => void;
   onEdgesChange: (changes: EdgeChange[]) => void;
   onConnect: OnConnect;
-  addNode: (kind: BuilderNodeKind, position: { x: number; y: number }) => void;
+  addNode: (template: string, position: { x: number; y: number }) => void;
   deleteSelected: () => void;
   nodeTypes: NodeTypes; // reactflow's NodeTypes value type
   templates: TemplateNodeSchema[];
@@ -58,16 +59,21 @@ function CanvasArea({
   const flowWrapper = useRef<HTMLDivElement | null>(null);
   const reactFlow = useReactFlow();
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [isAnyDragging, setIsAnyDragging] = useState(false);
 
-  const [{ isOver }, dropRef] = useDrop(
+  const [{ isOver }, dropRef] = useDrop<DragItem, { inserted: boolean }, { isOver: boolean }>(
     () => ({
       accept: DND_ITEM_NODE,
-      drop: (item: { kind: BuilderNodeKind }, monitor) => {
+      drop: (item, monitor) => {
         const client = monitor.getClientOffset();
-        if (!client || !flowWrapper.current) return;
+        if (!client || !flowWrapper.current) return undefined;
         const bounds = flowWrapper.current.getBoundingClientRect();
         const position = reactFlow.project({ x: client.x - bounds.left, y: client.y - bounds.top });
-        addNode(item.kind, position);
+        const templateName = item.template; // always use item.template; no legacy fallback
+        if (!templateName) return undefined;
+        addNode(templateName, position);
+        return { inserted: true };
       },
       collect: (monitor) => ({ isOver: monitor.isOver() }),
     }),
@@ -129,53 +135,247 @@ function CanvasArea({
         <SaveStatusIndicator state={saveState} />
       </div>
 
-      {/* Bottom-center add button and popover */}
+      {/* Bottom-center floating toolbar and popover */}
       <div className="pointer-events-none absolute bottom-4 left-1/2 z-10 -translate-x-1/2">
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover
+          open={open}
+          onOpenChange={(v) => {
+            setOpen(v);
+            if (!v) setTimeout(() => triggerRef.current?.focus(), 0);
+          }}
+        >
           <PopoverTrigger asChild>
-            <Button
-              variant="default"
-              size="icon"
-              type="button"
-              aria-label="Add node"
-              className="pointer-events-auto"
-              data-testid="add-node-button"
+            <div
+              role="toolbar"
+              aria-label="Builder toolbar"
+              className="pointer-events-auto inline-flex items-center gap-1 rounded-full border bg-background/95 shadow-lg backdrop-blur px-2 py-1"
+              data-testid="builder-toolbar"
             >
-              <Plus />
-            </Button>
+              <Button
+                ref={triggerRef}
+                variant="default"
+                size="sm"
+                type="button"
+                aria-label="Add node"
+                className="h-8 w-8 rounded-full"
+                data-testid="add-node-button"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
           </PopoverTrigger>
-          <PopoverContent side="top" align="center" className="w-[720px] max-w-[90vw] p-2" aria-labelledby="add-node-title">
+          <PopoverContent
+            forceMount
+            side="top"
+            align="center"
+            sideOffset={8}
+            onInteractOutside={(e) => {
+              // Keep popover open during active drags from its content
+              if (isAnyDragging) e.preventDefault();
+            }}
+            className="w-[560px] max-w-[90vw] p-2"
+            aria-labelledby="add-node-title"
+          >
             <h2 id="add-node-title" className="sr-only">Add node</h2>
-            <ScrollArea className="max-h-[60vh]">
-              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-2 p-1">
-                {templates.map((tpl) => (
-                  <Card key={tpl.name} className="p-0">
-                    <button
-                      type="button"
-                      className="w-full rounded-lg p-3 text-left outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:border-ring hover:bg-accent hover:text-accent-foreground"
-                      onClick={() => {
-                        insertAtViewportCenter(tpl.name);
-                        setOpen(false);
-                      }}
-                      aria-label={`Insert ${tpl.title || tpl.name}`}
-                      data-testid={`template-${tpl.name}`}
-                    >
-                      <div className="flex items-center gap-2">
-                        <span className={`inline-block rounded px-1.5 py-0.5 text-[10px] leading-none ${kindBadgeClasses(tpl.kind)}`}>
-                          {kindLabel(tpl.kind)}
-                        </span>
-                        <span className="text-sm font-medium text-primary">{tpl.title || tpl.name}</span>
-                      </div>
-                    </button>
-                  </Card>
-                ))}
-              </div>
-            </ScrollArea>
+            <PopoverList
+              templates={templates}
+              onInsert={(tplName) => {
+                insertAtViewportCenter(tplName);
+                setOpen(false);
+                triggerRef.current?.focus();
+              }}
+              onDropSuccess={() => {
+                setOpen(false);
+                triggerRef.current?.focus();
+              }}
+              setAnyDragging={setIsAnyDragging}
+              onRequestClose={() => {
+                setOpen(false);
+                triggerRef.current?.focus();
+              }}
+            />
           </PopoverContent>
         </Popover>
       </div>
     </div>
   );
+}
+
+function PopoverList({
+  templates,
+  onInsert,
+  onDropSuccess,
+  setAnyDragging,
+  onRequestClose,
+}: {
+  templates: TemplateNodeSchema[];
+  onInsert: (templateName: string) => void;
+  onDropSuccess: () => void;
+  setAnyDragging: (dragging: boolean) => void;
+  onRequestClose: () => void;
+}) {
+  // Roving focus management
+  const [activeIndex, setActiveIndex] = useState(0);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    // Keep refs array length in sync
+    itemRefs.current = itemRefs.current.slice(0, templates.length);
+  }, [templates.length]);
+
+  // Focus first option when the list appears
+  useEffect(() => {
+    itemRefs.current[activeIndex]?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = (activeIndex + 1) % templates.length;
+      setActiveIndex(next);
+      itemRefs.current[next]?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = (activeIndex - 1 + templates.length) % templates.length;
+      setActiveIndex(prev);
+      itemRefs.current[prev]?.focus();
+    } else if (e.key === 'Enter' || e.key === ' ' || e.key === 'Space') {
+      e.preventDefault();
+      const tpl = templates[activeIndex];
+      if (tpl) onInsert(tpl.name);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onRequestClose();
+    }
+  };
+
+  return (
+    <ScrollArea className="max-h-[60vh]">
+      <div role="listbox" className="flex flex-col gap-1 p-1" onKeyDown={onKeyDown}>
+        {templates.map((tpl, idx) => (
+          <ForwardedPopoverListItem
+            key={tpl.name}
+            template={tpl}
+            ref={(el) => (itemRefs.current[idx] = el)}
+            id={`tpl-opt-${idx}`}
+            active={idx === activeIndex}
+            onInsert={() => onInsert(tpl.name)}
+            onDragStateChange={setAnyDragging}
+            onDropSuccess={onDropSuccess}
+            onFocus={() => setActiveIndex(idx)}
+          />
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}
+
+interface PopoverListItemProps {
+  template: TemplateNodeSchema;
+  active: boolean;
+  onInsert: () => void;
+  onDragStateChange: (dragging: boolean) => void;
+  id: string;
+  onDropSuccess: () => void;
+  onFocus?: () => void;
+}
+
+function mergeRefs<T>(...refs: Array<React.Ref<T> | undefined>) {
+  return (value: T) => {
+    for (const ref of refs) {
+      if (!ref) continue;
+      if (typeof ref === 'function') {
+        ref(value);
+      } else {
+        try {
+          // @ts-expect-error - React types allow this at runtime
+          (ref as React.MutableRefObject<T | null>).current = value;
+        } catch {
+          // ignore
+        }
+      }
+    }
+  };
+}
+
+const PopoverListItem = (
+  { template, active, onInsert, onDragStateChange, id, onDropSuccess, onFocus }: PopoverListItemProps,
+  ref: React.Ref<HTMLButtonElement>,
+) => {
+  const [{ isDragging }, dragRef, dragPreview] = useDrag<DragItem, { inserted: boolean }, { isDragging: boolean }>(
+    () => ({
+      type: DND_ITEM_NODE,
+      item: { template: template.name, title: template.title, kind: template.kind },
+      collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+      end: (_item, monitor) => {
+        onDragStateChange(false);
+        if (monitor.didDrop()) {
+          const result = monitor.getDropResult<{ inserted: boolean }>();
+          if (result?.inserted) onDropSuccess();
+        }
+      },
+    }),
+    [template, onDragStateChange, onDropSuccess],
+  );
+  // Report drag start using isDragging to avoid deprecated begin hook
+  useEffect(() => {
+    if (isDragging) onDragStateChange(true);
+  }, [isDragging, onDragStateChange]);
+  useEffect(() => {
+    // Optional: hide default drag preview
+    if (dragPreview) {
+      try {
+        dragPreview(getEmptyImage(), { captureDraggingState: true });
+      } catch {
+        // ignore if backend doesn't support
+      }
+    }
+  }, [dragPreview]);
+
+  // Lazy import to avoid top-level dependency; fallback if not available
+  function getEmptyImage(): HTMLImageElement {
+    // Minimal 1x1 transparent gif
+    const img = new Image();
+    img.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+    return img;
+  }
+
+  const setRef = mergeRefs<HTMLButtonElement>(ref, dragRef);
+
+  return (
+    <Card className={`p-0 ${isDragging ? 'opacity-70' : ''}`}>
+      <button
+        id={id}
+        ref={setRef}
+        role="option"
+        aria-selected={active}
+        tabIndex={active ? 0 : -1}
+        type="button"
+        className="w-full rounded-lg px-3 py-2 text-left outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:border-ring hover:bg-accent hover:text-accent-foreground"
+        onClick={onInsert}
+        onFocus={onFocus}
+        data-testid={`template-${template.name}`}
+      >
+        <div className="flex items-center gap-2">
+          <KindIcon kind={template.kind} />
+          <span className={`inline-block rounded px-1.5 py-0.5 text-[10px] leading-none ${kindBadgeClasses(template.kind)}`}>
+            {kindLabel(template.kind)}
+          </span>
+          <span className="text-sm font-medium text-primary">{template.title || template.name}</span>
+        </div>
+      </button>
+    </Card>
+  );
+};
+const ForwardedPopoverListItem = forwardRef(PopoverListItem);
+
+function KindIcon({ kind }: { kind?: TemplateNodeSchema['kind'] }) {
+  const cls = 'h-4 w-4 text-muted-foreground';
+  if (kind === 'agent') return <Bot className={cls} />;
+  if (kind === 'tool') return <Wrench className={cls} />;
+  if (kind === 'trigger') return <Zap className={cls} />;
+  return <Zap className={cls} />;
 }
 
 export function AgentBuilder() {

--- a/apps/ui/src/builder/dnd.ts
+++ b/apps/ui/src/builder/dnd.ts
@@ -1,2 +1,9 @@
 export const DND_ITEM_NODE = 'BUILDER_NODE';
 export type { BuilderNodeKind } from './types';
+
+// Drag item carried by template list items
+export type DragItem = {
+  template: string;
+  title?: string;
+  kind?: import('shared').TemplateNodeSchema['kind'];
+};

--- a/apps/ui/src/layout/RootLayout.tsx
+++ b/apps/ui/src/layout/RootLayout.tsx
@@ -1,0 +1,255 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Outlet, NavLink } from 'react-router-dom';
+import {
+  Sidebar,
+  SidebarHeader,
+  SidebarFooter,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  Button,
+  Drawer,
+  DrawerTrigger,
+  DrawerContent,
+  DrawerClose,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  Separator
+} from '@hautech/ui';
+import {
+  Bot,
+  Activity,
+  Boxes,
+  Settings as SettingsIcon,
+  GitBranch,
+  MessageSquare,
+  AlertTriangle,
+  Gauge,
+  KeyRound,
+  Menu,
+  ChevronLeft,
+  ChevronRight
+} from 'lucide-react';
+import { useUser } from '../user/user.runtime';
+
+const STORAGE_KEYS = {
+  collapsed: 'ui.sidebar.collapsed',
+  agentsOpen: 'ui.sidebar.section.agents.open',
+  tracingOpen: 'ui.sidebar.section.tracing.open',
+  monitoringOpen: 'ui.sidebar.section.monitoring.open',
+  settingsOpen: 'ui.sidebar.section.settings.open'
+};
+
+function useStoredBoolean(key: string, defaultValue: boolean) {
+  const [value, setValue] = useState<boolean>(() => {
+    try {
+      const v = localStorage.getItem(key);
+      if (v === 'true') return true;
+      if (v === 'false') return false;
+    } catch {
+      /* ignore localStorage read errors */
+    }
+    return defaultValue;
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, value ? 'true' : 'false');
+    } catch {
+      /* ignore localStorage write errors */
+    }
+  }, [key, value]);
+  return [value, setValue] as const;
+}
+
+type NavItem = { label: string; to: string; icon: React.ComponentType<{ className?: string }>; };
+type Section = {
+  id: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  isOpen: boolean;
+  setOpen: (open: boolean) => void;
+  items: NavItem[];
+};
+
+export function RootLayout() {
+  const [collapsed, setCollapsed] = useStoredBoolean(STORAGE_KEYS.collapsed, false);
+  const [agentsOpen, setAgentsOpen] = useStoredBoolean(STORAGE_KEYS.agentsOpen, true);
+  const [tracingOpen, setTracingOpen] = useStoredBoolean(STORAGE_KEYS.tracingOpen, false);
+  const [monitoringOpen, setMonitoringOpen] = useStoredBoolean(STORAGE_KEYS.monitoringOpen, false);
+  const [settingsOpen, setSettingsOpen] = useStoredBoolean(STORAGE_KEYS.settingsOpen, false);
+
+  const sections: Section[] = useMemo(
+    () => [
+      {
+        id: 'agents',
+        label: 'Agents',
+        icon: Bot,
+        isOpen: agentsOpen,
+        setOpen: setAgentsOpen,
+        items: [
+          { label: 'Graph', to: '/agents/graph', icon: GitBranch },
+          { label: 'Chat', to: '/agents/chat', icon: MessageSquare }
+        ]
+      },
+      {
+        id: 'tracing',
+        label: 'Tracing',
+        icon: Activity,
+        isOpen: tracingOpen,
+        setOpen: setTracingOpen,
+        items: [
+          { label: 'Traces', to: '/tracing/traces', icon: Activity },
+          { label: 'Errors', to: '/tracing/errors', icon: AlertTriangle }
+        ]
+      },
+      {
+        id: 'monitoring',
+        label: 'Monitoring',
+        icon: Boxes,
+        isOpen: monitoringOpen,
+        setOpen: setMonitoringOpen,
+        items: [
+          { label: 'Containers', to: '/monitoring/containers', icon: Boxes },
+          { label: 'Resources', to: '/monitoring/resources', icon: Gauge }
+        ]
+      },
+      {
+        id: 'settings',
+        label: 'Settings',
+        icon: SettingsIcon,
+        isOpen: settingsOpen,
+        setOpen: setSettingsOpen,
+        items: [
+          { label: 'Secrets', to: '/settings/secrets', icon: KeyRound }
+        ]
+      }
+    ], [agentsOpen, tracingOpen, monitoringOpen, settingsOpen, setAgentsOpen, setTracingOpen, setMonitoringOpen, setSettingsOpen]
+  );
+
+  const { user } = useUser();
+
+  function SidebarInner({ linkWrapper }: { linkWrapper?: (children: React.ReactNode) => React.ReactNode }) {
+    return (
+      <div className="flex h-full flex-col">
+        <SidebarHeader className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {/* Logo or text */}
+            <span className="font-semibold">Hautech Agents</span>
+          </div>
+          <Button variant="ghost" size="icon" onClick={() => setCollapsed((c) => !c)} aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'} className="hidden md:inline-flex">
+            {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+          </Button>
+        </SidebarHeader>
+        <SidebarContent>
+          {sections.map((section) => (
+            <SidebarGroup key={section.id}>
+              <SidebarGroupLabel>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <section.icon className="h-4 w-4" />
+                    {!collapsed && <span>{section.label}</span>}
+                  </div>
+                  {!collapsed && (
+                    <Button variant="ghost" size="sm" className="h-6 px-2 py-0 text-xs" onClick={() => section.setOpen(!section.isOpen)} aria-expanded={section.isOpen} aria-controls={`section-${section.id}`}>
+                      {section.isOpen ? 'Hide' : 'Show'}
+                    </Button>
+                  )}
+                </div>
+              </SidebarGroupLabel>
+              {(!collapsed && section.isOpen) || collapsed ? (
+                <SidebarGroupContent id={`section-${section.id}`}>
+                  <SidebarMenu>
+                    {section.items.map((item) => (
+                      <SidebarMenuItem key={item.to}>
+                        {(linkWrapper ?? ((c) => c))(
+                          <NavLink to={item.to} className="block">
+                            {({ isActive }) => (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <SidebarMenuButton isActive={isActive} className="">
+                                    <item.icon className="h-4 w-4" />
+                                    {!collapsed && <span>{item.label}</span>}
+                                  </SidebarMenuButton>
+                                </TooltipTrigger>
+                                {collapsed && <TooltipContent side="right">{item.label}</TooltipContent>}
+                              </Tooltip>
+                            )}
+                          </NavLink>
+                        )}
+                      </SidebarMenuItem>
+                    ))}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              ) : null}
+            </SidebarGroup>
+          ))}
+        </SidebarContent>
+        <SidebarFooter>
+          <div className="flex items-center gap-2">
+            <Avatar className="h-8 w-8">
+              {user?.avatarUrl ? <AvatarImage src={user.avatarUrl} alt={user?.name || 'User'} /> : null}
+              <AvatarFallback>{(user?.name || 'G').slice(0, 2).toUpperCase()}</AvatarFallback>
+            </Avatar>
+            {!collapsed && (
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{user?.name || 'Guest'}</div>
+                <div className="truncate text-xs text-muted-foreground">{user?.email || 'guest@example.com'}</div>
+              </div>
+            )}
+          </div>
+        </SidebarFooter>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen w-full">
+      {/* Desktop sidebar */}
+      <aside className={`hidden md:flex`}>
+        <Sidebar className={`${collapsed ? 'w-16' : 'w-64'}`}>
+          <SidebarInner />
+        </Sidebar>
+      </aside>
+
+      {/* Mobile top bar + Drawer */}
+      <div className="flex min-h-screen flex-1 flex-col">
+        <div className="flex items-center gap-2 border-b px-3 py-2 md:hidden">
+          <Drawer>
+            <DrawerTrigger asChild>
+              <Button variant="ghost" size="icon" aria-label="Open navigation">
+                <Menu className="h-5 w-5" />
+              </Button>
+            </DrawerTrigger>
+            <DrawerContent className="p-0">
+              <div className="h-[85vh]">
+                <Sidebar className="w-full">
+                  <SidebarInner linkWrapper={(node) => <DrawerClose asChild>{node}</DrawerClose>} />
+                </Sidebar>
+                <div className="p-2">
+                  <DrawerClose asChild>
+                    <Button variant="secondary" className="w-full">Close</Button>
+                  </DrawerClose>
+                </div>
+              </div>
+            </DrawerContent>
+          </Drawer>
+          <Separator orientation="vertical" className="h-6" />
+          <div className="font-semibold">Hautech Agents</div>
+        </div>
+
+        {/* Main content */}
+        <main className="flex-1">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -4,12 +4,18 @@ import './index.css'
 import App from './App.tsx'
 import { initConfigViewsRegistry } from './configViews.init';
 import { TooltipProvider } from '@hautech/ui';
+import { BrowserRouter } from 'react-router-dom';
+import { UserProvider } from './user/UserProvider';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     {initConfigViewsRegistry()}
     <TooltipProvider>
-      <App />
+      <BrowserRouter>
+        <UserProvider>
+          <App />
+        </UserProvider>
+      </BrowserRouter>
     </TooltipProvider>
   </StrictMode>,
 )

--- a/apps/ui/src/pages/AgentsChat.tsx
+++ b/apps/ui/src/pages/AgentsChat.tsx
@@ -1,0 +1,9 @@
+export function AgentsChat() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold">Agents / Chat</h1>
+      <p className="text-sm text-muted-foreground">Placeholder page.</p>
+    </div>
+  );
+}
+

--- a/apps/ui/src/pages/MonitoringContainers.tsx
+++ b/apps/ui/src/pages/MonitoringContainers.tsx
@@ -1,0 +1,9 @@
+export function MonitoringContainers() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold">Monitoring / Containers</h1>
+      <p className="text-sm text-muted-foreground">Placeholder page.</p>
+    </div>
+  );
+}
+

--- a/apps/ui/src/pages/MonitoringResources.tsx
+++ b/apps/ui/src/pages/MonitoringResources.tsx
@@ -1,0 +1,9 @@
+export function MonitoringResources() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold">Monitoring / Resources</h1>
+      <p className="text-sm text-muted-foreground">Placeholder page.</p>
+    </div>
+  );
+}
+

--- a/apps/ui/src/pages/SettingsSecrets.tsx
+++ b/apps/ui/src/pages/SettingsSecrets.tsx
@@ -1,0 +1,9 @@
+export function SettingsSecrets() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold">Settings / Secrets</h1>
+      <p className="text-sm text-muted-foreground">Placeholder page.</p>
+    </div>
+  );
+}
+

--- a/apps/ui/src/pages/TracingErrors.tsx
+++ b/apps/ui/src/pages/TracingErrors.tsx
@@ -1,0 +1,9 @@
+export function TracingErrors() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold">Tracing / Errors</h1>
+      <p className="text-sm text-muted-foreground">Placeholder page.</p>
+    </div>
+  );
+}
+

--- a/apps/ui/src/pages/TracingTraces.tsx
+++ b/apps/ui/src/pages/TracingTraces.tsx
@@ -1,0 +1,9 @@
+export function TracingTraces() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold">Tracing / Traces</h1>
+      <p className="text-sm text-muted-foreground">Placeholder page.</p>
+    </div>
+  );
+}
+

--- a/apps/ui/src/user/UserProvider.tsx
+++ b/apps/ui/src/user/UserProvider.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import type { UserContextType } from './user-types';
+import { UserContext } from './user.runtime';
+
+export function UserProvider({ children }: { children: React.ReactNode }) {
+  const value: UserContextType = { user: { name: 'Casey Quinn', email: 'casey@example.com' } };
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+}

--- a/apps/ui/src/user/user-types.ts
+++ b/apps/ui/src/user/user-types.ts
@@ -1,0 +1,8 @@
+export type User = {
+  name: string;
+  email: string;
+  avatarUrl?: string;
+};
+
+export type UserContextType = { user: User | null };
+

--- a/apps/ui/src/user/user.runtime.ts
+++ b/apps/ui/src/user/user.runtime.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+import type { UserContextType } from './user-types';
+
+// Runtime-only context container; no components are exported here.
+export const UserContext = React.createContext<UserContextType>({ user: null });
+export function useUser() {
+  return React.useContext(UserContext);
+}
+

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -8,16 +8,31 @@ const Popover = PopoverPrimitive.Root;
 const PopoverTrigger = PopoverPrimitive.Trigger;
 const PopoverAnchor = PopoverPrimitive.Anchor;
 
+// Note: we keep a thin wrapper to apply common styles and allow presence-based animations.
+// We intentionally support `forceMount` on the Portal to allow closed-state animations.
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+    forceMount?: boolean;
+  }
+>(({ className, align = 'center', sideOffset = 4, forceMount, ...props }, ref) => (
+  <PopoverPrimitive.Portal forceMount={forceMount}>
+    {/* Radix sets data-state and data-side attributes. We rely on Tailwind data-[] variants for animations. */}
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      className={cn('z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none', className)}
+      className={cn(
+        // Surface + elevation + blur
+        'z-50 w-72 rounded-xl border bg-popover/95 p-4 text-popover-foreground shadow-2xl backdrop-blur',
+        // Open/close animations
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2',
+        'outline-none',
+        className,
+      )}
       {...props}
     />
   </PopoverPrimitive.Portal>
@@ -25,4 +40,3 @@ const PopoverContent = React.forwardRef<
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,9 @@ importers:
       react-resizable-panels:
         specifier: ^2.0.22
         version: 2.1.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react-router-dom:
+        specifier: ^6.27.0
+        version: 6.30.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       reactflow:
         specifier: ^11.11.4
         version: 11.11.4(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)


### PR DESCRIPTION
Implements Phase 2 of epic #248:

- Add NodeLifecycle interface and export.
- Refactor MemoryNode and MemoryConnectorNode to DI-only constructors and implement lifecycle.
- Orchestrator (LiveGraphRuntime): configure+start on create; configure on update; stop+delete on removal; add shutdown().
- Templates: construct Memory/Connector without config; lifecycle applies config.
- Tests: update Memory constructors; add lifecycle integration test.

No changes to lgnodes.

Validation: CI expected to be green. Closes #290. Links #248.