### PR TITLE
Threads page: Pending messages from agent queue with realtime updates (reopen)

### DIFF
--- a/packages/platform-server/__tests__/agent.busy.wait.mode.test.ts
+++ b/packages/platform-server/__tests__/agent.busy.wait.mode.test.ts
@@ -9,6 +9,7 @@ import type { LLMContext, LLMState } from '../src/llm/types';
 import { LLMProvisioner } from '../src/llm/provisioners/llm.provisioner';
 import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
+import { EventsBusService } from '../src/events/events-bus.service';
 
 class PassthroughReducer extends Reducer<LLMState, LLMContext> {
   async invoke(state: LLMState): Promise<LLMState> {
@@ -54,6 +55,13 @@ describe('Agent busy gating (wait mode)', () => {
           },
         },
         RunSignalsRegistry,
+        {
+          provide: EventsBusService,
+          useValue: {
+            emitAgentQueueEnqueued: vi.fn(),
+            emitAgentQueueDrained: vi.fn(),
+          },
+        },
       ],
     }).compile();
     const agent = await module.resolve(NoToolAgent);

--- a/packages/platform-server/__tests__/agent.injectAfterTools.test.ts
+++ b/packages/platform-server/__tests__/agent.injectAfterTools.test.ts
@@ -7,6 +7,7 @@ import { ConfigService, configSchema } from '../src/core/services/config.service
 import { LLMProvisioner } from '../src/llm/provisioners/llm.provisioner';
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
+import { EventsBusService } from '../src/events/events-bus.service';
 
 import { AIMessage, HumanMessage, Loop, Reducer, ResponseMessage, Router } from '@agyn/llm';
 import type { LLMContext, LLMState } from '../src/llm/types';
@@ -119,6 +120,13 @@ const createAgentFixture = async () => {
       },
       TestAgentNode,
       RunSignalsRegistry,
