### PR TITLE
fix(platform-server): Fastify reply injection fix for NixController

### DIFF
--- a/packages/platform-server/__tests__/nix.e2e.test.ts
+++ b/packages/platform-server/__tests__/nix.e2e.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import nock from 'nock';
+import { Test } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { NixController } from '../src/infra/ncps/nix.controller';
+import { ConfigService, configSchema } from '../src/core/services/config.service';
+
+const BASE = 'https://www.nixhub.io';
+
+describe('NixController E2E (Fastify)', () => {
+  let app: NestFastifyApplication;
+
+  beforeAll(async () => {
+    const cfg = new ConfigService().init(
+      configSchema.parse({
+        llmProvider: 'openai',
+        githubAppId: 'x', githubAppPrivateKey: 'x', githubInstallationId: 'x', githubToken: 'x', mongodbUrl: 'x',
+        agentsDatabaseUrl: 'postgres://localhost:5432/agents',
+        graphStore: 'mongo', graphRepoPath: './data/graph', graphBranch: 'graph-state',
+        dockerMirrorUrl: 'http://registry-mirror:5000', nixAllowedChannels: 'nixpkgs-unstable',
+        nixHttpTimeoutMs: String(200), nixCacheTtlMs: String(5 * 60_000), nixCacheMax: String(500),
+        mcpToolsStaleTimeoutMs: '0', ncpsEnabled: 'false', ncpsUrl: 'http://ncps:8501',
+        ncpsRefreshIntervalMs: '0',
+      })
+    );
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [NixController],
+      providers: [{ provide: ConfigService, useValue: cfg }],
+    }).compile();
+
+    app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => nock.cleanAll());
+  afterEach(() => nock.cleanAll());
+
+  it('GET /api/nix/packages returns 200 and sets cache-control', async () => {
+    const scope = nock(BASE)
+      .get('/search')
+      .query((q) => q.q === 'git' && q._data === 'routes/_nixhub.search')
+      .reply(200, { query: 'git', total_results: 1, results: [{ name: 'git', summary: 'the fast version control system' }] });
+
+    const res = await app.getHttpAdapter().getInstance().inject({ method: 'GET', url: '/api/nix/packages?query=git' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['cache-control']).toContain('max-age=60');
+    const body = JSON.parse(res.body);
+    expect(Array.isArray(body.packages)).toBe(true);
+    scope.done();
+  });
+
+  it('GET /api/nix/packages timeout returns 504', async () => {
+    const scope = nock(BASE)
+      .get('/search')
+      .query((q) => q.q === 'long')
+      .delay(500)
+      .reply(200, { query: 'long', total_results: 0, results: [] });
+
+    const res = await app.getHttpAdapter().getInstance().inject({ method: 'GET', url: '/api/nix/packages?query=long' });
+    expect(res.statusCode).toBe(504);
+    scope.done();
+  });
+
+  it('Invalid query params return 400', async () => {
+    const res = await app.getHttpAdapter().getInstance().inject({ method: 'GET', url: '/api/nix/packages?query=git&extra=x' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+

--- a/packages/platform-server/src/infra/ncps/nix.controller.ts
+++ b/packages/platform-server/src/infra/ncps/nix.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Inject } from '@nestjs/common';
+import { Controller, Get, Inject, Query, Res } from '@nestjs/common';
 import type { FastifyReply } from 'fastify';
 import { z } from 'zod';
 import semver from 'semver';
@@ -160,7 +160,7 @@ export class NixController {
   }
 
   @Get('packages')
-  async packages(query: Record<string, unknown>, reply: FastifyReply) {
+  async packages(@Query() query: Record<string, unknown>, @Res({ passthrough: true }) reply: FastifyReply) {
     try {
       const raw = (query || {}) as Record<string, unknown>;
       const parsed = this.packagesQuerySchema.safeParse(raw);
@@ -208,7 +208,7 @@ export class NixController {
   }
 
   @Get('versions')
-  async versions(query: Record<string, unknown>, reply: FastifyReply) {
+  async versions(@Query() query: Record<string, unknown>, @Res({ passthrough: true }) reply: FastifyReply) {
     try {
       const raw = (query || {}) as Record<string, unknown>;
       const parsed = this.versionsQuerySchema.safeParse(raw);
@@ -260,7 +260,7 @@ export class NixController {
   }
 
   @Get('resolve')
-  async resolve(query: Record<string, unknown>, reply: FastifyReply) {
+  async resolve(@Query() query: Record<string, unknown>, @Res({ passthrough: true }) reply: FastifyReply) {
     try {
       const raw = (query || {}) as Record<string, unknown>;
       const parsed = this.resolveQuerySchema.safeParse(raw);


### PR DESCRIPTION
Implements fix for Fastify reply injection in NixController.\n\nChanges:\n- Import Query and Res from @nestjs/common.\n- Add parameter decorators to packages/versions/resolve: @Query() and @Res({ passthrough: true }).\n- Keep zod validation and mapping intact.\n- Add e2e test to boot Nest Fastify app and verify: cache-control header, timeout 504, and 400 for invalid params.\n\nAll related tests for NixController pass locally, including new e2e test.\n\nCloses #548.