### PR TITLE
refactor: enforce resolver injection for platform nodes

### DIFF
--- a/packages/platform-server/__tests__/helpers/module-ref.stub.ts
+++ b/packages/platform-server/__tests__/helpers/module-ref.stub.ts
@@ -1,0 +1,15 @@
+import type { ModuleRef } from '@nestjs/core';
+
+type ModuleRefOverrides = Partial<Pick<ModuleRef, 'get' | 'create' | 'resolve'>>;
+
+export function createModuleRefStub(overrides: ModuleRefOverrides = {}): ModuleRef {
+  const base: ModuleRefOverrides = {
+    get: () => undefined,
+    create: async () => undefined,
+    resolve: async () => undefined,
+  };
+  return {
+    ...base,
+    ...overrides,
+  } as ModuleRef;
+}

--- a/packages/platform-server/__tests__/helpers/reference-resolver.stub.ts
+++ b/packages/platform-server/__tests__/helpers/reference-resolver.stub.ts
@@ -1,0 +1,28 @@
+import { vi } from 'vitest';
+
+import type { ReferenceResolverService } from '../../src/utils/reference-resolver.service';
+
+type ResolutionCounts = {
+  total: number;
+  resolved: number;
+  unresolved: number;
+  cacheHits: number;
+  errors: number;
+};
+
+const DEFAULT_COUNTS: ResolutionCounts = {
+  total: 0,
+  resolved: 0,
+  unresolved: 0,
+  cacheHits: 0,
+  errors: 0,
+};
+
+export function createReferenceResolverStub() {
+  const resolve = vi.fn(async <T>(input: T) => ({
+    output: input,
+    report: { events: [], counts: { ...DEFAULT_COUNTS } },
+  }));
+  const stub = { resolve } as unknown as ReferenceResolverService;
+  return { stub, resolve };
+}

