### PR TITLE
Fix: terminate runs and display errors on LLM call failure

### DIFF
--- a/packages/platform-server/__tests__/agent.error.termination.test.ts
+++ b/packages/platform-server/__tests__/agent.error.termination.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Test } from '@nestjs/testing';
+import { Reducer, Loop, HumanMessage } from '@agyn/llm';
+import type { LLMContext, LLMState } from '../src/llm/types';
+import { AgentNode } from '../src/nodes/agent/agent.node';
+import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
+import { ConfigService, configSchema } from '../src/core/services/config.service';
+import { LLMProvisioner } from '../src/llm/provisioners/llm.provisioner';
+import { RunSignalsRegistry } from '../src/agents/run-signals.service';
+
+class ErrorReducer extends Reducer<LLMState, LLMContext> {
+  override async invoke(): Promise<LLMState> {
+    throw new Error('LLM failure');
+  }
+}
+
+class ErrorAgentNode extends AgentNode {
+  protected override async prepareLoop(): Promise<Loop<LLMState, LLMContext>> {
+    return new Loop<LLMState, LLMContext>({ load: new ErrorReducer() });
+  }
+}
+
+describe('AgentNode error termination handling', () => {
+  it('completes run as terminated and emits status when reducers throw', async () => {
+    const beginRunThread = vi.fn(async () => ({ runId: 'run-error' }));
+    const runStatusChanged = vi.fn();
+    const completeRun = vi.fn(async (_runId: string, status: string) => {
+      runStatusChanged({ run: { id: 'run-error', status }, threadId: 'thread-1' });
+    });
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: new ConfigService().init(
+            configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://user:pass@host/db' }),
+          ),
+        },
+        { provide: LLMProvisioner, useValue: {} },
+        {
+          provide: AgentsPersistenceService,
+          useValue: {
+            beginRunThread,
+            completeRun,
+            recordInjected: vi.fn().mockResolvedValue({ messageIds: [] }),
+            ensureThreadModel: vi.fn(async (_threadId: string, model: string) => model),
+          },
+        },
+        RunSignalsRegistry,
+        ErrorAgentNode,
+      ],
+    }).compile();
+
+    const agent = await moduleRef.resolve(ErrorAgentNode);
+    agent.setRuntimeContext({ nodeId: 'agent-test', get: () => undefined });
+    await agent.setConfig({ whenBusy: 'wait' });
+
+    await expect(agent.invoke('thread-1', [HumanMessage.fromText('hi')])).rejects.toThrow('LLM failure');
+
+    expect(beginRunThread).toHaveBeenCalledTimes(1);
+    expect(completeRun).toHaveBeenCalledWith('run-error', 'terminated', []);
+    expect(runStatusChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ run: expect.objectContaining({ id: 'run-error', status: 'terminated' }) }),
+    );
+  });
+});

--- a/packages/platform-server/__tests__/callModel.error.serialization.test.ts
+++ b/packages/platform-server/__tests__/callModel.error.serialization.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CallModelLLMReducer } from '../src/llm/reducers/callModel.llm.reducer';
+import { HumanMessage, SystemMessage } from '@agyn/llm';
+import { RunEventStatus } from '@prisma/client';
+import { Signal } from '../src/signal';
+
+const createRunEventsStub = () => ({
+  startLLMCall: vi.fn(async () => ({ id: 'evt-llm' })),
+  completeLLMCall: vi.fn(async () => {}),
+  createContextItems: vi.fn(async () => []),
+});
+
+const createEventsBusStub = () => ({
+  publishEvent: vi.fn(async () => {}),
+});
+
+describe('CallModelLLMReducer error serialization', () => {
+  it('records error message, code, and raw response when LLM call throws', async () => {
+    const runEvents = createRunEventsStub();
+    const eventsBus = createEventsBusStub();
+    const failingCall = vi.fn(async () => {
+      throw new Error('model explosion');
+    });
+
+    const reducer = new CallModelLLMReducer(runEvents as any, eventsBus as any).init({
+      llm: { call: failingCall } as any,
+      model: 'test-model',
+      systemPrompt: 'SYS',
+      tools: [],
+    });
+
+    const state = {
+      messages: [SystemMessage.fromText('SYS'), HumanMessage.fromText('start')],
+      context: { messageIds: [], memory: [] },
+      meta: {},
+    } as any;
+
+    await expect(
+      reducer.invoke(state, {
+        threadId: 'thread-err',
+        runId: 'run-err',
+        finishSignal: new Signal(),
+        terminateSignal: new Signal(),
+        callerAgent: { getAgentNodeId: () => 'agent-err' } as any,
+      }),
+    ).rejects.toThrow('model explosion');
+
+    expect(runEvents.completeLLMCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: 'evt-llm',
+        status: RunEventStatus.error,
+        errorMessage: 'model explosion',
+        errorCode: 'Error',
+      }),
+    );
+
+    const callArgs = runEvents.completeLLMCall.mock.calls.at(-1)?.[0];
+    expect(callArgs).toBeTruthy();
+    const raw = callArgs?.rawResponse as Record<string, unknown> | null | undefined;
+    expect(raw && typeof raw === 'object' ? raw.message : undefined).toBe('model explosion');
+    expect(raw && typeof raw === 'object' ? raw.name : undefined).toBe('Error');
+  });
+
+});

--- a/packages/platform-server/src/nodes/agent/agent.node.ts
+++ b/packages/platform-server/src/nodes/agent/agent.node.ts
@@ -567,6 +567,15 @@ export class AgentNode extends Node<AgentStaticConfig> implements OnModuleInit {
         result = last;
       }
     } catch (err) {
+      if (runId) {
+        try {
+          const persistence = this.getPersistenceOrThrow();
+          await persistence.completeRun(runId, 'terminated', []);
+        } catch (completeErr) {
+          this.logger.error(`Failed to mark run ${runId} as terminated after error:`, completeErr);
+        }
+      }
+
       this.logger.error(`Agent invocation error in thread ${thread}:`, err);
       throw err;
     } finally {

--- a/packages/platform-ui/src/pages/__tests__/AgentsRunScreen.test.tsx
+++ b/packages/platform-ui/src/pages/__tests__/AgentsRunScreen.test.tsx
@@ -632,6 +632,20 @@ describe('extractLlmResponse', () => {
       ...overrides,
     } satisfies RunTimelineEvent);
 
+  it('returns errorMessage when provided on the event', () => {
+    const event = baseEvent({ status: 'error', errorMessage: 'LLM unhappy' });
+    const extract = getExtract();
+    expect(extract(event)).toBe('LLM unhappy');
+  });
+
+  it('uses rawResponse.message when errorMessage is absent', () => {
+    const event = baseEvent({ status: 'error' });
+    if (!event.llmCall) throw new Error('llmCall missing');
+    event.llmCall.rawResponse = { message: 'LLM crashed', name: 'ModelError' };
+    const extract = getExtract();
+    expect(extract(event)).toBe('LLM crashed');
+  });
+
   it('prefers responseText when present', () => {
     const event = baseEvent({});
     if (!event.llmCall) throw new Error('llmCall missing');


### PR DESCRIPTION
## Summary
- ensure agent runs complete as terminated when reducers throw and avoid stuck running status
- serialize LLM error payloads with name/message/stack and expose error codes for run events
- surface LLM error messages in run screen and extend server/UI test coverage for the new behavior

## Testing
- pnpm --filter @agyn/platform-server lint
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-server test
- pnpm --filter @agyn/platform-ui test -- --runInBand

Resolves #1107