+      {
+        provide: EventsBusService,
+        useValue: {
+          emitAgentQueueEnqueued: vi.fn(),
+          emitAgentQueueDrained: vi.fn(),
+        },
+      },
       { provide: AgentNode, useExisting: TestAgentNode },
       { provide: LLMProvisioner, useValue: { getLLM } },
       {

--- a/packages/platform-server/__tests__/agent.terminate.run.test.ts
+++ b/packages/platform-server/__tests__/agent.terminate.run.test.ts
@@ -7,6 +7,7 @@ import { LLMProvisioner } from '../src/llm/provisioners/llm.provisioner';
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { Reducer, Loop, ResponseMessage, HumanMessage } from '@agyn/llm';
 import type { LLMContext, LLMState } from '../src/llm/types';
+import { EventsBusService } from '../src/events/events-bus.service';
 
 class TestReducer extends Reducer<LLMState, LLMContext> {
   override async invoke(state: LLMState): Promise<LLMState> {
@@ -49,6 +50,13 @@ describe('AgentNode termination flow', () => {
         },
         RunSignalsRegistry,
         TerminateAwareAgent,
+        {
+          provide: EventsBusService,
+          useValue: {
+            emitAgentQueueEnqueued: vi.fn(),
+            emitAgentQueueDrained: vi.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/packages/platform-server/__tests__/agent.tools.deduplication.test.ts
+++ b/packages/platform-server/__tests__/agent.tools.deduplication.test.ts
@@ -9,6 +9,7 @@ import type { ModuleRef } from '@nestjs/core';
 import { FunctionTool } from '@agyn/llm';
 import { BaseToolNode } from '../src/nodes/tools/baseToolNode';
 import type { LocalMCPServerNode } from '../src/nodes/mcp';
+import type { EventsBusService } from '../src/events/events-bus.service';
 
 class StubProvisioner extends LLMProvisioner {
   async getLLM(): Promise<unknown> {
@@ -89,8 +90,12 @@ const createAgent = async () => {
     get: vi.fn(),
     create: vi.fn(async () => undefined),
   } as unknown as ModuleRef;
+  const eventsBus = {
+    emitAgentQueueEnqueued: vi.fn(),
+    emitAgentQueueDrained: vi.fn(),
+  } as unknown as EventsBusService;
 
-  const agent = new AgentNode(configService, provisioner, moduleRef);
+  const agent = new AgentNode(configService, provisioner, moduleRef, eventsBus);
   (agent as unknown as { logger: LoggerStub }).logger = logger;
   agent.init({ nodeId: 'agent-node' });
   await agent.setConfig({ title: 'Test Agent' } as AgentStaticConfig);

--- a/packages/platform-server/__tests__/agents.fail_fast.test.ts
+++ b/packages/platform-server/__tests__/agents.fail_fast.test.ts
@@ -11,6 +11,7 @@ import { RunEventsService } from '../src/events/run-events.service';
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
 import { TemplateRegistry } from '../src/graph-core/templateRegistry';
+import { EventsBusService } from '../src/events/events-bus.service';
 
 class StubLLMProvisioner extends LLMProvisioner {
   async getLLM(): Promise<{ call: (messages: unknown) => Promise<{ text: string; output: unknown[] }> }> {
@@ -25,6 +26,13 @@ describe('Fail-fast behavior', () => {
         ConfigService,
         { provide: LLMProvisioner, useClass: StubLLMProvisioner },
         AgentNode,
+        {
+          provide: EventsBusService,
+          useValue: {
+            emitAgentQueueEnqueued: vi.fn(),
+            emitAgentQueueDrained: vi.fn(),
+          },
+        },
         {
           provide: AgentsPersistenceService,
           useValue: {

--- a/packages/platform-server/__tests__/call_agent.tool.busy.sync.test.ts
+++ b/packages/platform-server/__tests__/call_agent.tool.busy.sync.test.ts
@@ -1,5 +1,5 @@
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '../src/core/services/config.service';
 import { AgentNode } from '../src/nodes/agent/agent.node';
@@ -10,6 +10,7 @@ import { AgentsPersistenceService } from '../src/agents/agents.persistence.servi
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { Signal } from '../src/signal';
 import { CallAgentLinkingService } from '../src/agents/call-agent-linking.service';
+import { EventsBusService } from '../src/events/events-bus.service';
 
 class BusyAgent extends AgentNode {
   override async invoke(): Promise<ResponseMessage> {
@@ -34,6 +35,13 @@ describe('call_agent sync busy', () => {
           },
         },
         RunSignalsRegistry,
+        {
+          provide: EventsBusService,
+          useValue: {
+            emitAgentQueueEnqueued: vi.fn(),
+            emitAgentQueueDrained: vi.fn(),
+          },
+        },
       ],
     }).compile();
     const agent = await module.resolve(BusyAgent);

--- a/packages/platform-server/__tests__/graph.mcp.integration.test.ts
+++ b/packages/platform-server/__tests__/graph.mcp.integration.test.ts
@@ -18,6 +18,8 @@ import type { GraphDefinition } from '../src/shared/types/graph.types';
 import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { ReferenceResolverService } from '../src/utils/reference-resolver.service';
+import { EventsBusService } from '../src/events/events-bus.service';
+import { createEventsBusStub } from './helpers/eventsBus.stub';
 
 class StubContainerService extends ContainerService {
   constructor(registry: ContainerRegistry) {
@@ -152,6 +154,7 @@ describe('Graph MCP integration', () => {
           },
         },
         RunSignalsRegistry,
+        { provide: EventsBusService, useValue: createEventsBusStub() },
       ],
     }).compile();
 

--- a/packages/platform-server/__tests__/helpers/eventsBus.stub.ts
+++ b/packages/platform-server/__tests__/helpers/eventsBus.stub.ts
@@ -9,6 +9,8 @@ export type EventsBusStub = {
   emitRunStatusChanged: ReturnType<typeof vi.fn>;
   emitThreadMetrics: ReturnType<typeof vi.fn>;
   emitThreadMetricsAncestors: ReturnType<typeof vi.fn>;
+  emitAgentQueueEnqueued: ReturnType<typeof vi.fn>;
+  emitAgentQueueDrained: ReturnType<typeof vi.fn>;
   emitReminderCount: ReturnType<typeof vi.fn>;
   emitToolOutputChunk: ReturnType<typeof vi.fn>;
   emitToolOutputTerminal: ReturnType<typeof vi.fn>;
@@ -23,6 +25,8 @@ export type EventsBusStub = {
   subscribeToRunStatusChanged: ReturnType<typeof vi.fn>;
   subscribeToThreadMetrics: ReturnType<typeof vi.fn>;
   subscribeToThreadMetricsAncestors: ReturnType<typeof vi.fn>;
+  subscribeToAgentQueueEnqueued: ReturnType<typeof vi.fn>;
+  subscribeToAgentQueueDrained: ReturnType<typeof vi.fn>;
 };
 
 export function createEventsBusStub(): EventsBusStub {
@@ -36,6 +40,8 @@ export function createEventsBusStub(): EventsBusStub {
     emitRunStatusChanged: vi.fn(),
     emitThreadMetrics: vi.fn(),
     emitThreadMetricsAncestors: vi.fn(),
+    emitAgentQueueEnqueued: vi.fn(),
+    emitAgentQueueDrained: vi.fn(),
     emitReminderCount: vi.fn(),
     emitToolOutputChunk: vi.fn(),
     emitToolOutputTerminal: vi.fn(),
@@ -50,5 +56,7 @@ export function createEventsBusStub(): EventsBusStub {
     subscribeToRunStatusChanged: vi.fn(() => disposer()),
     subscribeToThreadMetrics: vi.fn(() => disposer()),
     subscribeToThreadMetricsAncestors: vi.fn(() => disposer()),
+    subscribeToAgentQueueEnqueued: vi.fn(() => disposer()),
+    subscribeToAgentQueueDrained: vi.fn(() => disposer()),
   };
 }

--- a/packages/platform-server/__tests__/live.graph.runtime.simpleAgent.config.propagation.test.ts
+++ b/packages/platform-server/__tests__/live.graph.runtime.simpleAgent.config.propagation.test.ts
@@ -14,6 +14,8 @@ import { LLMProvisioner } from '../src/llm/provisioners/llm.provisioner';
 import { AgentNode } from '../src/nodes/agent/agent.node';
 import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
+import { EventsBusService } from '../src/events/events-bus.service';
+import { createEventsBusStub } from './helpers/eventsBus.stub';
 
 // Avoid any real network calls by ensuring ChatOpenAI token counting/invoke are not used in this test.
 // We don't invoke the graph; we only verify propagation of config to internal nodes/fields.
@@ -88,6 +90,7 @@ describe('LiveGraphRuntime -> Agent config propagation', () => {
           },
         },
         RunSignalsRegistry,
+        { provide: EventsBusService, useValue: createEventsBusStub() },
       ],
     })
       .compile()

--- a/packages/platform-server/__tests__/manage.tool.test.ts
+++ b/packages/platform-server/__tests__/manage.tool.test.ts
@@ -19,6 +19,8 @@ import { ManageFunctionTool } from '../src/nodes/tools/manage/manage.tool';
 import { ManageToolNode } from '../src/nodes/tools/manage/manage.node';
 import { ReferenceResolverService } from '../src/utils/reference-resolver.service';
 import { createReferenceResolverStub } from './helpers/reference-resolver.stub';
+import { EventsBusService } from '../src/events/events-bus.service';
+import { createEventsBusStub } from './helpers/eventsBus.stub';
 
 class StubLLMProvisioner extends LLMProvisioner {
   async getLLM(): Promise<{ call: (messages: unknown) => Promise<{ text: string; output: unknown[] }> }> {
@@ -71,6 +73,7 @@ async function createHarness(options: { persistence?: AgentsPersistenceService }
       { provide: AgentsPersistenceService, useValue: persistence },
       RunSignalsRegistry,
       { provide: ReferenceResolverService, useValue: createReferenceResolverStub().stub },
+      { provide: EventsBusService, useValue: createEventsBusStub() },
     ],
   }).compile();
 
@@ -286,6 +289,7 @@ describe('ManageTool unit', () => {
           useValue: { getOrCreateSubthreadByAlias: async () => 'child-t' } as unknown as AgentsPersistenceService,
         },
         RunSignalsRegistry,
+        { provide: EventsBusService, useValue: createEventsBusStub() },
       ],
     }).compile();
 
@@ -333,6 +337,7 @@ describe('ManageTool graph wiring', () => {
           useValue: { getOrCreateSubthreadByAlias: async () => 'child-t' } as unknown as AgentsPersistenceService,
         },
         RunSignalsRegistry,
+        { provide: EventsBusService, useValue: createEventsBusStub() },
       ],
     }).compile();
 
@@ -376,6 +381,7 @@ describe('ManageTool graph wiring', () => {
           useValue: { getOrCreateSubthreadByAlias: async () => 'child-t' } as unknown as AgentsPersistenceService,
         },
         RunSignalsRegistry,
+        { provide: EventsBusService, useValue: createEventsBusStub() },
       ],
     }).compile();
     const runtime = await runtimeModule.resolve(LiveGraphRuntime);

--- a/packages/platform-server/src/agents/agent-node.utils.ts
+++ b/packages/platform-server/src/agents/agent-node.utils.ts
@@ -2,13 +2,17 @@ import { AgentNode } from '../nodes/agent/agent.node';
 import type { LiveNode } from '../graph/liveGraph.types';
 import { TemplateRegistry } from '../graph-core/templateRegistry';
 
-export type AgentRuntimeInstance = Pick<AgentNode, 'invoke' | 'status'>;
+export type AgentRuntimeInstance = Pick<AgentNode, 'invoke' | 'status' | 'getQueueSnapshot'>;
 
 export function isAgentRuntimeInstance(value: unknown): value is AgentRuntimeInstance {
   if (value instanceof AgentNode) return true;
   if (!value || typeof value !== 'object') return false;
   const candidate = value as Partial<AgentNode>;
-  return typeof candidate.invoke === 'function' && typeof candidate.status === 'string';
+  return (
+    typeof candidate.invoke === 'function' &&
+    typeof candidate.status === 'string' &&
+    typeof candidate.getQueueSnapshot === 'function'
+  );
 }
 
 export function isAgentTemplate(template: string, registry: TemplateRegistry): boolean {

--- a/packages/platform-server/src/events/events-bus.service.ts
+++ b/packages/platform-server/src/events/events-bus.service.ts
@@ -69,6 +69,11 @@ export type RunStatusBroadcast = {
   };
 };
 
+export type AgentQueueEvent = {
+  threadId: string;
+  at: Date;
+};
+
 type EventsBusEvents = {
   run_event: [RunEventBusPayload];
   tool_output_chunk: [ToolOutputChunkPayload];
@@ -81,6 +86,8 @@ type EventsBusEvents = {
   run_status_changed: [RunStatusBroadcast];
   thread_metrics: [ThreadMetricsEvent];
   thread_metrics_ancestors: [ThreadMetricsAncestorsEvent];
+  agent_queue_enqueued: [AgentQueueEvent];
+  agent_queue_drained: [AgentQueueEvent];
 };
 
 @Injectable()
@@ -194,6 +201,28 @@ export class EventsBusService implements OnModuleDestroy {
 
   emitRunStatusChanged(payload: RunStatusBroadcast): void {
     this.emitter.emit('run_status_changed', payload);
+  }
+
+  subscribeToAgentQueueEnqueued(listener: (payload: AgentQueueEvent) => void): () => void {
+    this.emitter.on('agent_queue_enqueued', listener);
+    return () => {
+      this.emitter.off('agent_queue_enqueued', listener);
+    };
+  }
+
+  emitAgentQueueEnqueued(payload: AgentQueueEvent): void {
+    this.emitter.emit('agent_queue_enqueued', payload);
+  }
+
+  subscribeToAgentQueueDrained(listener: (payload: AgentQueueEvent) => void): () => void {
+    this.emitter.on('agent_queue_drained', listener);
+    return () => {
+      this.emitter.off('agent_queue_drained', listener);
+    };
+  }
+
+  emitAgentQueueDrained(payload: AgentQueueEvent): void {
+    this.emitter.emit('agent_queue_drained', payload);
   }
 
   subscribeToThreadMetrics(listener: (payload: ThreadMetricsEvent) => void): () => void {

--- a/packages/platform-server/src/nodes/agent/agent.node.ts
+++ b/packages/platform-server/src/nodes/agent/agent.node.ts
@@ -29,6 +29,7 @@ import { SummarizationLLMReducer } from '../../llm/reducers/summarization.llm.re
 import { Signal } from '../../signal';
 import { AgentsPersistenceService } from '../../agents/agents.persistence.service';
 import { RunSignalsRegistry } from '../../agents/run-signals.service';
+import { EventsBusService } from '../../events/events-bus.service';
 
 import { BaseToolNode } from '../tools/baseToolNode';
 import { BufferMessage, MessagesBuffer, ProcessBuffer } from './messagesBuffer';
@@ -173,6 +174,7 @@ export class AgentNode extends Node<AgentStaticConfig> implements OnModuleInit {
     @Inject(ConfigService) protected configService: ConfigService,
     @Inject(LLMProvisioner) protected llmProvisioner: LLMProvisioner,
     @Inject(ModuleRef) protected readonly moduleRef: ModuleRef,
+    @Inject(EventsBusService) private readonly eventsBus: EventsBusService,
   ) {
     super();
   }
@@ -327,7 +329,8 @@ export class AgentNode extends Node<AgentStaticConfig> implements OnModuleInit {
     ctx: LLMContext,
   ): Promise<void> {
     const mode = behavior.processBuffer === 'oneByOne' ? ProcessBuffer.OneByOne : ProcessBuffer.AllTogether;
-    const drained = this.buffer.tryDrain(ctx.threadId, mode);
+    const drainedAt = Date.now();
+    const drained = this.buffer.tryDrain(ctx.threadId, mode, drainedAt);
     if (drained.length === 0) return;
 
     this.logger.debug?.(
@@ -336,6 +339,7 @@ export class AgentNode extends Node<AgentStaticConfig> implements OnModuleInit {
 
     await this.getPersistenceOrThrow().recordInjected(ctx.runId, drained, { threadId: ctx.threadId });
     state.messages.push(...drained);
+    this.eventsBus.emitAgentQueueDrained({ threadId: ctx.threadId, at: new Date(drainedAt) });
   }
 
   private resolveBufferModeFromBehavior(behavior?: EffectiveAgentConfig['behavior']): ProcessBuffer {
@@ -499,7 +503,9 @@ export class AgentNode extends Node<AgentStaticConfig> implements OnModuleInit {
   async invoke(thread: string, messages: BufferMessage[]): Promise<ResponseMessage | ToolCallOutputMessage> {
     const busy = this.runningThreads.has(thread);
     if (busy) {
-      this.buffer.enqueue(thread, messages);
+      const now = Date.now();
+      this.buffer.enqueue(thread, messages, now);
+      this.eventsBus.emitAgentQueueEnqueued({ threadId: thread, at: new Date(now) });
       return ResponseMessage.fromText('queued');
     }
 
@@ -578,8 +584,10 @@ export class AgentNode extends Node<AgentStaticConfig> implements OnModuleInit {
       if (runId) this.getRunSignals().clear(runId);
     }
 
-    const nextMessages = this.buffer.tryDrain(thread, this.resolveBufferModeFromBehavior(effectiveBehavior));
+    const drainedAt = Date.now();
+    const nextMessages = this.buffer.tryDrain(thread, this.resolveBufferModeFromBehavior(effectiveBehavior), drainedAt);
     if (nextMessages.length > 0) {
+      this.eventsBus.emitAgentQueueDrained({ threadId: thread, at: new Date(drainedAt) });
       void this.invoke(thread, nextMessages);
     }
 

--- a/packages/platform-server/src/nodes/agent/agent.node.ts
+++ b/packages/platform-server/src/nodes/agent/agent.node.ts
@@ -181,6 +181,10 @@ export class AgentNode extends Node<AgentStaticConfig> implements OnModuleInit {
     this.moduleInitialized = true;
   }
 
+  getQueueSnapshot(threadId: string): ReturnType<MessagesBuffer['snapshot']> {
+    return this.buffer.snapshot(threadId);
+  }
+
   private getPersistenceOrThrow(): AgentsPersistenceService {
     if (this.persistenceRef === undefined) {
       try {

--- a/packages/platform-ui/__tests__/AgentsThreads.chat.view.test.tsx
+++ b/packages/platform-ui/__tests__/AgentsThreads.chat.view.test.tsx
@@ -1,11 +1,12 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router-dom';
 import { AgentsThreads } from '../src/pages/AgentsThreads';
 import { TestProviders, server, abs } from './integration/testUtils';
+import { graphSocket } from '../src/lib/graph/socket';
 
 const navigateMock = vi.fn();
 
@@ -29,9 +30,11 @@ describe('AgentsThreads conversation view', () => {
   });
   afterAll(() => server.close());
 
+  const THREAD_ID = '00000000-0000-0000-0000-000000000001';
+
   function setupThreadData() {
     const thread = {
-      id: 'th1',
+      id: THREAD_ID,
       alias: 'th-a',
       summary: 'Thread A',
       status: 'open',
@@ -40,13 +43,13 @@ describe('AgentsThreads conversation view', () => {
       metrics: { remindersCount: 1, containersCount: 1, activity: 'working', runsCount: 1 },
     };
 
-    const runMeta = { id: 'run1', threadId: 'th1', status: 'finished', createdAt: t(1), updatedAt: t(2) };
+    const runMeta = { id: 'run1', threadId: THREAD_ID, status: 'finished', createdAt: t(1), updatedAt: t(2) };
 
-    const reminders = [{ id: 'rem1', threadId: 'th1', note: 'Follow up', at: t(50) }];
+    const reminders = [{ id: 'rem1', threadId: THREAD_ID, note: 'Follow up', at: t(50) }];
     const containers = [
       {
         containerId: 'cont-1',
-        threadId: 'th1',
+        threadId: THREAD_ID,
         image: 'ai:latest',
         name: 'cont-1-name',
         status: 'running',
@@ -79,12 +82,12 @@ describe('AgentsThreads conversation view', () => {
     server.use(
       http.get('/api/agents/threads', threadsHandler),
       http.get(abs('/api/agents/threads'), threadsHandler),
-      http.get('/api/agents/threads/th1', threadHandler),
-      http.get(abs('/api/agents/threads/th1'), threadHandler),
-      http.get('/api/agents/threads/th1/children', () => HttpResponse.json({ items: [] })),
-      http.get(abs('/api/agents/threads/th1/children'), () => HttpResponse.json({ items: [] })),
-      http.get('/api/agents/threads/th1/runs', runsHandler),
-      http.get(abs('/api/agents/threads/th1/runs'), runsHandler),
+      http.get(`/api/agents/threads/${THREAD_ID}`, threadHandler),
+      http.get(abs(`/api/agents/threads/${THREAD_ID}`), threadHandler),
+      http.get(`/api/agents/threads/${THREAD_ID}/children`, () => HttpResponse.json({ items: [] })),
+      http.get(abs(`/api/agents/threads/${THREAD_ID}/children`), () => HttpResponse.json({ items: [] })),
+      http.get(`/api/agents/threads/${THREAD_ID}/runs`, runsHandler),
+      http.get(abs(`/api/agents/threads/${THREAD_ID}/runs`), runsHandler),
       http.get('/api/agents/reminders', () => HttpResponse.json({ items: reminders })),
       http.get(abs('/api/agents/reminders'), () => HttpResponse.json({ items: reminders })),
       http.get('/api/containers', () => HttpResponse.json({ items: containers })),
@@ -122,18 +125,92 @@ describe('AgentsThreads conversation view', () => {
     expect(runInfo).toHaveTextContent('Finished');
     const viewRunButton = within(runInfo).getByRole('button', { name: /View Run/i });
     await user.click(viewRunButton);
-    expect(navigateMock).toHaveBeenCalledWith('/agents/threads/th1/runs/run1/timeline');
+    expect(navigateMock).toHaveBeenCalledWith(`/agents/threads/${THREAD_ID}/runs/run1/timeline`);
+  });
+
+  it('shows reminders and queued messages under pending, then moves queued items into runs when the run starts', async () => {
+    setupThreadData();
+
+    const user = userEvent.setup();
+
+    render(
+      <TestProviders>
+        <MemoryRouter>
+          <AgentsThreads />
+        </MemoryRouter>
+      </TestProviders>,
+    );
+
+    const threadRow = await screen.findByText('Thread A');
+    await user.click(threadRow);
+
+    const conversation = await screen.findByTestId('conversation');
+    await within(conversation).findByText('Follow up');
+    const pendingLabel = within(conversation).getByText('PENDING');
+    const pendingRoot = pendingLabel.parentElement?.parentElement as HTMLElement | null;
+    expect(pendingRoot).not.toBeNull();
+    if (!pendingRoot) throw new Error('Pending section not rendered');
+
+    expect(within(pendingRoot).getByText('Follow up')).toBeInTheDocument();
+    expect(within(pendingRoot).queryByText('Pending reply')).toBeNull();
+
+    const bufferedPayload = {
+      threadId: THREAD_ID,
+      message: {
+        id: 'msg-buffer',
+        kind: 'assistant' as const,
+        text: 'Pending reply',
+        source: {},
+        createdAt: t(55),
+        runId: 'run-late',
+      },
+    };
+
+    const messageListeners = (graphSocket as any).messageCreatedListeners as Set<(payload: typeof bufferedPayload) => void>;
+    await act(async () => {
+      for (const listener of messageListeners) {
+        listener(bufferedPayload);
+      }
+    });
+
+    expect(within(pendingRoot).getByText('Pending reply')).toBeInTheDocument();
+    expect(
+      within(conversation)
+        .queryAllByTestId('conversation-message')
+        .some((node) => within(node).queryByText('Pending reply')),
+    ).toBe(false);
+
+    const runPayload = {
+      threadId: THREAD_ID,
+      run: { id: 'run-late', status: 'running' as const, createdAt: t(56), updatedAt: t(57) },
+    };
+    const runListeners = (graphSocket as any).runStatusListeners as Set<(payload: typeof runPayload) => void>;
+    await act(async () => {
+      for (const listener of runListeners) {
+        listener(runPayload);
+      }
+    });
+
+    await waitFor(() => {
+      expect(within(pendingRoot).queryByText('Pending reply')).toBeNull();
+    });
+
+    await waitFor(() => {
+      const nodes = within(conversation).queryAllByTestId('conversation-message');
+      const found = nodes.some((node) => within(node).queryByText('Pending reply'));
+      expect(found).toBe(true);
+    });
   });
 
   it('loads subthreads when expanding a thread', async () => {
     setupThreadData();
 
     const childThread = {
-      id: 'th-child',
+      id: '00000000-0000-0000-0000-000000000002',
       alias: 'th-child',
       summary: 'Child thread',
       status: 'open',
-      parentId: 'th1',
+      parentId: THREAD_ID,
       createdAt: t(3),
       metrics: { remindersCount: 0, containersCount: 0, activity: 'waiting', runsCount: 0 },
       agentTitle: 'Agent Junior',
@@ -142,8 +219,8 @@ describe('AgentsThreads conversation view', () => {
     const childrenHandler = vi.fn(() => HttpResponse.json({ items: [childThread] }));
 
     server.use(
-      http.get('/api/agents/threads/th1/children', () => childrenHandler()),
-      http.get(abs('/api/agents/threads/th1/children'), () => childrenHandler()),
+      http.get(`/api/agents/threads/${THREAD_ID}/children`, () => childrenHandler()),
+      http.get(abs(`/api/agents/threads/${THREAD_ID}/children`), () => childrenHandler()),
     );
 
     const user = userEvent.setup();

--- a/packages/platform-ui/__tests__/AgentsThreads.queue.realtime.test.tsx
+++ b/packages/platform-ui/__tests__/AgentsThreads.queue.realtime.test.tsx
@@ -1,0 +1,112 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AgentsThreads } from '../src/pages/AgentsThreads';
+import { TestProviders, server, abs } from './integration/testUtils';
+import { graphSocket } from '../src/lib/graph/socket';
+
+function t(offsetMs: number) {
+  return new Date(1700000000000 + offsetMs).toISOString();
+}
+
+describe('AgentsThreads queue realtime updates', () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  const THREAD_ID = '00000000-0000-0000-0000-000000000001';
+
+  async function waitForListenerSet<T>(
+    key: 'agentQueueEnqueuedListeners' | 'agentQueueDrainedListeners',
+  ): Promise<Set<T>> {
+    await waitFor(() =>
+      expect(((graphSocket as any)[key] as Set<T> | undefined)?.size ?? 0).toBeGreaterThan(0),
+    );
+    return (graphSocket as any)[key] as Set<T>;
+  }
+
+  function setupBaseMocks() {
+    const thread = { id: THREAD_ID, alias: 'th-a', summary: 'Thread A', status: 'open', createdAt: t(0) };
+    const queueItems: Array<{ id: string; kind: 'user' | 'assistant' | 'system'; text: string; enqueuedAt: string }> = [];
+    const queueHandler = vi.fn(() => HttpResponse.json({ items: queueItems }));
+
+    server.use(
+      http.get('/api/agents/threads', () => HttpResponse.json({ items: [thread] })),
+      http.get(abs('/api/agents/threads'), () => HttpResponse.json({ items: [thread] })),
+      http.get(`/api/agents/threads/${THREAD_ID}`, () => HttpResponse.json({ ...thread, parentId: null, metrics: { remindersCount: 0, containersCount: 0, activity: 'idle', runsCount: 0 } })),
+      http.get(abs(`/api/agents/threads/${THREAD_ID}`), () => HttpResponse.json({ ...thread, parentId: null, metrics: { remindersCount: 0, containersCount: 0, activity: 'idle', runsCount: 0 } })),
+      http.get(`/api/agents/threads/${THREAD_ID}/children`, () => HttpResponse.json({ items: [] })),
+      http.get(abs(`/api/agents/threads/${THREAD_ID}/children`), () => HttpResponse.json({ items: [] })),
+      http.get(`/api/agents/threads/${THREAD_ID}/runs`, () => HttpResponse.json({ items: [] })),
+      http.get(abs(`/api/agents/threads/${THREAD_ID}/runs`), () => HttpResponse.json({ items: [] })),
+      http.get('/api/agents/reminders', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/agents/reminders'), () => HttpResponse.json({ items: [] })),
+      http.get('/api/containers', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/containers'), () => HttpResponse.json({ items: [] })),
+      http.get(`/api/agents/threads/${THREAD_ID}/queue`, queueHandler),
+      http.get(abs(`/api/agents/threads/${THREAD_ID}/queue`), queueHandler),
+    );
+
+    return { queueItems, queueHandler };
+  }
+
+  it('reflects enqueued and drained queue events without manual refresh', async () => {
+    const { queueItems, queueHandler } = setupBaseMocks();
+    const user = userEvent.setup();
+
+    render(
+      <TestProviders>
+        <MemoryRouter>
+          <AgentsThreads />
+        </MemoryRouter>
+      </TestProviders>,
+    );
+
+    await user.click(await screen.findByText('Thread A'));
+    const conversation = await screen.findByTestId('conversation');
+    expect(within(conversation).queryByText('PENDING')).toBeNull();
+
+    queueItems.push({ id: 'queued-1', kind: 'assistant', text: 'Needs processing', enqueuedAt: t(5) });
+    await waitFor(() => expect(queueHandler).toHaveBeenCalled());
+    const initialCalls = queueHandler.mock.calls.length;
+    const enqueueListeners = await waitForListenerSet<(payload: { threadId: string; at: string }) => void>(
+      'agentQueueEnqueuedListeners',
+    );
+
+    await act(async () => {
+      for (const listener of enqueueListeners) {
+        listener({ threadId: THREAD_ID, at: t(5) });
+      }
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+
+    const pendingLabel = await within(conversation).findByText('PENDING');
+    const pendingRoot = pendingLabel.parentElement?.parentElement as HTMLElement | null;
+    expect(pendingRoot).not.toBeNull();
+    if (!pendingRoot) throw new Error('Pending section missing');
+    await waitFor(() => expect(queueHandler).toHaveBeenCalledTimes(initialCalls + 1));
+    await waitFor(() => expect(within(pendingRoot).getByText('Needs processing')).toBeInTheDocument());
+
+    queueItems.splice(0);
+    const drainedListeners = await waitForListenerSet<(payload: { threadId: string; at: string }) => void>(
+      'agentQueueDrainedListeners',
+    );
+    const beforeDrainCalls = queueHandler.mock.calls.length;
+    await act(async () => {
+      for (const listener of drainedListeners) {
+        listener({ threadId: THREAD_ID, at: t(10) });
+      }
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+
+    await waitFor(() => expect(queueHandler).toHaveBeenCalledTimes(beforeDrainCalls + 1));
+    await waitFor(() => expect(within(conversation).queryByText('PENDING')).toBeNull());
+  });
+});

--- a/packages/platform-ui/__tests__/AgentsThreads.realtime.test.tsx
+++ b/packages/platform-ui/__tests__/AgentsThreads.realtime.test.tsx
@@ -113,7 +113,11 @@ describe('AgentsThreads realtime updates', () => {
       }
     });
 
-    expect(within(conversation).queryByText('Buffered message')).toBeNull();
+    const pendingLabel = await within(conversation).findByText('PENDING');
+    const pendingRoot = pendingLabel.parentElement?.parentElement as HTMLElement | null;
+    expect(pendingRoot).not.toBeNull();
+    if (!pendingRoot) throw new Error('Missing pending section');
+    expect(within(pendingRoot).getByText('Buffered message')).toBeInTheDocument();
 
     const runPayload = {
       threadId: 'th1',
@@ -126,6 +130,7 @@ describe('AgentsThreads realtime updates', () => {
       }
     });
 
+    await waitFor(() => expect(within(conversation).queryByText('PENDING')).toBeNull());
     await waitFor(() => expect(within(conversation).getByText('Buffered message')).toBeInTheDocument());
   });
 });

--- a/packages/platform-ui/__tests__/ThreadsScreen.render.test.tsx
+++ b/packages/platform-ui/__tests__/ThreadsScreen.render.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import ThreadsScreen from '../src/components/screens/ThreadsScreen';
+import type { Thread } from '../src/components/ThreadItem';
+
+type ThreadsScreenProps = React.ComponentProps<typeof ThreadsScreen>;
+
+const baseThread: Thread = {
+  id: 'thread-1',
+  summary: 'Coordinate release tasks',
+  agentName: 'Release Agent',
+  createdAt: '2024-06-01T12:00:00.000Z',
+  status: 'pending',
+  isOpen: true,
+};
+
+const queuedMessages = [
+  { id: 'qm-1', content: 'Queued alpha' },
+  { id: 'qm-2', content: 'Queued beta' },
+];
+
+const conversationReminders = [
+  { id: 'rem-1', content: 'Reminder gamma', scheduledTime: '09:00', date: '2024-06-02' },
+];
+
+function renderScreen(overrides: Partial<ThreadsScreenProps> = {}) {
+  const props: ThreadsScreenProps = {
+    threads: [baseThread],
+    runs: [],
+    containers: [],
+    reminders: [],
+    queuedMessages: [],
+    conversationReminders: [],
+    filterMode: 'all',
+    selectedThreadId: baseThread.id,
+    inputValue: '',
+    isRunsInfoCollapsed: false,
+    threadsHasMore: false,
+    threadsIsLoading: false,
+    isLoading: false,
+    isEmpty: false,
+    ...overrides,
+  };
+
+  return render(<ThreadsScreen {...props} />);
+}
+
+describe('ThreadsScreen pending items rendering', () => {
+  it('renders queued messages ahead of reminders within the pending section', () => {
+    renderScreen({ queuedMessages, conversationReminders });
+
+    const pendingLabel = screen.getByText('PENDING');
+    const pendingRoot = pendingLabel.parentElement?.parentElement as HTMLElement | null;
+    expect(pendingRoot).not.toBeNull();
+    if (!pendingRoot) throw new Error('Missing pending section');
+
+    expect(within(pendingRoot).getByText('Queued alpha')).toBeInTheDocument();
+    expect(within(pendingRoot).getByText('Queued beta')).toBeInTheDocument();
+    expect(within(pendingRoot).getByText('Reminder gamma')).toBeInTheDocument();
+
+    const textContent = pendingRoot.textContent ?? '';
+    expect(textContent.indexOf('Queued alpha')).toBeLessThan(textContent.indexOf('Reminder gamma'));
+    expect(textContent.indexOf('Queued beta')).toBeLessThan(textContent.indexOf('Reminder gamma'));
+  });
+
+  it('renders the pending divider when only reminders are provided', () => {
+    renderScreen({ conversationReminders });
+    expect(screen.getByText('PENDING')).toBeInTheDocument();
+  });
+
+  it('hides the pending divider when no queued messages or reminders exist', () => {
+    renderScreen();
+    expect(screen.queryByText('PENDING')).toBeNull();
+  });
+});

--- a/packages/platform-ui/__tests__/ThreadsScreen.render.test.tsx
+++ b/packages/platform-ui/__tests__/ThreadsScreen.render.test.tsx
@@ -21,7 +21,13 @@ const queuedMessages = [
 ];
 
 const conversationReminders = [
-  { id: 'rem-1', content: 'Reminder gamma', scheduledTime: '09:00', date: '2024-06-02' },
+  {
+    id: 'rem-1',
+    content: 'Reminder gamma',
+    scheduledTime: '09:00',
+    date: '2024-06-02',
+    utcTs: '2024-06-02T09:00:00Z',
+  },
 ];
 
 function renderScreen(overrides: Partial<ThreadsScreenProps> = {}) {

--- a/packages/platform-ui/__tests__/ThreadsScreen.render.test.tsx
+++ b/packages/platform-ui/__tests__/ThreadsScreen.render.test.tsx
@@ -16,8 +16,8 @@ const baseThread: Thread = {
 };
 
 const queuedMessages = [
-  { id: 'qm-1', content: 'Queued alpha' },
-  { id: 'qm-2', content: 'Queued beta' },
+  { id: 'qm-1', content: 'Queued alpha', kind: 'user' as const, enqueuedAt: '2024-06-01T12:05:00Z' },
+  { id: 'qm-2', content: 'Queued beta', kind: 'assistant' as const, enqueuedAt: '2024-06-01T12:07:00Z' },
 ];
 
 const conversationReminders = [

--- a/packages/platform-ui/src/api/types/agents.ts
+++ b/packages/platform-ui/src/api/types/agents.ts
@@ -7,6 +7,15 @@ export type ThreadMetrics = {
   runsCount: number;
 };
 
+export type AgentQueueItem = {
+  id: string;
+  kind: 'assistant' | 'user' | 'system';
+  text: string;
+  enqueuedAt: string;
+  tokenId?: string;
+  priority?: number | null;
+};
+
 export type ThreadReminder = {
   id: string;
   threadId: string;

--- a/packages/platform-ui/src/components/Conversation.tsx
+++ b/packages/platform-ui/src/components/Conversation.tsx
@@ -33,6 +33,7 @@ export interface ReminderData {
   content: ReactNode;
   scheduledTime: string;
   date?: string;
+  utcTs?: string;
 }
 
 interface ConversationProps {
@@ -184,6 +185,7 @@ export function Conversation({
                         content={reminder.content}
                         scheduledTime={reminder.scheduledTime}
                         date={reminder.date}
+                        utcTs={reminder.utcTs}
                       />
                     ))}
                   </div>

--- a/packages/platform-ui/src/components/Conversation.tsx
+++ b/packages/platform-ui/src/components/Conversation.tsx
@@ -26,6 +26,8 @@ export interface Run {
 export interface QueuedMessageData {
   id: string;
   content: ReactNode;
+  kind?: 'user' | 'assistant' | 'system';
+  enqueuedAt?: string;
 }
 
 export interface ReminderData {
@@ -175,6 +177,8 @@ export function Conversation({
                       <QueuedMessage
                         key={msg.id}
                         content={msg.content}
+                        kind={msg.kind}
+                        enqueuedAt={msg.enqueuedAt}
                       />
                     ))}
 

--- a/packages/platform-ui/src/components/QueuedMessage.tsx
+++ b/packages/platform-ui/src/components/QueuedMessage.tsx
@@ -1,17 +1,31 @@
 import { type ReactNode } from 'react';
+import { formatDistanceToNow } from 'date-fns';
 import { Clock } from 'lucide-react';
 
 interface QueuedMessageProps {
   content: ReactNode;
+  kind?: 'user' | 'assistant' | 'system';
+  enqueuedAt?: string;
   className?: string;
 }
 
 export function QueuedMessage({
   content,
+  kind = 'user',
+  enqueuedAt,
   className = '',
 }: QueuedMessageProps) {
+  const kindLabel = kind === 'assistant' ? 'Assistant' : kind === 'system' ? 'System' : 'User';
+  let relativeTime: string | null = null;
+  if (enqueuedAt) {
+    const ts = Date.parse(enqueuedAt);
+    if (Number.isFinite(ts)) {
+      relativeTime = formatDistanceToNow(ts, { addSuffix: true });
+    }
+  }
+
   return (
-    <div className={`flex justify-start mb-4 ${className}`}>
+    <div className={`flex justify-start mb-4 ${className}`} data-testid="queued-message">
       <div className="flex gap-3 max-w-[70%]">
         {/* Avatar */}
         <div
@@ -25,7 +39,7 @@ export function QueuedMessage({
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <span className="text-xs text-[var(--agyn-gray)]">
-              User
+              {relativeTime ? `${kindLabel} · ${relativeTime}` : kindLabel}
             </span>
           </div>
           <div className="text-[var(--agyn-gray)]">

--- a/packages/platform-ui/src/components/__tests__/Reminder.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/Reminder.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { Reminder } from '../Reminder';
+import { vi } from 'vitest';
+
+describe('Reminder countdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses utcTs for countdown even with localized scheduled time', async () => {
+    render(
+      <Reminder content="국제화 알림" scheduledTime="오후 6시 30분" utcTs="2024-06-01T12:30:00Z" />,
+    );
+
+    expect(screen.getByText('오후 6시 30분')).toBeInTheDocument();
+    expect(screen.getByText('국제화 알림')).toBeInTheDocument();
+    await act(async () => {});
+    expect(screen.getByText(/\(in \d+m\)/)).toBeInTheDocument();
+  });
+
+  it('updates countdown over time using utcTs', async () => {
+    render(
+      <Reminder content="타이머 확인" scheduledTime="오후 6시 30분" utcTs="2024-06-01T12:30:00Z" />,
+    );
+
+    await act(async () => {});
+    expect(screen.getByText(/\(in \d+m\)/)).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(30 * 60 * 1000);
+    });
+
+    expect(screen.getByText('(now)')).toBeInTheDocument();
+  });
+});

--- a/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
+++ b/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
@@ -7,7 +7,7 @@ import { IconButton } from '../IconButton';
 import { ThreadsList } from '../ThreadsList';
 import type { Thread } from '../ThreadItem';
 import { SegmentedControl } from '../SegmentedControl';
-import { Conversation, type Run } from '../Conversation';
+import { Conversation, type Run, type QueuedMessageData, type ReminderData } from '../Conversation';
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
 import { StatusIndicator } from '../StatusIndicator';
 import { AutosizeTextarea } from '../AutosizeTextarea';
@@ -19,6 +19,8 @@ interface ThreadsScreenProps {
   runs: Run[];
   containers: { id: string; name: string; status: 'running' | 'finished' }[];
   reminders: { id: string; title: string; time: string }[];
+  queuedMessages?: QueuedMessageData[];
+  conversationReminders?: ReminderData[];
   filterMode: 'all' | 'open' | 'closed';
   selectedThreadId: string | null;
   selectedThread?: Thread;
@@ -56,6 +58,8 @@ export default function ThreadsScreen({
   runs,
   containers,
   reminders,
+  queuedMessages = [],
+  conversationReminders = [],
   filterMode,
   selectedThreadId,
   selectedThread,
@@ -428,7 +432,13 @@ export default function ThreadsScreen({
         </div>
 
         <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-          <Conversation runs={runs} className="h-full rounded-none border-none" collapsed={isRunsInfoCollapsed} />
+          <Conversation
+            runs={runs}
+            queuedMessages={queuedMessages}
+            reminders={conversationReminders}
+            className="h-full rounded-none border-none"
+            collapsed={isRunsInfoCollapsed}
+          />
         </div>
 
         {renderComposer(!onSendMessage || !selectedThreadId || isSendMessagePending)}

--- a/packages/platform-ui/src/pages/AgentsThreads.tsx
+++ b/packages/platform-ui/src/pages/AgentsThreads.tsx
@@ -376,6 +376,7 @@ function mapRemindersForConversation(items: ThreadReminder[]): ReminderData[] {
         id: reminder.id,
         content: sanitizedContent,
         scheduledTime: '--:--',
+        utcTs: reminder.at,
         sortValue: Number.POSITIVE_INFINITY,
       } satisfies ConversationReminderWithSort;
     }
@@ -389,6 +390,7 @@ function mapRemindersForConversation(items: ThreadReminder[]): ReminderData[] {
       content: sanitizedContent,
       scheduledTime,
       date,
+      utcTs: reminder.at,
       sortValue: timestamp,
     } satisfies ConversationReminderWithSort;
   });

--- a/packages/platform-ui/stories/Conversation.stories.tsx
+++ b/packages/platform-ui/stories/Conversation.stories.tsx
@@ -131,10 +131,14 @@ const sampleQueued: QueuedMessageData[] = [
   {
     id: 'queued-1',
     content: 'Generate unit tests for the authentication endpoint',
+    kind: 'user',
+    enqueuedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
   },
   {
     id: 'queued-2',
     content: 'Add rate limiting to prevent brute force attacks',
+    kind: 'assistant',
+    enqueuedAt: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
   },
 ];
 

--- a/packages/platform-ui/stories/Conversation.stories.tsx
+++ b/packages/platform-ui/stories/Conversation.stories.tsx
@@ -147,6 +147,15 @@ const sampleReminders: ReminderData[] = [
   },
 ];
 
+const localizedUtcReminders: ReminderData[] = [
+  {
+    id: 'reminder-locale-1',
+    content: '현지화 상태 점검',
+    scheduledTime: '오후 6시 30분',
+    utcTs: new Date(Date.now() + 45 * 60 * 1000).toISOString(),
+  },
+];
+
 export const FullExample: Story = {
   render: (args) => {
     const [inputValue, setInputValue] = useState('');
@@ -484,6 +493,16 @@ export const WordWrapTest: Story = {
             },
           ]}
         />
+      </div>
+    </div>
+  ),
+};
+
+export const LocalizedUtcReminderCountdown: Story = {
+  render: () => (
+    <div className="p-6 bg-[var(--agyn-bg-light)] min-h-screen flex items-center justify-center">
+      <div className="w-full max-w-3xl h-[320px]">
+        <Conversation runs={minimalRuns} reminders={localizedUtcReminders} queuedMessages={[]} />
       </div>
     </div>
   ),

--- a/packages/platform-ui/stories/ThreadsScreen.stories.tsx
+++ b/packages/platform-ui/stories/ThreadsScreen.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useArgs } from 'storybook/preview-api';
 import ThreadsScreen from '../src/components/screens/ThreadsScreen';
 import type { Thread } from '../src/components/ThreadItem';
-import type { Run } from '../src/components/Conversation';
+import type { Run, QueuedMessageData, ReminderData } from '../src/components/Conversation';
 import type { AutocompleteOption } from '../src/components/AutocompleteInput';
 import { withMainLayout } from './decorators/withMainLayout';
 
@@ -165,6 +165,16 @@ const reminders = [
   { id: 'r-2', title: 'Update documentation', time: 'Friday at 2:00 PM' },
 ];
 
+const pendingConversationReminders: ReminderData[] = [
+  { id: 'rem-1', content: 'Review agent summary draft', scheduledTime: '09:30', date: '2024-06-02' },
+  { id: 'rem-2', content: 'Check deployment status', scheduledTime: '14:15', date: '2024-06-02' },
+];
+
+const pendingQueuedMessages: QueuedMessageData[] = [
+  { id: 'queue-1', content: 'Queued message awaiting agent availability.' },
+  { id: 'queue-2', content: 'Queued message with additional context.' },
+];
+
 const baseArgs: ThreadsScreenProps = {
   threads,
   runs,
@@ -294,6 +304,42 @@ export const Populated: Story = {
     threadsIsLoading: false,
     isLoading: false,
     isEmpty: false,
+  },
+  render: ControlledRender,
+  parameters: {
+    selectedMenuItem: 'threads',
+  },
+};
+
+export const RunsOnlyPending: Story = {
+  args: {
+    ...baseArgs,
+    queuedMessages: [],
+    conversationReminders: [],
+  },
+  render: ControlledRender,
+  parameters: {
+    selectedMenuItem: 'threads',
+  },
+};
+
+export const RunsWithPendingReminders: Story = {
+  args: {
+    ...baseArgs,
+    queuedMessages: [],
+    conversationReminders: pendingConversationReminders,
+  },
+  render: ControlledRender,
+  parameters: {
+    selectedMenuItem: 'threads',
+  },
+};
+
+export const RunsQueuedAndReminders: Story = {
+  args: {
+    ...baseArgs,
+    queuedMessages: pendingQueuedMessages,
+    conversationReminders: pendingConversationReminders,
   },
   render: ControlledRender,
   parameters: {

--- a/packages/platform-ui/stories/ThreadsScreen.stories.tsx
+++ b/packages/platform-ui/stories/ThreadsScreen.stories.tsx
@@ -171,8 +171,18 @@ const pendingConversationReminders: ReminderData[] = [
 ];
 
 const pendingQueuedMessages: QueuedMessageData[] = [
-  { id: 'queue-1', content: 'Queued message awaiting agent availability.' },
-  { id: 'queue-2', content: 'Queued message with additional context.' },
+  {
+    id: 'queue-1',
+    content: 'Queued message awaiting agent availability.',
+    kind: 'user',
+    enqueuedAt: new Date(Date.now() - 7 * 60 * 1000).toISOString(),
+  },
+  {
+    id: 'queue-2',
+    content: 'Queued message with additional context.',
+    kind: 'assistant',
+    enqueuedAt: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+  },
 ];
 
 const baseArgs: ThreadsScreenProps = {
@@ -315,6 +325,19 @@ export const RunsOnlyPending: Story = {
   args: {
     ...baseArgs,
     queuedMessages: [],
+    conversationReminders: [],
+  },
+  render: ControlledRender,
+  parameters: {
+    selectedMenuItem: 'threads',
+  },
+};
+
+export const QueueOnly: Story = {
+  args: {
+    ...baseArgs,
+    runs: [],
+    queuedMessages: pendingQueuedMessages,
     conversationReminders: [],
   },
   render: ControlledRender,


### PR DESCRIPTION
## Summary
- emit agent queue enqueue/drain events through the events bus and graph socket gateway
- subscribe the UI socket client to queue events and debounce queue invalidation for realtime pending updates
- expand realtime coverage with queue-focused specs and helpers

## Testing
- pnpm --filter @agyn/platform-server lint
- LOG_LEVEL=error pnpm --filter @agyn/platform-server test -- --reporter=dot --threads=false
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test -- --reporter=dot --threads=false
- pnpm --filter @agyn/platform-ui typecheck
- pnpm --filter @agyn/platform-ui build-storybook

Fixes #1079