--- a/packages/platform-server/__tests__/localMcpServer.heartbeat.test.ts
+++ b/packages/platform-server/__tests__/localMcpServer.heartbeat.test.ts
@@ -3,6 +3,7 @@ import { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
 import { ContainerService } from '../src/infra/container/container.service';
 import type { ContainerRegistry } from '../src/infra/container/container.registry';
 import { PassThrough } from 'node:stream';
+import { createModuleRefStub } from './helpers/module-ref.stub';
 
 function createBlockingMcpMock() {
   const tools = [
@@ -98,7 +99,7 @@ describe('LocalMCPServer heartbeat behavior', () => {
       }),
     });
     const envStub = { resolveEnvItems: async () => ({}), resolveProviderEnv: async () => ({}) } as any;
-    const server = new LocalMCPServerNode(containerService as any, envStub, {} as any, undefined as any);
+    const server = new LocalMCPServerNode(containerService as any, envStub, {} as any, createModuleRefStub());
     server.setContainerProvider({ provide: async (t: string) => ({ id: `cid-${t}` }) } as any);
     await server.setConfig({ namespace: 'mock', command: 'ignored', heartbeatIntervalMs: 100 } as any);
 

--- a/packages/platform-server/__tests__/localMcpServer.test.ts
+++ b/packages/platform-server/__tests__/localMcpServer.test.ts
@@ -4,6 +4,7 @@ import { McpServerConfig } from '../src/mcp/types.js';
 import { PassThrough } from 'node:stream';
 import { ContainerService } from '../src/infra/container/container.service';
 import type { ContainerRegistry } from '../src/infra/container/container.registry';
+import { createModuleRefStub } from './helpers/module-ref.stub';
 // no extra imports
 
 /**
@@ -139,7 +140,7 @@ describe('LocalMCPServer (mock)', () => {
       }),
     });
     const envStub = { resolveEnvItems: async () => ({}), resolveProviderEnv: async () => ({}) } as any;
-    server = new LocalMCPServerNode(containerService as any, envStub, {} as any, undefined as any);
+    server = new LocalMCPServerNode(containerService as any, envStub, {} as any, createModuleRefStub());
     // Provide a dummy container provider to satisfy start precondition (reuse mocked docker above)
     const mockProvider = {
       provide: async (threadId: string) => ({ 

--- a/packages/platform-server/__tests__/manage.tool.test.ts
+++ b/packages/platform-server/__tests__/manage.tool.test.ts
@@ -17,6 +17,8 @@ import type { LLMContext } from '../src/llm/types';
 import { AgentNode } from '../src/nodes/agent/agent.node';
 import { ManageFunctionTool } from '../src/nodes/tools/manage/manage.tool';
 import { ManageToolNode } from '../src/nodes/tools/manage/manage.node';
+import { ReferenceResolverService } from '../src/utils/reference-resolver.service';
+import { createReferenceResolverStub } from './helpers/reference-resolver.stub';
 
 class StubLLMProvisioner extends LLMProvisioner {
   async getLLM(): Promise<{ call: (messages: unknown) => Promise<{ text: string; output: unknown[] }> }> {
@@ -68,6 +70,7 @@ async function createHarness(options: { persistence?: AgentsPersistenceService }
       FakeAgent,
       { provide: AgentsPersistenceService, useValue: persistence },
       RunSignalsRegistry,
+      { provide: ReferenceResolverService, useValue: createReferenceResolverStub().stub },
     ],
   }).compile();
 
@@ -366,6 +369,7 @@ describe('ManageTool graph wiring', () => {
             upsertNodeState: async () => {},
           },
         },
+        { provide: ReferenceResolverService, useValue: createReferenceResolverStub().stub },
         { provide: ModuleRef, useValue: moduleRef },
         {
           provide: AgentsPersistenceService,

--- a/packages/platform-server/__tests__/mcp-lifecycle-changes.test.ts
+++ b/packages/platform-server/__tests__/mcp-lifecycle-changes.test.ts
@@ -3,6 +3,7 @@ import { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
 import { McpServerConfig } from '../src/mcp/types.js';
 import { ContainerService } from '../src/infra/container/container.service';
 import type { ContainerRegistry } from '../src/infra/container/container.registry';
+import { createModuleRefStub } from './helpers/module-ref.stub';
 
 describe('MCP Lifecycle Changes', () => {
   const createContainerService = () => {
@@ -23,7 +24,7 @@ describe('MCP Lifecycle Changes', () => {
 
   it('supports threadId parameter in callTool method', async () => {
     const containerService = createContainerService();
-    const server = new LocalMCPServerNode(containerService as any, envStub, {} as any, undefined as any);
+    const server = new LocalMCPServerNode(containerService as any, envStub, {} as any, createModuleRefStub());
     const mockProvider = {
       provide: async (threadId: string) => ({
         id: `container-${threadId}`,
@@ -44,7 +45,7 @@ describe('MCP Lifecycle Changes', () => {
 
   it('has discoverTools method for initial tool discovery', async () => {
     const containerService = createContainerService();
-    const server = new LocalMCPServerNode(containerService as any, envStub, {} as any, undefined as any);
+    const server = new LocalMCPServerNode(containerService as any, envStub, {} as any, createModuleRefStub());
     expect(typeof server.discoverTools).toBe('function');
 
     try {
@@ -56,7 +57,7 @@ describe('MCP Lifecycle Changes', () => {
 
   it('demonstrates new vs old lifecycle pattern', () => {
     const containerService = createContainerService();
-    const server = new LocalMCPServerNode(containerService as any, envStub, {} as any, undefined as any);
+    const server = new LocalMCPServerNode(containerService as any, envStub, {} as any, createModuleRefStub());
     expect(typeof server.discoverTools).toBe('function');
     expect(server.callTool.length >= 2).toBe(true);
     expect((server as any).client).toBeUndefined();

--- a/packages/platform-server/__tests__/mcp.listTools.snapshot_fallback.test.ts
+++ b/packages/platform-server/__tests__/mcp.listTools.snapshot_fallback.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
+import { createModuleRefStub } from './helpers/module-ref.stub';
 
 class MockContainerService {
   getDocker() {
@@ -16,7 +17,8 @@ describe('LocalMCPServerNode listTools: snapshot-first, fallback-to-setState, na
   beforeEach(async () => {
     logger = { log: vi.fn(), error: vi.fn(), debug: vi.fn() };
     const nodeStateService = { getSnapshot: vi.fn((_id: string) => undefined) } as any; // snapshot not ready
-    server = new LocalMCPServerNode(new MockContainerService() as any, makeEnvService() as any, {} as any, undefined as any);
+    const moduleRef = createModuleRefStub({ get: () => nodeStateService });
+    server = new LocalMCPServerNode(new MockContainerService() as any, makeEnvService() as any, {} as any, moduleRef);
     (server as any).init({ nodeId: 'node-x' });
     await server.setConfig({ namespace: 'ns' } as any);
     (server as any).preloadCachedTools(

--- a/packages/platform-server/__tests__/mcp.preload.stale.persist.test.ts
+++ b/packages/platform-server/__tests__/mcp.preload.stale.persist.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
 import { ContainerService } from '../src/infra/container/container.service';
 import type { ContainerRegistry } from '../src/infra/container/container.registry';
+import { createModuleRefStub } from './helpers/module-ref.stub';
 
 describe('LocalMCPServer preload + staleness + persist', () => {
   let server: LocalMCPServerNode;
@@ -21,7 +22,7 @@ describe('LocalMCPServer preload + staleness + persist', () => {
     } as unknown as ContainerRegistry;
     const cs = new ContainerService(registryStub);
     const envStub = { resolveEnvItems: async () => ({}), resolveProviderEnv: async () => ({}) } as any;
-    server = new LocalMCPServerNode(cs as any, envStub, {} as any, undefined as any);
+    server = new LocalMCPServerNode(cs as any, envStub, {} as any, createModuleRefStub());
     await server.setConfig({ namespace: 'x', command: 'echo' } as any);
     (server as any).setContainerProvider({ provide: async () => ({ id: 'cid', stop: async () => {}, remove: async () => {} }) });
     (server as any).on('mcp.tools_updated', (p: { tools: any[]; updatedAt: number }) => { lastUpdate = p; });

--- a/packages/platform-server/__tests__/mcp.provision.dynamic.test.ts
+++ b/packages/platform-server/__tests__/mcp.provision.dynamic.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
 import type { McpServerConfig, McpTool } from '../src/mcp/types';
+import { createModuleRefStub } from './helpers/module-ref.stub';
 
 class MockLogger {
   info = vi.fn();
@@ -28,7 +29,7 @@ describe('LocalMCPServer provision/deprovision + enabledTools filtering', () => 
       resolveEnvItems: vi.fn(async () => ({})),
       resolveProviderEnv: vi.fn(async () => ({})),
     } as any;
-    server = new LocalMCPServerNode(new MockContainerService() as any, envStub, {} as any, undefined as any);
+    server = new LocalMCPServerNode(new MockContainerService() as any, envStub, {} as any, createModuleRefStub());
     (server as any).logger = logger;
     (server as any).setContainerProvider(mockProvider as any);
   });

--- a/packages/platform-server/__tests__/mcp.tools.sync.test.ts
+++ b/packages/platform-server/__tests__/mcp.tools.sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
+import { createModuleRefStub } from './helpers/module-ref.stub';
 
 class MockLogger {
   info = vi.fn();
@@ -17,7 +18,7 @@ describe('LocalMCPServerNode listTools filtering by enabledTools', () => {
 
   beforeEach(async () => {
     const nodeStateService = { getSnapshot: vi.fn((_id: string) => ({ mcp: { enabledTools: [] } })) } as any;
-    const moduleRef = { get: vi.fn(() => nodeStateService) } as any;
+    const moduleRef = createModuleRefStub({ get: vi.fn(() => nodeStateService) });
     const envStub = { resolveEnvItems: vi.fn(), resolveProviderEnv: vi.fn() } as any;
     const logger = new MockLogger();
     server = new LocalMCPServerNode(new MockContainerService() as any, envStub, {} as any, moduleRef as any);
@@ -60,7 +61,7 @@ describe('LocalMCPServerNode setState enabledTools emits mcp.tools_updated', () 
   it('emits on hook invocation', async () => {
     const logger = new MockLogger();
     const envStub = { resolveEnvItems: vi.fn(), resolveProviderEnv: vi.fn() } as any;
-    const server = new LocalMCPServerNode(new MockContainerService() as any, envStub, {} as any, undefined as any);
+    const server = new LocalMCPServerNode(new MockContainerService() as any, envStub, {} as any, createModuleRefStub());
     (server as any).logger = logger;
     // Preload one tool for payload consistency
     (server as any).preloadCachedTools([{ name: 'x', description: 'X', inputSchema: { type: 'object' } }], Date.now());

--- a/packages/platform-server/__tests__/mixed.shell.mcp.isolation.test.ts
+++ b/packages/platform-server/__tests__/mixed.shell.mcp.isolation.test.ts
@@ -5,6 +5,7 @@ import { EnvService } from '../src/env/env.service';
 import { ShellCommandNode } from '../src/nodes/tools/shell_command/shell_command.node';
 import { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
 import { Signal } from '../src/signal';
+import { createModuleRefStub } from './helpers/module-ref.stub';
 
 class FakeContainer {
   last: unknown;
@@ -75,7 +76,7 @@ describe('Mixed Shell + MCP overlay isolation', () => {
       }),
     } as const;
     const cs = { getDocker: () => docker };
-    const mcp = new LocalMCPServerNode(cs as any, envService as any, cfg as any, undefined as any);
+    const mcp = new LocalMCPServerNode(cs as any, envService as any, cfg as any, createModuleRefStub());
     mcp.init({ nodeId: 'mcp' });
     (mcp as any).setContainerProvider(provider);
     await mcp.setConfig({ namespace: 'n', command: 'mcp start --stdio', env: [ { name: 'M_VAR', value: 'm' } ], startupTimeoutMs: 10 });

--- a/packages/platform-server/__tests__/nodes.module.di.smoke.test.ts
+++ b/packages/platform-server/__tests__/nodes.module.di.smoke.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { SlackTrigger } from '../src/nodes/slackTrigger/slackTrigger.node';
 import { RemindMeNode } from '../src/nodes/tools/remind_me/remind_me.node';
-import { VaultService } from '../src/vault/vault.service';
 import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
 import { PrismaService } from '../src/core/services/prisma.service';
 import { SlackAdapter } from '../src/messaging/slack/slack.adapter';
 import { EventsBusService } from '../src/events/events-bus.service';
+import { createReferenceResolverStub } from './helpers/reference-resolver.stub';
 
 process.env.LLM_PROVIDER = process.env.LLM_PROVIDER || 'openai';
 process.env.AGENTS_DATABASE_URL = process.env.AGENTS_DATABASE_URL || 'postgres://localhost:5432/test';
@@ -24,10 +24,6 @@ const makeStub = <T extends Record<string, unknown>>(overrides: T): T =>
 
 const slackAdapterStub = makeStub({
   sendText: vi.fn(),
-});
-
-const vaultServiceStub = makeStub({
-  getSecret: vi.fn().mockResolvedValue('xoxb-test-token'),
 });
 
 const persistenceStub = makeStub({
@@ -76,7 +72,7 @@ if (!shouldRunDbTests) {
   describe('NodesModule DI smoke test', () => {
     it('constructs SlackTrigger and RemindMeNode with stubs', () => {
       const slackTrigger = new SlackTrigger(
-        vaultServiceStub as unknown as VaultService,
+        createReferenceResolverStub().stub,
         persistenceStub as unknown as AgentsPersistenceService,
         prismaStub as unknown as PrismaService,
         slackAdapterStub as unknown as SlackAdapter,

--- a/packages/platform-server/__tests__/nodes/node-di.helper.ts
+++ b/packages/platform-server/__tests__/nodes/node-di.helper.ts
@@ -22,6 +22,8 @@ import { LLMProvisioner } from '../../src/llm/provisioners/llm.provisioner';
 import { SlackAdapter } from '../../src/messaging/slack/slack.adapter';
 import { ManageFunctionTool } from '../../src/nodes/tools/manage/manage.tool';
 import { VaultService } from '../../src/vault/vault.service';
+import { ReferenceResolverService } from '../../src/utils/reference-resolver.service';
+import { createReferenceResolverStub } from '../helpers/reference-resolver.stub';
 
 type InjectionToken = Type<unknown> | string | symbol;
 
@@ -91,6 +93,13 @@ const DEFAULT_TOKEN_FACTORIES = new Map<InjectionToken, () => unknown>([
   [CallAgentLinkingService, () => createDefaultStub('CallAgentLinkingService')],
   [LiveGraphRuntime, () => createDefaultStub('LiveGraphRuntime')],
   [TemplateRegistry, () => createDefaultStub('TemplateRegistry', { getMeta: vi.fn(() => undefined) })],
+  [
+    ReferenceResolverService,
+    () => {
+      const { stub } = createReferenceResolverStub();
+      return stub;
+    },
+  ],
   [
     ManageFunctionTool,
     () =>

--- a/packages/platform-server/__tests__/slack.pr.trigger.lifecycle.test.ts
+++ b/packages/platform-server/__tests__/slack.pr.trigger.lifecycle.test.ts
@@ -3,6 +3,7 @@ import { SlackTrigger } from '../src/nodes/slackTrigger/slackTrigger.node';
 import type { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
 import type { PrismaService } from '../src/core/services/prisma.service';
 import type { SlackAdapter } from '../src/messaging/slack/slack.adapter';
+import { createReferenceResolverStub } from './helpers/reference-resolver.stub';
 
 // Mock @slack/socket-mode to avoid network/real client
 const socketClients: Array<{ start: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }> = [];
@@ -46,7 +47,8 @@ describe('SlackTrigger and PRTrigger lifecycle', () => {
       getNodes: () => [],
     } satisfies Pick<import('../src/graph-core/liveGraph.manager').LiveGraphRuntime, 'getOutboundNodeIds' | 'getNodes'>) as import('../src/graph-core/liveGraph.manager').LiveGraphRuntime;
     const templateRegistryStub = ({ getMeta: () => undefined } satisfies Pick<import('../src/graph-core/templateRegistry').TemplateRegistry, 'getMeta'>) as import('../src/graph-core/templateRegistry').TemplateRegistry;
-    const trigger = new SlackTrigger(undefined as any, persistence, prisma as PrismaService, slackAdapter, runtimeStub, templateRegistryStub);
+    const { stub: referenceResolver } = createReferenceResolverStub();
+    const trigger = new SlackTrigger(referenceResolver, persistence, prisma as PrismaService, slackAdapter, runtimeStub, templateRegistryStub);
     await trigger.setConfig({ app_token: 'xapp-test', bot_token: 'xoxb-test' });
     await trigger.provision();
     await trigger.deprovision();

--- a/packages/platform-server/__tests__/slack.threading.integration.test.ts
+++ b/packages/platform-server/__tests__/slack.threading.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SlackTrigger } from '../src/nodes/slackTrigger/slackTrigger.node';
 import type { SlackAdapter } from '../src/messaging/slack/slack.adapter';
+import { createReferenceResolverStub } from './helpers/reference-resolver.stub';
 
 type ChannelDescriptor = import('../src/messaging/types').ChannelDescriptor;
 
@@ -98,7 +99,8 @@ describe('SlackTrigger threading integration', () => {
       getNodes: () => [{ id: 'agent-slack', template: 'agent' }],
     } satisfies Pick<import('../src/graph-core/liveGraph.manager').LiveGraphRuntime, 'getOutboundNodeIds' | 'getNodes'>) as import('../src/graph-core/liveGraph.manager').LiveGraphRuntime;
     const templateRegistryStub = ({ getMeta: (template: string) => (template === 'agent' ? { kind: 'agent', title: 'Agent' } : undefined) } satisfies Pick<import('../src/graph-core/templateRegistry').TemplateRegistry, 'getMeta'>) as import('../src/graph-core/templateRegistry').TemplateRegistry;
-    const trigger = new SlackTrigger(undefined as any, persistence, prismaStub, slackAdapter, runtimeStub, templateRegistryStub);
+    const { stub: referenceResolver } = createReferenceResolverStub();
+    const trigger = new SlackTrigger(referenceResolver, persistence, prismaStub, slackAdapter, runtimeStub, templateRegistryStub);
     trigger.init({ nodeId: 'slack-node' });
     await trigger.setConfig({ app_token: 'xapp-abc', bot_token: 'xoxb-bot' });
     await trigger.provision();

--- a/packages/platform-server/__tests__/tools.send_message.integration.test.ts
+++ b/packages/platform-server/__tests__/tools.send_message.integration.test.ts
@@ -4,6 +4,7 @@ import { SendMessageFunctionTool } from '../src/nodes/tools/send_message/send_me
 import { SlackTrigger } from '../src/nodes/slackTrigger/slackTrigger.node';
 import type { SlackAdapter } from '../src/messaging/slack/slack.adapter';
 import type { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
+import { createReferenceResolverStub } from './helpers/reference-resolver.stub';
 
 // Mock slack web api
 import { vi } from 'vitest';
@@ -81,7 +82,8 @@ describe('send_message tool', () => {
       getNodes: () => [],
     } satisfies Pick<import('../src/graph-core/liveGraph.manager').LiveGraphRuntime, 'getOutboundNodeIds' | 'getNodes'>) as import('../src/graph-core/liveGraph.manager').LiveGraphRuntime;
     const templateRegistryStub = ({ getMeta: () => undefined } satisfies Pick<import('../src/graph-core/templateRegistry').TemplateRegistry, 'getMeta'>) as import('../src/graph-core/templateRegistry').TemplateRegistry;
-    const trigger = new SlackTrigger(undefined as any, persistence, prismaService, slackAdapter, runtimeStub, templateRegistryStub);
+    const { stub: referenceResolver } = createReferenceResolverStub();
+    const trigger = new SlackTrigger(referenceResolver, persistence, prismaService, slackAdapter, runtimeStub, templateRegistryStub);
     trigger.init({ nodeId: 'channel-node' });
 
     // Override prisma behavior for descriptor lookup inside sendToChannel
@@ -134,7 +136,8 @@ describe('send_message tool', () => {
       getNodes: () => [],
     } satisfies Pick<import('../src/graph-core/liveGraph.manager').LiveGraphRuntime, 'getOutboundNodeIds' | 'getNodes'>) as import('../src/graph-core/liveGraph.manager').LiveGraphRuntime;
     const templateRegistryStub = ({ getMeta: () => undefined } satisfies Pick<import('../src/graph-core/templateRegistry').TemplateRegistry, 'getMeta'>) as import('../src/graph-core/templateRegistry').TemplateRegistry;
-    const trigger = new SlackTrigger(undefined as any, persistence, prismaService, slackAdapter, runtimeStub, templateRegistryStub);
+    const { stub: referenceResolver } = createReferenceResolverStub();
+    const trigger = new SlackTrigger(referenceResolver, persistence, prismaService, slackAdapter, runtimeStub, templateRegistryStub);
     trigger.init({ nodeId: 'channel-node' });
     const runtime = makeRuntimeStub(trigger);
     const tool = new SendMessageFunctionTool(prismaService, runtime);

--- a/packages/platform-server/__tests__/tools.send_slack_message.tool.test.ts
+++ b/packages/platform-server/__tests__/tools.send_slack_message.tool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { SendSlackMessageNode } from '../src/nodes/tools/send_slack_message/send_slack_message.node';
 import { SendSlackMessageFunctionTool } from '../src/nodes/tools/send_slack_message/send_slack_message.tool';
+import { createReferenceResolverStub } from './helpers/reference-resolver.stub';
 
 vi.mock('@slack/web-api', () => {
   const postEphemeral = vi.fn(async (_opts: { channel: string; user: string; text: string }) => ({ ok: true, message_ts: '999' }));
@@ -16,7 +17,8 @@ vi.mock('@slack/web-api', () => {
 
 describe('SendSlackMessageFunctionTool', () => {
   it('omits thread_ts for ephemeral responses', async () => {
-    const node = new SendSlackMessageNode(undefined as any);
+    const { stub: referenceResolver } = createReferenceResolverStub();
+    const node = new SendSlackMessageNode(referenceResolver);
     await node.setConfig({ bot_token: 'xoxb-bot' });
     const tool = new SendSlackMessageFunctionTool(node);
     const res = await tool.execute({

--- a/packages/platform-server/src/graph-core/liveGraph.manager.ts
+++ b/packages/platform-server/src/graph-core/liveGraph.manager.ts
@@ -8,7 +8,7 @@ import {
 } from '../graph/liveGraph.types';
 import type { EdgeDef, GraphDefinition, NodeDef } from '../shared/types/graph.types';
 import { GraphError } from '../graph/types';
-import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { ZodError, type ZodIssue } from 'zod';
 
@@ -49,7 +49,7 @@ export class LiveGraphRuntime {
     @Inject(TemplateRegistry) private readonly templateRegistry: TemplateRegistry,
     @Inject(GraphRepository) private readonly graphs: GraphRepository,
     @Inject(ModuleRef) private readonly moduleRef: ModuleRef,
-    @Optional() @Inject(ReferenceResolverService) private readonly referenceResolver?: ReferenceResolverService,
+    @Inject(ReferenceResolverService) private readonly referenceResolver: ReferenceResolverService,
   ) {
     this.portsRegistry = new PortsRegistry();
   }
@@ -461,7 +461,6 @@ export class LiveGraphRuntime {
   }
 
   private async resolveNodeConfig(nodeId: string, config: Record<string, unknown>): Promise<Record<string, unknown>> {
-    if (!this.referenceResolver) return config;
     try {
       const { output } = await this.referenceResolver.resolve<Record<string, unknown>>(config, {
         graphName: this.graphName,

--- a/packages/platform-server/src/nodes/mcp/localMcpServer.node.ts
+++ b/packages/platform-server/src/nodes/mcp/localMcpServer.node.ts
@@ -12,7 +12,7 @@ import { LocalMCPServerTool } from './localMcpServer.tool';
 import { DEFAULT_MCP_COMMAND, McpError, type McpTool, McpToolCallResult, PersistedMcpState } from './types';
 import { NodeStateService } from '../../graph/nodeState.service';
 import Node from '../base/Node';
-import { Inject, Injectable, Scope, Optional } from '@nestjs/common';
+import { Inject, Injectable, Scope } from '@nestjs/common';
 import { jsonSchemaToZod } from '@agyn/json-schema-to-zod';
 import { isEqual } from 'lodash-es';
 import { ModuleRef } from '@nestjs/core';
@@ -107,7 +107,7 @@ export class LocalMCPServerNode extends Node<z.infer<typeof LocalMcpServerStatic
     @Inject(ContainerService) protected containerService: ContainerService,
     @Inject(EnvService) protected envService: EnvService,
     @Inject(ConfigService) protected configService: ConfigService,
-    @Inject(ModuleRef) @Optional() private readonly moduleRef?: ModuleRef,
+    @Inject(ModuleRef) private readonly moduleRef: ModuleRef,
   ) {
     super();
   }
@@ -121,7 +121,6 @@ export class LocalMCPServerNode extends Node<z.infer<typeof LocalMcpServerStatic
 
   private getNodeStateService(): NodeStateService | undefined {
     if (!this.nodeStateService) {
-      if (!this.moduleRef) return undefined;
       try {
         this.nodeStateService = this.moduleRef.get(NodeStateService, { strict: false });
       } catch {

--- a/packages/platform-server/src/nodes/slackTrigger/slackTrigger.node.ts
+++ b/packages/platform-server/src/nodes/slackTrigger/slackTrigger.node.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ReferenceResolverService } from '../../utils/reference-resolver.service';
 import { ResolveError } from '../../utils/references';
 import Node from '../base/Node';
-import { Inject, Injectable, Scope, Optional } from '@nestjs/common';
+import { Inject, Injectable, Scope } from '@nestjs/common';
 import { BufferMessage } from '../agent/messagesBuffer';
 import { HumanMessage } from '@agyn/llm';
 import { stringify as YamlStringify } from 'yaml';
@@ -61,8 +61,7 @@ export class SlackTrigger extends Node<SlackTriggerConfig> {
 
   constructor(
     @Inject(ReferenceResolverService)
-    @Optional()
-    private readonly referenceResolver: ReferenceResolverService | null = null,
+    private readonly referenceResolver: ReferenceResolverService,
     @Inject(AgentsPersistenceService) private readonly persistence: AgentsPersistenceService,
     @Inject(PrismaService) private readonly prismaService: PrismaService,
     @Inject(SlackAdapter) private readonly slackAdapter: SlackAdapter,
@@ -101,16 +100,6 @@ export class SlackTrigger extends Node<SlackTriggerConfig> {
   }
 
   private async resolveTokens(cfg: SlackTriggerConfig): Promise<{ app: string; bot: string }> {
-    if (!this.referenceResolver) {
-      if (typeof cfg?.app_token !== 'string' || typeof cfg?.bot_token !== 'string') {
-        throw new Error('SlackTrigger config requires resolved tokens');
-      }
-      return {
-        app: this.ensureToken(cfg.app_token, 'xapp-', 'app_token'),
-        bot: this.ensureToken(cfg.bot_token, 'xoxb-', 'bot_token'),
-      };
-    }
-
     try {
       const { output } = await this.referenceResolver.resolve(cfg, {
         basePath: '/slack',

--- a/packages/platform-server/src/nodes/tools/github_clone_repo/github_clone_repo.node.ts
+++ b/packages/platform-server/src/nodes/tools/github_clone_repo/github_clone_repo.node.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import { BaseToolNode } from '../baseToolNode';
 import { WorkspaceNode } from '../../workspace/workspace.node';
 import { GithubCloneRepoFunctionTool } from './github_clone_repo.tool';
-import { Inject, Injectable, Optional, Scope } from '@nestjs/common';
+import { Inject, Injectable, Scope } from '@nestjs/common';
 import { SecretReferenceSchema, VariableReferenceSchema } from '../../../utils/reference-schemas';
 import { ReferenceResolverService } from '../../../utils/reference-resolver.service';
 import { ResolveError } from '../../../utils/references';
@@ -38,18 +38,12 @@ export class GithubCloneRepoNode extends BaseToolNode<StaticConfigType> {
 
   private toolInstance?: GithubCloneRepoFunctionTool;
   private resolvedToken: string = '';
-  constructor(
-    @Inject(ReferenceResolverService) @Optional() private readonly referenceResolver?: ReferenceResolverService,
-  ) {
+  constructor(@Inject(ReferenceResolverService) private readonly referenceResolver: ReferenceResolverService) {
     super();
   }
 
   private async resolveTokenValue(token: StaticConfigType['token']): Promise<string> {
     if (token === undefined) return '';
-    if (!this.referenceResolver) {
-      if (typeof token !== 'string') throw new Error('GithubCloneRepoNode config requires resolved token');
-      return token;
-    }
     try {
       const { output } = await this.referenceResolver.resolve({ token }, { basePath: '/github_clone_repo/token' });
       const resolved = output.token;

--- a/packages/platform-server/src/nodes/tools/send_slack_message/send_slack_message.node.ts
+++ b/packages/platform-server/src/nodes/tools/send_slack_message/send_slack_message.node.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 import { BaseToolNode } from '../baseToolNode';
 import { SendSlackMessageFunctionTool, SendSlackMessageToolStaticConfigSchema } from './send_slack_message.tool';
-import { Inject, Injectable, Optional, Scope } from '@nestjs/common';
+import { Inject, Injectable, Scope } from '@nestjs/common';
 import { ReferenceResolverService } from '../../../utils/reference-resolver.service';
 import { ResolveError } from '../../../utils/references';
 
@@ -9,9 +9,7 @@ import { ResolveError } from '../../../utils/references';
 export class SendSlackMessageNode extends BaseToolNode<z.infer<typeof SendSlackMessageToolStaticConfigSchema>> {
   private toolInstance?: SendSlackMessageFunctionTool;
   private resolvedBotToken: string | null = null;
-  constructor(
-    @Inject(ReferenceResolverService) @Optional() private readonly referenceResolver?: ReferenceResolverService,
-  ) {
+  constructor(@Inject(ReferenceResolverService) private readonly referenceResolver: ReferenceResolverService) {
     super();
   }
 
@@ -23,9 +21,6 @@ export class SendSlackMessageNode extends BaseToolNode<z.infer<typeof SendSlackM
   }
 
   private async resolveBotToken(value: unknown): Promise<string> {
-    if (!this.referenceResolver) {
-      return this.ensureBotToken(value);
-    }
     try {
       const { output } = await this.referenceResolver.resolve({ bot_token: value }, { basePath: '/slack/tool' });
       return this.ensureBotToken(output.bot_token);


### PR DESCRIPTION
## Summary
- require ReferenceResolverService and ModuleRef in live graph, slack, and MCP nodes
- add testing stubs and update platform-server tests for required dependencies
- tighten SlackTrigger token validation when resolver leaves unresolved values

## Testing
- pnpm --filter @agyn/platform-server lint
- pnpm --filter @agyn/platform-server exec vitest run --reporter=json --outputFile=/tmp/platform-server-after.json

Closes #1088