### PR TITLE
feat: cache agents thread scroll state

### DIFF
--- a/packages/platform-ui/__tests__/AgentsThreads.cache.integration.test.tsx
+++ b/packages/platform-ui/__tests__/AgentsThreads.cache.integration.test.tsx
@@ -1,0 +1,350 @@
+import React from 'react';
+import { describe, it, beforeAll, afterAll, afterEach, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AgentsThreads } from '../src/pages/AgentsThreads';
+import { TestProviders, server, abs } from './integration/testUtils';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...(actual as Record<string, unknown>),
+    useNavigate: () => navigateMock,
+  };
+});
+
+type ThreadDescriptor = {
+  id: string;
+  summary: string;
+  runId: string;
+  createdAt: string;
+};
+
+function setupScrollMetrics(element: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop?: number }) {
+  let currentTop = metrics.scrollTop ?? 0;
+  Object.defineProperty(element, 'scrollHeight', {
+    configurable: true,
+    get: () => metrics.scrollHeight,
+  });
+  Object.defineProperty(element, 'clientHeight', {
+    configurable: true,
+    get: () => metrics.clientHeight,
+  });
+  Object.defineProperty(element, 'scrollTop', {
+    configurable: true,
+    get: () => currentTop,
+    set: (value: number) => {
+      currentTop = value;
+    },
+  });
+}
+
+function stubRaf() {
+  const queue: FrameRequestCallback[] = [];
+  const spy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+    queue.push(cb);
+    return queue.length;
+  });
+  return {
+    flush() {
+      while (queue.length > 0) {
+        const cb = queue.shift()!;
+        cb(performance.now());
+      }
+    },
+    restore() {
+      spy.mockRestore();
+    },
+  };
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitInAct(ms: number) {
+  await act(async () => {
+    await wait(ms);
+  });
+}
+
+function flushRaf(controller: { flush(): void }) {
+  act(() => {
+    controller.flush();
+  });
+}
+
+function registerThreadHandlers(threads: ThreadDescriptor[], options?: { messageDelayMs?: number }) {
+  const threadList = threads.map((thread, index) => ({
+    id: thread.id,
+    alias: `${thread.id}-alias`,
+    summary: thread.summary,
+    status: 'open',
+    createdAt: thread.createdAt,
+    parentId: null,
+    metrics: { remindersCount: 0, containersCount: 0, activity: index % 2 === 0 ? 'working' : 'idle', runsCount: 1 },
+  }));
+
+  const threadById = new Map(threadList.map((item) => [item.id, item]));
+  const runMetaByThread = new Map(
+    threads.map((thread) => [thread.id, { id: thread.runId, threadId: thread.id, status: 'finished', createdAt: thread.createdAt, updatedAt: thread.createdAt }]),
+  );
+
+  const buildMessages = (threadId: string) => {
+    const prefix = threadId.toUpperCase();
+    const createdAt = threads.find((item) => item.id === threadId)?.createdAt ?? new Date().toISOString();
+    return {
+      input: [{ id: `${prefix}-in`, kind: 'user', text: `Input ${threadId}`, createdAt }],
+      injected: [{ id: `${prefix}-ctx`, kind: 'system', text: `Ctx ${threadId}`, createdAt }],
+      output: [{ id: `${prefix}-out`, kind: 'assistant', text: `Output ${threadId}`, createdAt }],
+    };
+  };
+
+  const messageMap = new Map(threads.map((thread) => [thread.runId, buildMessages(thread.id)]));
+  const delay = options?.messageDelayMs ?? 0;
+  const listRequestLog: string[] = [];
+
+  server.use(
+    http.get('/api/agents/threads', ({ request }) => {
+      listRequestLog.push(request.url);
+      return HttpResponse.json({ items: threadList });
+    }),
+    http.get(abs('/api/agents/threads'), ({ request }) => {
+      listRequestLog.push(request.url);
+      return HttpResponse.json({ items: threadList });
+    }),
+    http.get('/api/agents/threads/:threadId', ({ params }) => HttpResponse.json(threadById.get(params.threadId as string) ?? threadList[0])),
+    http.get(abs('/api/agents/threads/:threadId'), ({ params }) => HttpResponse.json(threadById.get(params.threadId as string) ?? threadList[0])),
+    http.get('/api/agents/threads/:threadId/runs', ({ params }) => {
+      const run = runMetaByThread.get(params.threadId as string);
+      return HttpResponse.json({ items: run ? [run] : [] });
+    }),
+    http.get(abs('/api/agents/threads/:threadId/runs'), ({ params }) => {
+      const run = runMetaByThread.get(params.threadId as string);
+      return HttpResponse.json({ items: run ? [run] : [] });
+    }),
+    http.get('/api/agents/threads/:threadId/children', () => HttpResponse.json({ items: [] })),
+    http.get(abs('/api/agents/threads/:threadId/children'), () => HttpResponse.json({ items: [] })),
+    http.get('/api/agents/reminders', () => HttpResponse.json({ items: [] })),
+    http.get(abs('/api/agents/reminders'), () => HttpResponse.json({ items: [] })),
+    http.get('/api/containers', () => HttpResponse.json({ items: [] })),
+    http.get(abs('/api/containers'), () => HttpResponse.json({ items: [] })),
+    http.get('/api/agents/runs/:runId/messages', async ({ params, request }) => {
+      if (delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+      const runId = params.runId as string;
+      const url = new URL(request.url);
+      const type = url.searchParams.get('type') as 'input' | 'injected' | 'output' | null;
+      const messages = messageMap.get(runId);
+      if (!messages || !type) return HttpResponse.json({ items: [] });
+      return HttpResponse.json({ items: messages[type] ?? [] });
+    }),
+    http.get(abs('/api/agents/runs/:runId/messages'), async ({ params, request }) => {
+      if (delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+      const runId = params.runId as string;
+      const url = new URL(request.url);
+      const type = url.searchParams.get('type') as 'input' | 'injected' | 'output' | null;
+      const messages = messageMap.get(runId);
+      if (!messages || !type) return HttpResponse.json({ items: [] });
+      return HttpResponse.json({ items: messages[type] ?? [] });
+    }),
+  );
+
+  return { listRequestLog };
+}
+
+function renderThreads() {
+  render(
+    <TestProviders>
+      <MemoryRouter>
+        <AgentsThreads />
+      </MemoryRouter>
+    </TestProviders>,
+  );
+}
+
+describe('AgentsThreads caching and scroll restoration', () => {
+  beforeAll(() => server.listen());
+  afterEach(() => {
+    server.resetHandlers();
+    navigateMock.mockReset();
+    vi.useRealTimers();
+  });
+  afterAll(() => server.close());
+
+  it('restores bottom scroll position when switching back to a cached thread', async () => {
+    const raf = stubRaf();
+    try {
+      const threads: ThreadDescriptor[] = [
+        { id: 'th1', summary: 'Thread 1', runId: 'run1', createdAt: new Date(1700000000000).toISOString() },
+        { id: 'th2', summary: 'Thread 2', runId: 'run2', createdAt: new Date(1700000005000).toISOString() },
+      ];
+      const { listRequestLog } = registerThreadHandlers(threads);
+
+      const user = userEvent.setup();
+      renderThreads();
+
+      await waitFor(() => {
+        expect(listRequestLog.length).toBeGreaterThan(0);
+      });
+      const threadOneRow = await screen.findByText('Thread 1');
+      await user.click(threadOneRow);
+
+      await screen.findByText('Loading thread…');
+      const scrollContainer = await screen.findByTestId('conversation-scroll');
+      setupScrollMetrics(scrollContainer, { scrollHeight: 1200, clientHeight: 300, scrollTop: 0 });
+
+      flushRaf(raf);
+      await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+      flushRaf(raf);
+
+      expect(scrollContainer.scrollTop).toBe(1200);
+
+      const threadTwoRow = await screen.findByText('Thread 2');
+      await user.click(threadTwoRow);
+      await screen.findByText('Loading thread…');
+      const scrollContainerTwo = await screen.findByTestId('conversation-scroll');
+      setupScrollMetrics(scrollContainerTwo, { scrollHeight: 900, clientHeight: 300, scrollTop: 0 });
+      flushRaf(raf);
+      await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+      flushRaf(raf);
+
+      await user.click(threadOneRow);
+      await screen.findByText('Loading thread…');
+      setupScrollMetrics(scrollContainer, { scrollHeight: 1200, clientHeight: 300, scrollTop: scrollContainer.scrollTop });
+      flushRaf(raf);
+      await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+      flushRaf(raf);
+
+      expect(scrollContainer.scrollTop).toBe(1200);
+    } finally {
+      raf.restore();
+    }
+  });
+
+  it('restores distance-from-bottom when returning to a cached thread mid-scroll', async () => {
+    const raf = stubRaf();
+    try {
+      const threads: ThreadDescriptor[] = [
+        { id: 'thA', summary: 'Thread A', runId: 'runA', createdAt: new Date(1700001000000).toISOString() },
+        { id: 'thB', summary: 'Thread B', runId: 'runB', createdAt: new Date(1700002000000).toISOString() },
+      ];
+      registerThreadHandlers(threads);
+
+      const user = userEvent.setup();
+      renderThreads();
+
+      const threadARow = await screen.findByText('Thread A');
+      await user.click(threadARow);
+      await screen.findByText('Loading thread…');
+      const scrollContainer = await screen.findByTestId('conversation-scroll');
+      setupScrollMetrics(scrollContainer, { scrollHeight: 1000, clientHeight: 250, scrollTop: 0 });
+
+      flushRaf(raf);
+      await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+      flushRaf(raf);
+
+      scrollContainer.scrollTop = 600;
+      fireEvent.scroll(scrollContainer);
+      await waitInAct(100);
+      flushRaf(raf);
+
+      const threadBRow = await screen.findByText('Thread B');
+      await user.click(threadBRow);
+      await screen.findByText('Loading thread…');
+      const scrollContainerB = await screen.findByTestId('conversation-scroll');
+      setupScrollMetrics(scrollContainerB, { scrollHeight: 800, clientHeight: 250, scrollTop: 0 });
+      flushRaf(raf);
+      await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+      flushRaf(raf);
+
+      await user.click(threadARow);
+      await screen.findByText('Loading thread…');
+      setupScrollMetrics(scrollContainer, { scrollHeight: 1000, clientHeight: 250, scrollTop: scrollContainer.scrollTop });
+      flushRaf(raf);
+      await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+      flushRaf(raf);
+
+      expect(scrollContainer.scrollTop).toBe(600);
+    } finally {
+      raf.restore();
+    }
+  });
+
+  it('evicts the least recently used thread after exceeding cache capacity', async () => {
+    const raf = stubRaf();
+    try {
+      const baseTime = 1700010000000;
+      const threads: ThreadDescriptor[] = Array.from({ length: 11 }, (_value, index) => {
+        const id = `thread-${index + 1}`;
+        return {
+          id,
+          summary: `Thread ${index + 1}`,
+          runId: `run-${index + 1}`,
+          createdAt: new Date(baseTime + index * 1000).toISOString(),
+        };
+      });
+      registerThreadHandlers(threads, { messageDelayMs: 50 });
+
+      const user = userEvent.setup();
+      renderThreads();
+
+      const setMetrics = () => {
+        const container = screen.getByTestId('conversation-scroll');
+        setupScrollMetrics(container, { scrollHeight: 1400, clientHeight: 300, scrollTop: 0 });
+        return container;
+      };
+
+      for (let i = 0; i < 10; i += 1) {
+        const threadLabel = `Thread ${i + 1}`;
+        const row = await screen.findByText(threadLabel);
+        await user.click(row);
+        await screen.findByText('Loading thread…');
+        const container = setMetrics();
+        flushRaf(raf);
+        await waitInAct(60);
+        flushRaf(raf);
+        await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+        expect(container.scrollTop).toBe(1400);
+      }
+
+      const thread11 = await screen.findByText('Thread 11');
+      await user.click(thread11);
+      await screen.findByText('Loading thread…');
+      setMetrics();
+      flushRaf(raf);
+      await waitInAct(60);
+      flushRaf(raf);
+      await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+
+      const thread1 = await screen.findByText('Thread 1');
+      await user.click(thread1);
+      await screen.findByText('Loading thread…');
+      setMetrics();
+      flushRaf(raf);
+      // Still loading because entry was evicted and messages refetch is pending
+      expect(screen.getByText('Loading thread…')).toBeInTheDocument();
+      // Complete pending fetch and restoration
+      await waitInAct(60);
+      flushRaf(raf);
+      await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+
+      // Re-select a thread still in cache (thread 5) should hide overlay immediately
+      const thread5 = await screen.findByText('Thread 5');
+      await user.click(thread5);
+      await screen.findByText('Loading thread…');
+      setMetrics();
+      flushRaf(raf);
+      await waitFor(() => expect(screen.queryByText('Loading thread…')).not.toBeInTheDocument());
+    } finally {
+      raf.restore();
+    }
+  });
+});

--- a/packages/platform-ui/src/components/Conversation.tsx
+++ b/packages/platform-ui/src/components/Conversation.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useRef, useEffect, useState } from 'react';
+import { type ReactNode, useRef, useEffect, useState, type Ref, type UIEvent } from 'react';
 import { Message, type MessageRole } from './Message';
 import { RunInfo } from './RunInfo';
 import { QueuedMessage } from './QueuedMessage';
@@ -44,6 +44,8 @@ interface ConversationProps {
   className?: string;
   defaultCollapsed?: boolean;
   collapsed?: boolean;
+  scrollRef?: Ref<HTMLDivElement>;
+  onScroll?: (event: UIEvent<HTMLDivElement>) => void;
 }
 
 export function Conversation({
@@ -55,13 +57,15 @@ export function Conversation({
   className = '',
   defaultCollapsed = false,
   collapsed,
+  scrollRef,
+  onScroll,
 }: ConversationProps) {
   const messagesRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const [runHeights, setRunHeights] = useState<Map<string, number>>(new Map());
 
   // Use controlled or uncontrolled state
   const isCollapsed = collapsed ?? defaultCollapsed;
-  
+
   // Measure run heights for the sticky run info column
   useEffect(() => {
     const newHeights = new Map<string, number>();
@@ -89,7 +93,12 @@ export function Conversation({
       )}
 
       {/* Main Content Area - Single Scroll Container */}
-      <div className="flex-1 min-w-0 overflow-y-auto flex flex-col">
+      <div
+        className="flex-1 min-w-0 overflow-y-auto flex flex-col"
+        ref={scrollRef ?? undefined}
+        onScroll={onScroll}
+        data-testid="conversation-scroll"
+      >
         {/* Runs Container */}
         <div className="flex flex-col flex-1 min-w-0">
           {/* Runs */}

--- a/packages/platform-ui/src/components/__tests__/Conversation.scroll.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/Conversation.scroll.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Conversation } from '../Conversation';
+
+describe('Conversation scroll handling', () => {
+  it('forwards the scroll ref and invokes the onScroll handler', () => {
+    const scrollRef = React.createRef<HTMLDivElement>();
+    const handleScroll = vi.fn();
+
+    render(
+      <Conversation
+        runs={[
+          {
+            id: 'run-1',
+            status: 'finished',
+            messages: [
+              {
+                id: 'msg-1',
+                role: 'user',
+                content: 'Hello world',
+              },
+            ],
+          },
+        ]}
+        scrollRef={scrollRef}
+        onScroll={handleScroll}
+      />,
+    );
+
+    const scrollContainer = screen.getByTestId('conversation-scroll');
+    expect(scrollRef.current).toBe(scrollContainer);
+
+    fireEvent.scroll(scrollContainer, { target: { scrollTop: 42 } });
+    expect(handleScroll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/platform-ui/src/lib/lru/LruCache.ts
+++ b/packages/platform-ui/src/lib/lru/LruCache.ts
@@ -1,0 +1,120 @@
+export class LruCache<K, V> {
+  private readonly capacity: number;
+  private readonly entries = new Map<K, LruNode<K, V>>();
+  private head: LruNode<K, V> | null = null;
+  private tail: LruNode<K, V> | null = null;
+
+  constructor(capacity: number) {
+    if (!Number.isFinite(capacity) || capacity <= 0) {
+      throw new Error('LRU cache capacity must be a positive finite number');
+    }
+    this.capacity = Math.floor(capacity);
+    if (this.capacity <= 0) {
+      throw new Error('LRU cache capacity must be at least 1');
+    }
+  }
+
+  get(key: K): V | undefined {
+    const node = this.entries.get(key);
+    if (!node) return undefined;
+    this.moveToFront(node);
+    return node.value;
+  }
+
+  set(key: K, value: V): void {
+    const existing = this.entries.get(key);
+    if (existing) {
+      existing.value = value;
+      this.moveToFront(existing);
+      return;
+    }
+
+    const node: LruNode<K, V> = { key, value, newer: null, older: null };
+    this.entries.set(key, node);
+    this.insertAtFront(node);
+    if (this.entries.size > this.capacity) {
+      this.evictLeastRecent();
+    }
+  }
+
+  has(key: K): boolean {
+    return this.entries.has(key);
+  }
+
+  delete(key: K): boolean {
+    const node = this.entries.get(key);
+    if (!node) return false;
+    this.removeNode(node);
+    this.entries.delete(key);
+    return true;
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.head = null;
+    this.tail = null;
+  }
+
+  keys(): K[] {
+    const result: K[] = [];
+    let current = this.head;
+    while (current) {
+      result.push(current.key);
+      current = current.newer;
+    }
+    return result;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  private moveToFront(node: LruNode<K, V>): void {
+    if (this.head === node) return;
+    this.removeNode(node);
+    this.insertAtFront(node);
+  }
+
+  private insertAtFront(node: LruNode<K, V>): void {
+    node.older = null;
+    node.newer = this.head;
+    if (this.head) {
+      this.head.older = node;
+    }
+    this.head = node;
+    if (!this.tail) {
+      this.tail = node;
+    }
+  }
+
+  private removeNode(node: LruNode<K, V>): void {
+    if (node.older) {
+      node.older.newer = node.newer;
+    } else if (this.head === node) {
+      this.head = node.newer;
+    }
+
+    if (node.newer) {
+      node.newer.older = node.older;
+    } else if (this.tail === node) {
+      this.tail = node.older;
+    }
+
+    node.newer = null;
+    node.older = null;
+  }
+
+  private evictLeastRecent(): void {
+    if (!this.tail) return;
+    const node = this.tail;
+    this.removeNode(node);
+    this.entries.delete(node.key);
+  }
+}
+
+type LruNode<K, V> = {
+  key: K;
+  value: V;
+  newer: LruNode<K, V> | null;
+  older: LruNode<K, V> | null;
+};

--- a/packages/platform-ui/src/lib/lru/__tests__/LruCache.test.ts
+++ b/packages/platform-ui/src/lib/lru/__tests__/LruCache.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { LruCache } from '../LruCache';
+
+describe('LruCache', () => {
+  it('stores entries, updates recency, and evicts least recently used items', () => {
+    const cache = new LruCache<string, number>(3);
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+
+    expect(cache.size).toBe(3);
+    expect(cache.keys()).toEqual(['c', 'b', 'a']);
+    expect(cache.get('b')).toBe(2);
+    expect(cache.keys()).toEqual(['b', 'c', 'a']);
+
+    cache.set('d', 4);
+
+    expect(cache.size).toBe(3);
+    expect(cache.has('a')).toBe(false);
+    expect(cache.keys()).toEqual(['d', 'b', 'c']);
+  });
+
+  it('supports deleting entries and clearing the cache', () => {
+    const cache = new LruCache<string, string>(2);
+
+    cache.set('x', '1');
+    cache.set('y', '2');
+
+    expect(cache.delete('x')).toBe(true);
+    expect(cache.delete('missing')).toBe(false);
+    expect(cache.keys()).toEqual(['y']);
+
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.keys()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- maintain per-thread LRU cache for runs, messages, and scroll state
- surface Conversation scroll container for persistence + overlay preload UX
- cover caching flows with integration tests and new LRU unit tests

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm -w -C packages-platform-ui test

Resolves #1105