### PR TITLE
platform-ui: fix Workspace configuration view and NixPackages gating

### DIFF
--- a/packages/platform-ui/__tests__/components/configViews/ContainerProviderConfigView.payload.test.tsx
+++ b/packages/platform-ui/__tests__/components/configViews/ContainerProviderConfigView.payload.test.tsx
@@ -9,7 +9,7 @@ describe('ContainerProviderConfigView payload', () => {
     render(
       <TooltipProvider delayDuration={0}>
         <ContainerProviderConfigView
-          templateName="containerProvider"
+          templateName="workspace"
           value={{}}
           onChange={(v) => (cfg = v)}
           readOnly={false}

--- a/packages/platform-ui/__tests__/components/configViews/WorkspaceConfigView.payload.test.tsx
+++ b/packages/platform-ui/__tests__/components/configViews/WorkspaceConfigView.payload.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TooltipProvider } from '@agyn/ui';
-import ContainerProviderConfigView from '@/components/configViews/ContainerProviderConfigView';
+import WorkspaceConfigView from '@/components/configViews/WorkspaceConfigView';
 
-describe('ContainerProviderConfigView payload', () => {
+describe('WorkspaceConfigView payload', () => {
   it('emits aligned schema shape', () => {
     let cfg: any = {};
     render(
       <TooltipProvider delayDuration={0}>
-        <ContainerProviderConfigView
+        <WorkspaceConfigView
           templateName="workspace"
           value={{}}
           onChange={(v) => (cfg = v)}

--- a/packages/platform-ui/src/builder/panels/RightPropertiesPanel.tsx
+++ b/packages/platform-ui/src/builder/panels/RightPropertiesPanel.tsx
@@ -156,7 +156,7 @@ function RightPropertiesPanelBody({
           <div className="text-xs text-muted-foreground">No custom view registered for {data.template} (state)</div>
         )}
       </div>
-      {data.template === 'containerProvider' && (
+      {data.template === 'workspace' && (
         <div className="space-y-2">
           <NixPackagesSection config={cfg} onUpdateConfig={(next) => update({ config: next })} />
         </div>

--- a/packages/platform-ui/src/components/configViews/WorkspaceConfigView.tsx
+++ b/packages/platform-ui/src/components/configViews/WorkspaceConfigView.tsx
@@ -3,7 +3,7 @@ import { Input } from '@agyn/ui';
 import type { StaticConfigViewProps } from './types';
 import ReferenceEnvField, { type EnvItem } from './shared/ReferenceEnvField';
 
-export default function ContainerProviderConfigView({ value, onChange, readOnly, disabled, onValidate }: StaticConfigViewProps) {
+export default function WorkspaceConfigView({ value, onChange, readOnly, disabled, onValidate }: StaticConfigViewProps) {
   const init = useMemo(() => ({ ...(value || {}) }), [value]);
   const [image, setImage] = useState<string>((init.image as string) || '');
   const [env, setEnv] = useState<EnvItem[]>((init.env as EnvItem[]) || []);

--- a/packages/platform-ui/src/components/configViews/registerDefaults.ts
+++ b/packages/platform-ui/src/components/configViews/registerDefaults.ts
@@ -18,7 +18,9 @@ export function installDefaultConfigViews(register: (entry: ConfigViewRegistrati
   register({ template: 'agent', mode: 'static', component: SimpleAgentConfigView });
   register({ template: 'mcpServer', mode: 'dynamic', component: McpServerDynamicConfigView });
   register({ template: 'mcpServer', mode: 'static', component: McpServerStaticConfigView });
-  register({ template: 'containerProvider', mode: 'static', component: ContainerProviderConfigView });
+  // Register Workspace config view under new template name 'workspace'
+  // Component remains ContainerProviderConfigView for now
+  register({ template: 'workspace', mode: 'static', component: ContainerProviderConfigView });
   register({ template: 'shellTool', mode: 'static', component: ShellToolConfigView });
   register({ template: 'githubCloneRepoTool', mode: 'static', component: GithubCloneRepoToolConfigView });
   register({ template: 'sendSlackMessageTool', mode: 'static', component: SendSlackMessageToolConfigView });

--- a/packages/platform-ui/src/components/configViews/registerDefaults.ts
+++ b/packages/platform-ui/src/components/configViews/registerDefaults.ts
@@ -3,7 +3,7 @@ import type { ConfigViewRegistration } from './types';
 import SimpleAgentConfigView from './SimpleAgentConfigView';
 import McpServerDynamicConfigView from './McpServerDynamicConfigView';
 import McpServerStaticConfigView from './McpServerStaticConfigView';
-import ContainerProviderConfigView from './ContainerProviderConfigView';
+import WorkspaceConfigView from './WorkspaceConfigView';
 import ShellToolConfigView from './ShellToolConfigView';
 import GithubCloneRepoToolConfigView from './GithubCloneRepoToolConfigView';
 import SendSlackMessageToolConfigView from './SendSlackMessageToolConfigView';
@@ -18,9 +18,8 @@ export function installDefaultConfigViews(register: (entry: ConfigViewRegistrati
   register({ template: 'agent', mode: 'static', component: SimpleAgentConfigView });
   register({ template: 'mcpServer', mode: 'dynamic', component: McpServerDynamicConfigView });
   register({ template: 'mcpServer', mode: 'static', component: McpServerStaticConfigView });
-  // Register Workspace config view under new template name 'workspace'
-  // Component remains ContainerProviderConfigView for now
-  register({ template: 'workspace', mode: 'static', component: ContainerProviderConfigView });
+  // Register Workspace config view under template name 'workspace'
+  register({ template: 'workspace', mode: 'static', component: WorkspaceConfigView });
   register({ template: 'shellTool', mode: 'static', component: ShellToolConfigView });
   register({ template: 'githubCloneRepoTool', mode: 'static', component: GithubCloneRepoToolConfigView });
   register({ template: 'sendSlackMessageTool', mode: 'static', component: SendSlackMessageToolConfigView });

--- a/packages/platform-ui/src/lib/graph/__tests__/normalize.test.ts
+++ b/packages/platform-ui/src/lib/graph/__tests__/normalize.test.ts
@@ -7,7 +7,7 @@ describe('normalizeConfigByTemplate idempotence and behavior', () => {
   it('converts env object to array, wraps tokens, renames workdir, removes extras', () => {
     const nodes = [
       { id: '1', template: 'shellTool', config: { workingDir: '/w', env: { A: '1' } } },
-      { id: '2', template: 'containerProvider', config: { env: { B: '2' }, workingDir: '/x', note: 'n' } },
+      { id: '2', template: 'workspace', config: { env: { B: '2' }, workingDir: '/x', note: 'n' } },
       { id: '3', template: 'sendSlackMessageTool', config: { bot_token: 'xoxb-123', note: 'x' } },
       { id: '4', template: 'slackTrigger', config: { app_token: 'xapp-abc', bot_token: 'x', default_channel: '#g' } },
       { id: '5', template: 'githubCloneRepoTool', config: { token: 'tok', repoUrl: 'x', destPath: 'y', authToken: 'z' } },

--- a/packages/platform-ui/src/lib/graph/api.ts
+++ b/packages/platform-ui/src/lib/graph/api.ts
@@ -20,6 +20,7 @@ function isLikelyJsonSchemaRoot(obj: unknown): obj is Record<string, unknown> {
 // Normalize legacy UI config shapes to server-aligned templates
 type TemplateName =
   | 'containerProvider'
+  | 'workspace'
   | 'shellTool'
   | 'sendSlackMessageTool'
   | 'slackTrigger'
@@ -42,6 +43,7 @@ function normalizeConfigByTemplate(
   if (!cfg || typeof cfg !== 'object') return cfg;
   const c = { ...(cfg as Record<string, unknown>) };
   switch (template) {
+    case 'workspace':
     case 'containerProvider': {
       if (c.env && !Array.isArray(c.env) && typeof c.env === 'object') {
         c.env = Object.entries(c.env as Record<string, string>).map(

--- a/packages/platform-ui/src/lib/graph/api.ts
+++ b/packages/platform-ui/src/lib/graph/api.ts
@@ -19,7 +19,6 @@ function isLikelyJsonSchemaRoot(obj: unknown): obj is Record<string, unknown> {
 
 // Normalize legacy UI config shapes to server-aligned templates
 type TemplateName =
-  | 'containerProvider'
   | 'workspace'
   | 'shellTool'
   | 'sendSlackMessageTool'
@@ -43,8 +42,7 @@ function normalizeConfigByTemplate(
   if (!cfg || typeof cfg !== 'object') return cfg;
   const c = { ...(cfg as Record<string, unknown>) };
   switch (template) {
-    case 'workspace':
-    case 'containerProvider': {
+    case 'workspace': {
       if (c.env && !Array.isArray(c.env) && typeof c.env === 'object') {
         c.env = Object.entries(c.env as Record<string, string>).map(
           ([k, v]) => ({ key: k, value: v, source: 'static' }) as EnvItem,


### PR DESCRIPTION
Fixes #541.

Align platform-ui to the new template name workspace and remove legacy containerProvider references:
- Register WorkspaceConfigView under template workspace
- Gate NixPackagesSection on data.template === workspace
- Rename ContainerProviderConfigView to WorkspaceConfigView and update imports/exports
- Update tests to use workspace exclusively
- Remove normalization/support for containerProvider; keep only workspace

All platform-ui tests pass locally. Please review.