### PR TITLE
fix: manage tool persistence wiring and alias handling

### DIFF
--- a/packages/platform-server/__tests__/manage.tool.test.ts
+++ b/packages/platform-server/__tests__/manage.tool.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Test } from '@nestjs/testing';
 import { ModuleRef } from '@nestjs/core';
 
@@ -37,184 +37,199 @@ class FakeAgent extends AgentNode {
   }
 }
 
+function buildCtx(overrides: Partial<LLMContext> = {}): LLMContext {
+  return {
+    threadId: 'parent',
+    runId: 'run',
+    finishSignal: new Signal(),
+    terminateSignal: new Signal(),
+    callerAgent: { invoke: async () => new ResponseMessage({ output: [] }) },
+    ...overrides,
+  } as LLMContext;
+}
+
+async function createHarness(options: { persistence?: AgentsPersistenceService } = {}) {
+  const defaultSpy = vi.fn().mockResolvedValue('child-default');
+  const hasCustomPersistence = Object.prototype.hasOwnProperty.call(options, 'persistence');
+  const persistence = hasCustomPersistence
+    ? (options.persistence as AgentsPersistenceService)
+    : ({ getOrCreateSubthreadByAlias: defaultSpy } as unknown as AgentsPersistenceService);
+
+  const module = await Test.createTestingModule({
+    providers: [
+      LoggerService,
+      {
+        provide: ConfigService,
+        useValue: new ConfigService().init(
+          configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://localhost/agents' }),
+        ),
+      },
+      { provide: LLMProvisioner, useClass: StubLLMProvisioner },
+      ManageFunctionTool,
+      ManageToolNode,
+      FakeAgent,
+      { provide: AgentsPersistenceService, useValue: persistence },
+      RunSignalsRegistry,
+    ],
+  }).compile();
+
+  const node = await module.resolve(ManageToolNode);
+  await node.setConfig({ description: 'desc' });
+  const tool = node.getTool();
+
+  return { module, node, tool, spy: hasCustomPersistence ? null : defaultSpy };
+}
+
+async function addWorker(module: Awaited<ReturnType<typeof createHarness>>['module'], node: ManageToolNode, title: string) {
+  const worker = await module.resolve(FakeAgent);
+  await worker.setConfig({ title });
+  node.addWorker(worker);
+  return worker;
+}
+
 describe('ManageTool unit', () => {
-  it('send_message: matches worker by trimmed title and returns text', async () => {
-    const module = await Test.createTestingModule({
-      providers: [
-        LoggerService,
-        { provide: ConfigService, useValue: new ConfigService().init(configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://localhost/agents' })) },
-        { provide: LLMProvisioner, useClass: StubLLMProvisioner },
-        ManageFunctionTool,
-        ManageToolNode,
-        FakeAgent,
-        {
-          provide: AgentsPersistenceService,
-          useValue: {
-            beginRunThread: async () => ({ runId: 't' }),
-            recordInjected: async () => ({ messageIds: [] }),
-            completeRun: async () => {},
-            getOrCreateSubthreadByAlias: async () => 'child-t',
-          },
-        },
-        RunSignalsRegistry,
-      ],
-    }).compile();
+  it('send_message: uses explicit threadAlias', async () => {
+    const getOrCreateSubthreadByAlias = vi.fn().mockResolvedValue('child-explicit');
+    const persistence = { getOrCreateSubthreadByAlias } as unknown as AgentsPersistenceService;
+    const harness = await createHarness({ persistence });
+    await addWorker(harness.module, harness.node, '  child-1  ');
 
-    const node = await module.resolve(ManageToolNode);
-    await node.setConfig({ description: 'desc' });
-    const worker = await module.resolve(FakeAgent);
-    await worker.setConfig({ title: '  child-1  ' });
-    node.addWorker(worker);
-    expect(node.listWorkers()).toEqual(['child-1']);
+    const ctx = buildCtx();
+    const res = await harness.tool.execute(
+      { command: 'send_message', worker: ' child-1 ', message: 'hello', threadAlias: 'explicit-alias' },
+      ctx,
+    );
 
-    const tool = node.getTool();
-    const ctx: LLMContext = { threadId: 'parent', runId: 'r', finishSignal: new Signal(), terminateSignal: new Signal(), callerAgent: { invoke: async () => new ResponseMessage({ output: [] }) } };
-    const res = await tool.execute({ command: 'send_message', worker: ' child-1 ', message: 'hello', threadAlias: 'child-1' }, ctx);
     expect(res?.startsWith('ok-')).toBe(true);
+    expect(getOrCreateSubthreadByAlias).toHaveBeenCalledWith('manage', 'explicit-alias', 'parent', '');
   });
 
-  it('send_message: parameter validation and unknown worker', async () => {
-    const module = await Test.createTestingModule({
-      providers: [
-        LoggerService,
-        { provide: ConfigService, useValue: new ConfigService().init(configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://localhost/agents' })) },
-        { provide: LLMProvisioner, useClass: StubLLMProvisioner },
-        ManageFunctionTool,
-        ManageToolNode,
-        FakeAgent,
-        {
-          provide: AgentsPersistenceService,
-          useValue: {
-            beginRunThread: async () => ({ runId: 't' }),
-            recordInjected: async () => ({ messageIds: [] }),
-            completeRun: async () => {},
-            getOrCreateSubthreadByAlias: async () => 'child-t',
-          },
-        },
-        RunSignalsRegistry,
-      ],
-    }).compile();
+  it('send_message: derives sanitized alias when omitted', async () => {
+    const getOrCreateSubthreadByAlias = vi.fn().mockResolvedValue('child-derived');
+    const persistence = { getOrCreateSubthreadByAlias } as unknown as AgentsPersistenceService;
+    const harness = await createHarness({ persistence });
+    await addWorker(harness.module, harness.node, 'Alpha Worker');
 
-    const node = await module.resolve(ManageToolNode);
-    await node.setConfig({ description: 'd' });
-    const tool = node.getTool();
-    const ctx: LLMContext = { threadId: 'p', runId: 'r', finishSignal: new Signal(), terminateSignal: new Signal(), callerAgent: { invoke: async () => new ResponseMessage({ output: [] }) } };
+    const ctx = buildCtx();
+    const res = await harness.tool.execute(
+      { command: 'send_message', worker: 'Alpha Worker', message: 'ping' },
+      ctx,
+    );
 
-    await expect(tool.execute({ command: 'send_message', worker: 'x', threadAlias: 'alias-x' }, ctx)).rejects.toThrow('No agents connected');
+    expect(res?.startsWith('ok-')).toBe(true);
+    expect(getOrCreateSubthreadByAlias).toHaveBeenCalledWith('manage', 'alpha-worker', 'parent', '');
+  });
 
-    const agent = await module.resolve(FakeAgent);
-    await agent.setConfig({ title: 'w1' });
-    node.addWorker(agent);
+  it('send_message: rejects invalid alias input', async () => {
+    const harness = await createHarness();
+    await addWorker(harness.module, harness.node, 'Worker X');
+    const ctx = buildCtx();
 
-    await expect(tool.execute({ command: 'send_message', worker: 'x', threadAlias: 'alias-x' }, ctx)).rejects.toThrow('message is required for send_message');
-    await expect(tool.execute({ command: 'send_message', worker: '   ', message: 'hi', threadAlias: 'alias-x' }, ctx)).rejects.toThrow('worker is required for send_message');
-    await expect(tool.execute({ command: 'send_message', worker: 'w1', message: '   ', threadAlias: 'alias-x' }, ctx)).rejects.toThrow('message is required for send_message');
-    await expect(tool.execute({ command: 'send_message', worker: 'unknown', message: 'm', threadAlias: 'alias-unknown' }, ctx)).rejects.toThrow('Unknown worker: unknown');
+    await expect(
+      harness.tool.execute(
+        { command: 'send_message', worker: 'Worker X', message: 'hi', threadAlias: '   @@@  ' },
+        ctx,
+      ),
+    ).rejects.toThrow('Manage: invalid or empty threadAlias');
+    expect(harness.spy).not.toHaveBeenCalled();
+  });
+
+  it('send_message: validates worker/message parameters and unknown worker', async () => {
+    const harness = await createHarness();
+    const ctx = buildCtx();
+
+    await expect(
+      harness.tool.execute({ command: 'send_message', worker: 'x', message: 'hi' }, ctx),
+    ).rejects.toThrow('No agents connected');
+
+    await addWorker(harness.module, harness.node, 'w1');
+
+    await expect(
+      harness.tool.execute({ command: 'send_message', worker: 'w1' }, ctx),
+    ).rejects.toThrow('message is required for send_message');
+    await expect(
+      harness.tool.execute({ command: 'send_message', worker: '   ', message: 'hi' }, ctx),
+    ).rejects.toThrow('worker is required for send_message');
+    await expect(
+      harness.tool.execute({ command: 'send_message', worker: 'w1', message: '   ' }, ctx),
+    ).rejects.toThrow('message is required for send_message');
+    await expect(
+      harness.tool.execute({ command: 'send_message', worker: 'unknown', message: 'm' }, ctx),
+    ).rejects.toThrow('Unknown worker: unknown');
+  });
+
+  it('send_message: persistence unavailable guard', async () => {
+    const harness = await createHarness({ persistence: undefined as unknown as AgentsPersistenceService });
+    await addWorker(harness.module, harness.node, 'Worker Y');
+    const ctx = buildCtx();
+
+    await expect(
+      harness.tool.execute({ command: 'send_message', worker: 'Worker Y', message: 'msg' }, ctx),
+    ).rejects.toThrow('Manage: persistence unavailable');
+  });
+
+  it('execute: missing threadId guard', async () => {
+    const harness = await createHarness();
+    await addWorker(harness.module, harness.node, 'Worker Z');
+    const ctx = buildCtx({ threadId: undefined as unknown as string });
+
+    await expect(
+      harness.tool.execute({ command: 'send_message', worker: 'Worker Z', message: 'msg' }, ctx),
+    ).rejects.toThrow('Manage: missing threadId in LLM context');
   });
 
   it('check_status: aggregates active child threads scoped to current thread', async () => {
-    const module = await Test.createTestingModule({
-      providers: [
-        LoggerService,
-        { provide: ConfigService, useValue: new ConfigService().init(configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://localhost/agents' })) },
-        { provide: LLMProvisioner, useClass: StubLLMProvisioner },
-        ManageFunctionTool,
-        ManageToolNode,
-        FakeAgent,
-        {
-          provide: AgentsPersistenceService,
-          useValue: {
-            beginRunThread: async () => ({ runId: 't' }),
-            recordInjected: async () => ({ messageIds: [] }),
-            completeRun: async () => {},
-            getOrCreateSubthreadByAlias: async () => 'child-t',
-          },
-        },
-        RunSignalsRegistry,
-      ],
-    }).compile();
+    const harness = await createHarness();
+    await addWorker(harness.module, harness.node, 'A');
+    await addWorker(harness.module, harness.node, 'B');
 
-    const node = await module.resolve(ManageToolNode);
-    await node.setConfig({ description: 'desc' });
-    const agentA = await module.resolve(FakeAgent);
-    const agentB = await module.resolve(FakeAgent);
-    await agentA.setConfig({ title: 'A' });
-    await agentB.setConfig({ title: 'B' });
-    node.addWorker(agentA);
-    node.addWorker(agentB);
-
-    const tool = node.getTool();
-    const ctx: LLMContext = { threadId: 'p', runId: 'r', finishSignal: new Signal(), terminateSignal: new Signal(), callerAgent: { invoke: async () => new ResponseMessage({ output: [] }) } };
-    const statusStr = await tool.execute({ command: 'check_status', threadAlias: 'status' }, ctx);
+    const ctx = buildCtx();
+    const statusStr = await harness.tool.execute({ command: 'check_status', threadAlias: 'status' }, ctx);
     const status = JSON.parse(statusStr) as { activeTasks: number; childThreadIds: string[] };
     expect(status.activeTasks).toBe(0);
     expect(status.childThreadIds.length).toBe(0);
   });
 
   it('ManageToolNode enforces titled workers and handles retitle/removal', async () => {
-    const module = await Test.createTestingModule({
-      providers: [
-        LoggerService,
-        { provide: ConfigService, useValue: new ConfigService().init(configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://localhost/agents' })) },
-        { provide: LLMProvisioner, useClass: StubLLMProvisioner },
-        ManageFunctionTool,
-        ManageToolNode,
-        FakeAgent,
-        {
-          provide: AgentsPersistenceService,
-          useValue: {
-            beginRunThread: async () => ({ runId: 't' }),
-            recordInjected: async () => ({ messageIds: [] }),
-            completeRun: async () => {},
-            getOrCreateSubthreadByAlias: async () => 'child-t',
-          },
-        },
-        RunSignalsRegistry,
-      ],
-    }).compile();
+    const harness = await createHarness();
 
-    const node = await module.resolve(ManageToolNode);
-    await node.setConfig({ description: 'desc' });
+    const first = await addWorker(harness.module, harness.node, 'Alpha');
+    expect(harness.node.listWorkers()).toEqual(['Alpha']);
+    expect(() => harness.node.addWorker(first)).not.toThrow();
 
-    const first = await module.resolve(FakeAgent);
-    await first.setConfig({ title: 'Alpha' });
-    node.addWorker(first);
-    expect(node.listWorkers()).toEqual(['Alpha']);
-    expect(() => node.addWorker(first)).not.toThrow();
-
-    const noTitle = await module.resolve(FakeAgent);
+    const noTitle = await harness.module.resolve(FakeAgent);
     await noTitle.setConfig({});
-    expect(() => node.addWorker(noTitle)).toThrow('ManageToolNode: worker agent requires non-empty title');
+    expect(() => harness.node.addWorker(noTitle)).toThrow('ManageToolNode: worker agent requires non-empty title');
 
-    const dup = await module.resolve(FakeAgent);
+    const dup = await harness.module.resolve(FakeAgent);
     await dup.setConfig({ title: '  Alpha  ' });
-    expect(() => node.addWorker(dup)).toThrow('ManageToolNode: worker with title "Alpha" already exists');
+    expect(() => harness.node.addWorker(dup)).toThrow('ManageToolNode: worker with title "Alpha" already exists');
 
     await first.setConfig({ title: ' Beta ' });
-    expect(node.listWorkers()).toEqual(['Beta']);
-    expect(node.getWorkerByTitle('Beta')).toBe(first);
+    expect(harness.node.listWorkers()).toEqual(['Beta']);
+    expect(harness.node.getWorkerByTitle('Beta')).toBe(first);
 
-    node.removeWorker(first);
-    expect(node.listWorkers()).toEqual([]);
+    harness.node.removeWorker(first);
+    expect(harness.node.listWorkers()).toEqual([]);
   });
 
   it('send_message: surfaces child agent failure', async () => {
     const module = await Test.createTestingModule({
       providers: [
         LoggerService,
-        { provide: ConfigService, useValue: new ConfigService().init(configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://localhost/agents' })) },
+        {
+          provide: ConfigService,
+          useValue: new ConfigService().init(
+            configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://localhost/agents' }),
+          ),
+        },
         { provide: LLMProvisioner, useClass: StubLLMProvisioner },
         ManageFunctionTool,
         ManageToolNode,
         FakeAgent,
         {
           provide: AgentsPersistenceService,
-          useValue: {
-            beginRunThread: async () => ({ runId: 't' }),
-            recordInjected: async () => ({ messageIds: [] }),
-            completeRun: async () => {},
-            getOrCreateSubthreadByAlias: async () => 'child-t',
-          },
+          useValue: { getOrCreateSubthreadByAlias: async () => 'child-t' } as unknown as AgentsPersistenceService,
         },
         RunSignalsRegistry,
       ],
@@ -222,18 +237,27 @@ describe('ManageTool unit', () => {
 
     const node = await module.resolve(ManageToolNode);
     await node.setConfig({ description: 'desc' });
+
     class ThrowingAgent extends FakeAgent {
       override async invoke(): Promise<ResponseMessage> {
         throw new Error('child failure');
       }
     }
-    const failingAgent = new ThrowingAgent(module.get(ConfigService), module.get(LoggerService), module.get(LLMProvisioner), module.get(ModuleRef));
+
+    const failingAgent = new ThrowingAgent(
+      module.get(ConfigService),
+      module.get(LoggerService),
+      module.get(LLMProvisioner),
+      module.get(ModuleRef),
+    );
     await failingAgent.setConfig({ title: 'W' });
     node.addWorker(failingAgent);
 
     const tool = node.getTool();
-    const ctx: LLMContext = { threadId: 'p', runId: 'r', finishSignal: new Signal(), terminateSignal: new Signal(), callerAgent: { invoke: async () => new ResponseMessage({ output: [] }) } };
-    await expect(tool.execute({ command: 'send_message', worker: 'W', message: 'go', threadAlias: 'alias-W' }, ctx)).rejects.toThrow('child failure');
+    const ctx = buildCtx({ threadId: 'p' });
+    await expect(
+      tool.execute({ command: 'send_message', worker: 'W', message: 'go', threadAlias: 'alias-W' }, ctx),
+    ).rejects.toThrow('child failure');
   });
 });
 
@@ -242,19 +266,19 @@ describe('ManageTool graph wiring', () => {
     const module = await Test.createTestingModule({
       providers: [
         LoggerService,
-        { provide: ConfigService, useValue: new ConfigService().init(configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://localhost/agents' })) },
+        {
+          provide: ConfigService,
+          useValue: new ConfigService().init(
+            configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://localhost/agents' }),
+          ),
+        },
         { provide: LLMProvisioner, useClass: StubLLMProvisioner },
         ManageFunctionTool,
         ManageToolNode,
         FakeAgent,
         {
           provide: AgentsPersistenceService,
-          useValue: {
-            beginRunThread: async () => ({ runId: 't' }),
-            recordInjected: async () => ({ messageIds: [] }),
-            completeRun: async () => {},
-            getOrCreateSubthreadByAlias: async () => 'child-t',
-          },
+          useValue: { getOrCreateSubthreadByAlias: async () => 'child-t' } as unknown as AgentsPersistenceService,
         },
         RunSignalsRegistry,
       ],
@@ -264,7 +288,10 @@ describe('ManageTool graph wiring', () => {
       addTool(_tool: unknown) {}
       removeTool(_tool: unknown) {}
       override getPortConfig() {
-        return { sourcePorts: { tools: { kind: 'method', create: 'addTool', destroy: 'removeTool' } }, targetPorts: { $self: { kind: 'instance' } } } as const;
+        return {
+          sourcePorts: { tools: { kind: 'method', create: 'addTool', destroy: 'removeTool' } },
+          targetPorts: { $self: { kind: 'instance' } },
+        } as const;
       }
     }
 
@@ -294,12 +321,7 @@ describe('ManageTool graph wiring', () => {
         { provide: ModuleRef, useValue: moduleRef },
         {
           provide: AgentsPersistenceService,
-          useValue: {
-            beginRunThread: async () => ({ runId: 't' }),
-            recordInjected: async () => ({ messageIds: [] }),
-            completeRun: async () => {},
-            getOrCreateSubthreadByAlias: async () => 'child-t',
-          },
+          useValue: { getOrCreateSubthreadByAlias: async () => 'child-t' } as unknown as AgentsPersistenceService,
         },
         RunSignalsRegistry,
       ],

--- a/packages/platform-server/src/nodes/tools/manage/manage.node.ts
+++ b/packages/platform-server/src/nodes/tools/manage/manage.node.ts
@@ -4,6 +4,7 @@ import { BaseToolNode } from '../baseToolNode';
 import { ManageFunctionTool } from './manage.tool';
 import { AgentNode } from '../../agent/agent.node';
 import { LoggerService } from '../../../core/services/logger.service';
+import { AgentsPersistenceService } from '../../../agents/agents.persistence.service';
 
 export const ManageToolStaticConfigSchema = z
   .object({
@@ -24,6 +25,7 @@ export class ManageToolNode extends BaseToolNode<z.infer<typeof ManageToolStatic
   constructor(
     @Inject(ManageFunctionTool) private readonly manageTool: ManageFunctionTool,
     @Inject(LoggerService) protected logger: LoggerService,
+    @Inject(AgentsPersistenceService) private readonly persistence: AgentsPersistenceService,
   ) {
     super(logger);
   }
@@ -77,7 +79,7 @@ export class ManageToolNode extends BaseToolNode<z.infer<typeof ManageToolStatic
   }
 
   protected createTool() {
-    return this.manageTool.init(this);
+    return this.manageTool.init(this, { persistence: this.persistence });
   }
 
   getTool() {

--- a/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
+++ b/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
@@ -84,7 +84,14 @@ export class ManageFunctionTool extends FunctionTool<typeof ManageInvocationSche
       if (!targetAgent) throw new Error(`Unknown worker: ${targetTitle}`);
       const persistence = this.getPersistence();
       if (!persistence) throw new Error('Manage: persistence unavailable');
-      const alias = this.sanitizeAlias(threadAlias ?? targetTitle);
+      const alias =
+        typeof threadAlias === 'string'
+          ? (() => {
+              const trimmed = threadAlias.trim();
+              if (!trimmed) throw new Error('Manage: invalid or empty threadAlias');
+              return trimmed;
+            })()
+          : this.sanitizeAlias(targetTitle);
       const childThreadId = await persistence.getOrCreateSubthreadByAlias('manage', alias, parentThreadId, '');
       try {
         const res = await targetAgent.invoke(childThreadId, [HumanMessage.fromText(messageText)]);

--- a/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
+++ b/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
@@ -12,20 +12,29 @@ export const ManageInvocationSchema = z
     command: z.enum(['send_message', 'check_status']).describe('Command to execute.'),
     worker: z.string().min(1).optional().describe('Target worker name (required for send_message).'),
     message: z.string().min(1).optional().describe('Message to send (required for send_message).'),
-    threadAlias: z.string().min(1).describe('Child thread alias'),
+    threadAlias: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Optional child thread alias; defaults per worker title.'),
   })
   .strict();
 
 @Injectable({ scope: Scope.TRANSIENT })
 export class ManageFunctionTool extends FunctionTool<typeof ManageInvocationSchema> {
   private _node?: ManageToolNode;
+  private persistence?: AgentsPersistenceService;
 
-  constructor(@Inject(LoggerService) private readonly logger: LoggerService, @Inject(AgentsPersistenceService) private readonly persistence: AgentsPersistenceService) {
+  constructor(
+    @Inject(LoggerService) private readonly logger: LoggerService,
+    @Inject(AgentsPersistenceService) private readonly injectedPersistence: AgentsPersistenceService,
+  ) {
     super();
   }
 
-  init(node: ManageToolNode) {
+  init(node: ManageToolNode, options?: { persistence?: AgentsPersistenceService }) {
     this._node = node;
+    this.persistence = options?.persistence ?? this.injectedPersistence;
     return this;
   }
 
@@ -44,9 +53,26 @@ export class ManageFunctionTool extends FunctionTool<typeof ManageInvocationSche
     return this.node.config.description ?? 'Manage tool';
   }
 
+  private getPersistence(): AgentsPersistenceService | undefined {
+    return this.persistence ?? this.injectedPersistence;
+  }
+
+  private sanitizeAlias(raw: string | undefined): string {
+    const normalized = (raw ?? '').toLowerCase();
+    const withHyphen = normalized.replace(/\s+/g, '-');
+    const cleaned = withHyphen.replace(/[^a-z0-9._-]/g, '');
+    const collapsed = cleaned.replace(/-+/g, '-');
+    const truncated = collapsed.slice(0, 64);
+    if (!truncated || !/[a-z0-9]/.test(truncated)) {
+      throw new Error('Manage: invalid or empty threadAlias');
+    }
+    return truncated;
+  }
+
   async execute(args: z.infer<typeof ManageInvocationSchema>, ctx: LLMContext): Promise<string> {
     const { command, worker, message, threadAlias } = args;
     const parentThreadId = ctx.threadId;
+    if (!parentThreadId) throw new Error('Manage: missing threadId in LLM context');
     const workerTitles = this.node.listWorkers();
     if (command === 'send_message') {
       if (!workerTitles.length) throw new Error('No agents connected');
@@ -56,7 +82,10 @@ export class ManageFunctionTool extends FunctionTool<typeof ManageInvocationSche
       if (!messageText) throw new Error('message is required for send_message');
       const targetAgent = this.node.getWorkerByTitle(targetTitle);
       if (!targetAgent) throw new Error(`Unknown worker: ${targetTitle}`);
-      const childThreadId = await this.persistence.getOrCreateSubthreadByAlias('manage', threadAlias, parentThreadId, '');
+      const persistence = this.getPersistence();
+      if (!persistence) throw new Error('Manage: persistence unavailable');
+      const alias = this.sanitizeAlias(threadAlias ?? targetTitle);
+      const childThreadId = await persistence.getOrCreateSubthreadByAlias('manage', alias, parentThreadId, '');
       try {
         const res = await targetAgent.invoke(childThreadId, [HumanMessage.fromText(messageText)]);
         return res?.text;


### PR DESCRIPTION
Explicitly wire AgentsPersistenceService into ManageFunctionTool via node init; add guards for missing persistence/threadId; preserve caller-provided threadAlias verbatim; sanitize only derived default alias. Tests included. Closes #832.