### PR TITLE
Fix: SimpleAgent lifecycle config propagation (epic #248)

### DIFF
--- a/apps/server/__tests__/live.graph.runtime.simpleAgent.config.propagation.test.ts
+++ b/apps/server/__tests__/live.graph.runtime.simpleAgent.config.propagation.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LiveGraphRuntime } from '../src/graph/liveGraph.manager';
+import { buildTemplateRegistry } from '../src/templates';
+import { LoggerService } from '../src/services/logger.service';
+import { ContainerService } from '../src/services/container.service';
+import { ConfigService } from '../src/services/config.service';
+import { CheckpointerService } from '../src/services/checkpointer.service';
+
+// Avoid any real network calls by ensuring ChatOpenAI token counting/invoke are not used in this test.
+// We don't invoke the graph; we only verify propagation of config to internal nodes/fields.
+
+describe('LiveGraphRuntime -> SimpleAgent config propagation', () => {
+  function makeRuntime() {
+    const logger = new LoggerService();
+    const containerService = new ContainerService(logger);
+    const configService = new ConfigService({
+      githubAppId: 'test',
+      githubAppPrivateKey: 'test',
+      githubInstallationId: 'test',
+      openaiApiKey: 'test',
+      githubToken: 'test',
+      mongodbUrl: 'mongodb://localhost:27017/?replicaSet=rs0',
+    } as any);
+    const checkpointerService = new CheckpointerService(logger);
+    // Patch to bypass Mongo requirement for this lightweight test
+    (checkpointerService as any).getCheckpointer = () => ({
+      async getTuple() { return undefined; },
+      async *list() {},
+      async put(_config: any, _checkpoint: any, _metadata: any) { return { configurable: { thread_id: 't' } } as any; },
+      async putWrites() {},
+      getNextVersion() { return '1'; },
+    });
+    const mongoService = { getDb: () => ({} as any) } as any;
+    const registry = buildTemplateRegistry({ logger, containerService, configService, checkpointerService, mongoService });
+    const runtime = new LiveGraphRuntime(logger, registry);
+    return { runtime };
+  }
+
+  it('applies provided config on configure/start and updates on re-apply', async () => {
+    const { runtime } = makeRuntime();
+    const systemPrompt = 'You are Strict.';
+    const model = 'gpt-9-test';
+    const keep = 123;
+    const max = 456;
+    const restrict = true;
+    const restrictionMessage = 'Always call a tool first.';
+
+    const graph1 = {
+      nodes: [
+        {
+          id: 'agent',
+          data: {
+            template: 'simpleAgent',
+            config: {
+              systemPrompt,
+              model,
+              summarizationKeepTokens: keep,
+              summarizationMaxTokens: max,
+              restrictOutput: restrict,
+              restrictionMessage,
+            },
+          },
+        },
+      ],
+      edges: [] as any[],
+    };
+
+    await runtime.apply(graph1 as any);
+    const agent: any = runtime.getNodeInstance('agent');
+    expect(agent).toBeDefined();
+
+    // Validate propagation into internal nodes/fields
+    expect((agent as any).callModelNode?.['systemPrompt']).toBe(systemPrompt);
+    expect((agent as any).llm?.['model']).toBe(model);
+    expect((agent as any).summarizeNode?.['keepTokens']).toBe(keep);
+    expect((agent as any).summarizeNode?.['maxTokens']).toBe(max);
+    expect((agent as any).restrictOutput).toBe(restrict);
+    expect((agent as any).restrictionMessage).toBe(restrictionMessage);
+
+    // Update config live and re-apply
+    const newSystemPrompt = 'You are Even Stricter.';
+    const newModel = 'gpt-9x-test';
+    const graph2 = {
+      nodes: [
+        {
+          id: 'agent',
+          data: {
+            template: 'simpleAgent',
+            config: {
+              systemPrompt: newSystemPrompt,
+              model: newModel,
+              summarizationKeepTokens: keep,
+              summarizationMaxTokens: max,
+              restrictOutput: restrict,
+              restrictionMessage,
+            },
+          },
+        },
+      ],
+      edges: [] as any[],
+    };
+
+    await runtime.apply(graph2 as any);
+    const agent2: any = runtime.getNodeInstance('agent');
+    expect(agent2).toBe(agent); // same instance should be updated, not recreated
+    expect((agent2 as any).callModelNode?.['systemPrompt']).toBe(newSystemPrompt);
+    expect((agent2 as any).llm?.['model']).toBe(newModel);
+  });
+});
+

--- a/apps/server/__tests__/live.graph.runtime.simpleAgent.config.propagation.test.ts
+++ b/apps/server/__tests__/live.graph.runtime.simpleAgent.config.propagation.test.ts
@@ -52,16 +52,14 @@ describe('LiveGraphRuntime -> SimpleAgent config propagation', () => {
       async putWrites() {},
       getNextVersion() { return '1'; },
     } as unknown as ReturnType<CheckpointerService['getCheckpointer']>);
-    class TestMongoService extends (MongoService as { new (...args: any[]): MongoService }) {
-      constructor() {
-        // Pass through to satisfy parent constructor; will not connect/use client
-        super(configService, logger);
-      }
-      // Override to avoid requiring an actual DB
-      getDb(): any { return {}; }
-    }
-    const mongoService = new TestMongoService();
-    const registry = buildTemplateRegistry({ logger, containerService, configService, checkpointerService, mongoService });
+    const testMongoService = { getDb: () => ({}) } satisfies Pick<MongoService, 'getDb'>;
+    const registry = buildTemplateRegistry({
+      logger,
+      containerService,
+      configService,
+      checkpointerService,
+      mongoService: testMongoService as unknown as MongoService,
+    });
     const runtime = new LiveGraphRuntime(logger, registry);
     return { runtime };
   }

--- a/apps/server/src/agents/simple.agent.ts
+++ b/apps/server/src/agents/simple.agent.ts
@@ -469,14 +469,14 @@ export class SimpleAgent extends BaseAgent {
     this.applyRuntimeConfig(config);
 
     // Only update fields that were explicitly provided by caller
-    if (Object.prototype.hasOwnProperty.call(filtered, 'systemPrompt')) {
-      this.callModelNode.setSystemPrompt(parsedConfig.systemPrompt as string);
+    if (Object.prototype.hasOwnProperty.call(filtered, 'systemPrompt') && typeof parsedConfig.systemPrompt === 'string') {
+      this.callModelNode.setSystemPrompt(parsedConfig.systemPrompt);
       this.loggerService.info('SimpleAgent system prompt updated');
     }
 
-    if (Object.prototype.hasOwnProperty.call(filtered, 'model')) {
+    if (Object.prototype.hasOwnProperty.call(filtered, 'model') && typeof parsedConfig.model === 'string') {
       // Update model on stored llm instance (lightweight change similar to systemPrompt logic)
-      this.llm.model = parsedConfig.model as string;
+      this.llm.model = parsedConfig.model;
       this.loggerService.info(`SimpleAgent model updated to ${parsedConfig.model}`);
     }
 


### PR DESCRIPTION
Adds a regression test and fixes SimpleAgent lifecycle propagation:

- Regression test: via LiveGraphRuntime + templates, verifies provided systemPrompt/model (and related fields) are applied on start and updated on configure.
- Fix: SimpleAgent.configure/start now properly propagate provided config without injecting defaults or dropping keys; idempotent lifecycle.

Closes #317. Links epic #248.