### PR TITLE
feat(threads): wire draft creation flow

### DIFF
--- a/packages/platform-server/__tests__/agents.threads.controller.create.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.create.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Test } from '@nestjs/testing';
+import { AgentsThreadsController } from '../src/agents/threads.controller';
+import { AgentsPersistenceService, ThreadParentNotFoundError } from '../src/agents/agents.persistence.service';
+import { ThreadCleanupCoordinator } from '../src/agents/threadCleanup.coordinator';
+import { RunEventsService } from '../src/events/run-events.service';
+import { RunSignalsRegistry } from '../src/agents/run-signals.service';
+import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
+import { TemplateRegistry } from '../src/graph-core/templateRegistry';
+
+const runEventsStub = {
+  getRunSummary: async () => null,
+  listRunEvents: async () => ({ items: [], nextCursor: null }),
+  getToolOutputSnapshot: async () => null,
+};
+
+type SetupOptions = {
+  nodes?: Array<{ id: string; template: string; instance: { status: string; invoke: ReturnType<typeof vi.fn> } }>;
+  templateMeta?: Record<string, { kind: 'agent' | 'tool'; title: string }>;
+  createThreadWithInitialMessage?: ReturnType<typeof vi.fn>;
+};
+
+async function setup(options: SetupOptions = {}) {
+  const invoke = vi.fn(async () => 'queued');
+  const nodes =
+    options.nodes ?? [
+      {
+        id: 'agent-1',
+        template: 'agent.template.one',
+        instance: { status: 'ready', invoke },
+      },
+    ];
+
+  const createThreadWithInitialMessage =
+    options.createThreadWithInitialMessage ??
+    vi.fn(async () => ({
+      id: 'thread-new',
+      alias: 'alias-new',
+      summary: null,
+      status: 'open',
+      createdAt: new Date(),
+      parentId: null,
+      channelNodeId: null,
+      assignedAgentNodeId: 'agent-1',
+    }));
+
+  const templateRegistryStub = {
+    getMeta: (template: string) => options.templateMeta?.[template] ?? { kind: 'agent', title: template },
+  } satisfies Pick<TemplateRegistry, 'getMeta'>;
+
+  const moduleRef = await Test.createTestingModule({
+    controllers: [AgentsThreadsController],
+    providers: [
+      {
+        provide: AgentsPersistenceService,
+        useValue: {
+          listThreads: async () => [],
+          listChildren: async () => [],
+          listRuns: async () => [],
+          listRunMessages: async () => [],
+          getThreadsMetrics: async () => ({}),
+          getThreadsAgentTitles: async () => ({}),
+          updateThread: async () => ({ previousStatus: 'open', status: 'open' }),
+          getThreadById: async () => null,
+          getLatestAgentNodeIdForThread: async () => null,
+          getRunById: async () => null,
+          ensureAssignedAgent: async () => {},
+          createThreadWithInitialMessage,
+        },
+      },
+      { provide: ThreadCleanupCoordinator, useValue: { closeThreadWithCascade: vi.fn() } },
+      { provide: RunEventsService, useValue: runEventsStub },
+      { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
+      { provide: LiveGraphRuntime, useValue: { getNodes: () => nodes } },
+      { provide: TemplateRegistry, useValue: templateRegistryStub },
+    ],
+  }).compile();
+
+  const controller = await moduleRef.resolve(AgentsThreadsController);
+  return {
+    controller,
+    createThreadWithInitialMessage,
+    invoke,
+  };
+}
+
+describe('AgentsThreadsController POST /api/agents/threads', () => {
+  it('returns bad_message_payload when text is missing', async () => {
+    const { controller, createThreadWithInitialMessage } = await setup();
+
+    await expect(controller.createThread({ agentNodeId: 'agent-1' } as any)).rejects.toMatchObject({
+      status: 400,
+      response: { error: 'bad_message_payload' },
+    });
+
+    expect(createThreadWithInitialMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns bad_message_payload when agentNodeId is missing', async () => {
+    const { controller, createThreadWithInitialMessage } = await setup();
+
+    await expect(controller.createThread({ text: 'hello there' } as any)).rejects.toMatchObject({
+      status: 400,
+      response: { error: 'bad_message_payload' },
+    });
+
+    expect(createThreadWithInitialMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns bad_message_payload when text exceeds limit', async () => {
+    const { controller, createThreadWithInitialMessage } = await setup();
+
+    await expect(
+      controller.createThread({ text: 'a'.repeat(8001), agentNodeId: 'agent-1' } as any),
+    ).rejects.toMatchObject({
+      status: 400,
+      response: { error: 'bad_message_payload' },
+    });
+
+    expect(createThreadWithInitialMessage).not.toHaveBeenCalled();
+  });
+
+  it('propagates parent_not_found errors without alteration', async () => {
+    const createThreadWithInitialMessage = vi.fn(async () => {
+      throw new ThreadParentNotFoundError();
+    });
+    const { controller } = await setup({ createThreadWithInitialMessage });
+
+    await expect(
+      controller.createThread({ text: 'hello', agentNodeId: 'agent-1', parentId: 'missing-parent' } as any),
+    ).rejects.toMatchObject({
+      status: 404,
+      response: { error: 'parent_not_found' },
+    });
+  });
+});

--- a/packages/platform-server/src/agents/threads.controller.ts
+++ b/packages/platform-server/src/agents/threads.controller.ts
@@ -16,7 +16,7 @@ import {
   Query,
   ServiceUnavailableException,
 } from '@nestjs/common';
-import { IsBooleanString, IsIn, IsInt, IsOptional, IsString, IsISO8601, Max, Min, ValidateIf } from 'class-validator';
+import { IsBooleanString, IsIn, IsInt, IsOptional, IsString, IsISO8601, Max, MaxLength, Min, MinLength, ValidateIf } from 'class-validator';
 import { AgentsPersistenceService } from './agents.persistence.service';
 import { Transform, Expose } from 'class-transformer';
 import type { RunEventStatus, RunEventType, RunMessageType, ThreadStatus } from '@prisma/client';
@@ -28,6 +28,8 @@ import { LiveGraphRuntime } from '../graph-core/liveGraph.manager';
 import { HumanMessage } from '@agyn/llm';
 import { TemplateRegistry } from '../graph-core/templateRegistry';
 import { isAgentLiveNode, isAgentRuntimeInstance } from './agent-node.utils';
+import { randomUUID } from 'node:crypto';
+import { ThreadParentNotFoundError } from './agents.persistence.service';
 
 // Avoid runtime import of Prisma in tests; enumerate allowed values
 export const RunMessageTypeValues: ReadonlyArray<RunMessageType> = ['input', 'injected', 'output'];
@@ -44,6 +46,8 @@ export const RunEventStatusValues: ReadonlyArray<RunEventStatus> = ['pending', '
 
 const isRunEventType = (value: string): value is RunEventType => (RunEventTypeValues as ReadonlyArray<string>).includes(value);
 const isRunEventStatus = (value: string): value is RunEventStatus => (RunEventStatusValues as ReadonlyArray<string>).includes(value);
+
+const THREAD_MESSAGE_MAX_LENGTH = 8000;
 
 export class ListRunMessagesQueryDto {
   @IsIn(RunMessageTypeValues)
@@ -161,9 +165,34 @@ export class PatchThreadBodyDto {
   status?: ThreadStatus;
 }
 
+export class CreateThreadBodyDto {
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MinLength(1)
+  @MaxLength(THREAD_MESSAGE_MAX_LENGTH)
+  text!: string;
+
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MinLength(1)
+  agentNodeId!: string;
+
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MinLength(1)
+  parentId?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MinLength(1)
+  alias?: string;
+}
+
 @Controller('api/agents')
 export class AgentsThreadsController {
-  private static readonly MAX_MESSAGE_LENGTH = 8000;
+  private static readonly MAX_MESSAGE_LENGTH = THREAD_MESSAGE_MAX_LENGTH;
   private readonly logger = new Logger(AgentsThreadsController.name);
   constructor(
     @Inject(AgentsPersistenceService) private readonly persistence: AgentsPersistenceService,
@@ -173,6 +202,79 @@ export class AgentsThreadsController {
     @Inject(LiveGraphRuntime) private readonly runtime: LiveGraphRuntime,
     @Inject(TemplateRegistry) private readonly templateRegistry: TemplateRegistry,
   ) {}
+
+  @Post('threads')
+  @HttpCode(201)
+  async createThread(@Body() body: CreateThreadBodyDto): Promise<{ id: string }> {
+    const text = body.text.trim();
+    if (text.length === 0 || text.length > AgentsThreadsController.MAX_MESSAGE_LENGTH) {
+      throw new BadRequestException({ error: 'bad_message_payload' });
+    }
+
+    const agentNodeId = body.agentNodeId.trim();
+    if (agentNodeId.length === 0) {
+      throw new BadRequestException({ error: 'bad_message_payload' });
+    }
+
+    const aliasCandidate = typeof body.alias === 'string' ? body.alias.trim() : '';
+    const alias = aliasCandidate.length > 0 ? aliasCandidate : `ui:${randomUUID()}`;
+    const parentIdCandidate = typeof body.parentId === 'string' ? body.parentId.trim() : '';
+    const parentId = parentIdCandidate.length > 0 ? parentIdCandidate : null;
+
+    const liveNodes = this.runtime.getNodes();
+    const agentNodes = liveNodes.filter((node) => isAgentLiveNode(node, this.templateRegistry));
+    if (agentNodes.length === 0) {
+      throw new ServiceUnavailableException({ error: 'agent_unavailable' });
+    }
+    const liveAgentNode = agentNodes.find((node) => node.id === agentNodeId);
+    if (!liveAgentNode) {
+      throw new ServiceUnavailableException({ error: 'agent_unavailable' });
+    }
+
+    const instance = liveAgentNode.instance;
+    if (!isAgentRuntimeInstance(instance)) {
+      throw new ServiceUnavailableException({ error: 'agent_unavailable' });
+    }
+
+    if (instance.status !== 'ready') {
+      throw new ServiceUnavailableException({ error: 'agent_unready' });
+    }
+
+    let threadId: string;
+    try {
+      const created = await this.persistence.createThreadWithInitialMessage({
+        alias,
+        text,
+        agentNodeId,
+        parentId,
+      });
+      threadId = created.id;
+    } catch (error) {
+      if (error instanceof ThreadParentNotFoundError || (error instanceof Error && error.message === 'parent_not_found')) {
+        throw new NotFoundException({ error: 'parent_not_found' });
+      }
+      if (error instanceof Error && (error.message === 'thread_alias_required' || error.message === 'agent_node_id_required')) {
+        throw new BadRequestException({ error: 'bad_message_payload' });
+      }
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error(`createThread persistence failed alias=${alias}`, stack, AgentsThreadsController.name);
+      throw new InternalServerErrorException({ error: 'create_failed' });
+    }
+
+    try {
+      const invocation = instance.invoke(threadId, [HumanMessage.fromText(text)]);
+      void invocation.catch((error) => {
+        const stack = error instanceof Error ? error.stack : undefined;
+        this.logger.error(`createThread invoke failed thread=${threadId} agent=${agentNodeId}`, stack, AgentsThreadsController.name);
+      });
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error(`createThread immediate failure thread=${threadId} agent=${agentNodeId}`, stack, AgentsThreadsController.name);
+      throw new InternalServerErrorException({ error: 'create_failed' });
+    }
+
+    return { id: threadId } as const;
+  }
 
   @Get('threads')
   async listThreads(@Query() query: ListThreadsQueryDto) {

--- a/packages/platform-ui/src/api/modules/threads.ts
+++ b/packages/platform-ui/src/api/modules/threads.ts
@@ -30,6 +30,12 @@ export const threads = {
     ),
   patchStatus: (id: string, status: 'open' | 'closed') =>
     asData<void>(http.patch(`/api/agents/threads/${encodeURIComponent(id)}`, { status })),
+  create: ({ agentNodeId, text, parentId, alias }: { agentNodeId: string; text: string; parentId?: string; alias?: string }) => {
+    const payload: Record<string, string> = { agentNodeId, text };
+    if (parentId !== undefined) payload.parentId = parentId;
+    if (alias !== undefined) payload.alias = alias;
+    return asData<{ id: string }>(http.post(`/api/agents/threads`, payload));
+  },
   sendMessage: (id: string, text: string) =>
     asData<{ ok: true }>(http.post(`/api/agents/threads/${encodeURIComponent(id)}/messages`, { text })),
   metrics: (id: string) =>


### PR DESCRIPTION
## Summary
- wire the agents threads draft composer to the new create-thread mutation and centralize API error mapping
- expose the POST /api/agents/threads endpoint with validation, parent checks, and run invocation orchestration
- expand AgentsThreads draft-flow tests to cover success, error mapping, and pending state handling

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test -- --runInBand
- pnpm --filter @agyn/platform-server lint

Resolves #1097
