### PR TITLE
fix(mcp): surface local tool errors

### DIFF
--- a/packages/platform-server/__tests__/localMcpServerTool.error.test.ts
+++ b/packages/platform-server/__tests__/localMcpServerTool.error.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import z from 'zod';
+import { LocalMCPServerTool } from '../src/nodes/mcp/localMcpServer.tool';
+import type { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
+import { McpError } from '../src/nodes/mcp/types';
+import { Signal } from '../src/signal';
+import type { LLMContext } from '../src/llm/types';
+
+const createContext = (): LLMContext => ({
+  threadId: 'thread-mcp',
+  runId: 'run-mcp',
+  finishSignal: new Signal(),
+  terminateSignal: new Signal(),
+  callerAgent: { invoke: vi.fn() },
+});
+
+const createNode = (overrides: Partial<Pick<LocalMCPServerNode, 'callTool'>> = {}) =>
+  ({
+    config: { namespace: 'demo' },
+    callTool: overrides.callTool ?? vi.fn(),
+  }) as unknown as LocalMCPServerNode;
+
+describe('LocalMCPServerTool error handling', () => {
+  it('throws an McpError with structured message when execution result is flagged as error', async () => {
+    const structured = { message: 'patch failed', code: 'E_PATCH', retriable: false };
+    const callTool = vi.fn(async () => ({ isError: true, structuredContent: structured }));
+    const node = createNode({ callTool });
+    const tool = new LocalMCPServerTool('codex_apply_patch', 'Apply patch', z.object({}), node);
+
+    let caught: unknown;
+    try {
+      await tool.execute({}, createContext());
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(callTool).toHaveBeenCalledTimes(1);
+    expect(callTool).toHaveBeenCalledWith('codex_apply_patch', {}, { threadId: 'thread-mcp' });
+    expect(caught).toBeInstanceOf(McpError);
+    expect((caught as Error).message).toBe('patch failed (code=E_PATCH retriable=false)');
+    expect((caught as Error & { cause?: unknown }).cause).toEqual(structured);
+  });
+
+  it('returns structured content when available and falls back to plain content otherwise', async () => {
+    const structured = { result: 'ok', instructions: ['a', 'b'] };
+    const callTool = vi
+      .fn()
+      .mockResolvedValueOnce({ isError: false, structuredContent: structured })
+      .mockResolvedValueOnce({ isError: false, content: 'plain text' });
+
+    const node = createNode({ callTool });
+    const tool = new LocalMCPServerTool('codex_apply_patch', 'Apply patch', z.object({}), node);
+    const ctx = createContext();
+
+    const structuredResult = await tool.execute({}, ctx);
+    expect(structuredResult).toBe(JSON.stringify(structured));
+
+    const plainResult = await tool.execute({}, ctx);
+    expect(plainResult).toBe('plain text');
+  });
+});

--- a/packages/platform-server/__tests__/mcp.error.mapping.test.ts
+++ b/packages/platform-server/__tests__/mcp.error.mapping.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ResponseMessage, ToolCallMessage, ToolCallOutputMessage } from '@agyn/llm';
+import z from 'zod';
+import { Signal } from '../src/signal';
+import { CallToolsLLMReducer } from '../src/llm/reducers/callTools.llm.reducer';
+import { createRunEventsStub, createEventsBusStub } from './helpers/runEvents.stub';
+import { LocalMCPServerTool } from '../src/nodes/mcp/localMcpServer.tool';
+import type { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
+import type { LLMState } from '../src/llm/types';
+
+const buildState = (toolName: string, callId: string, args: string): LLMState => {
+  const toolCall = new ToolCallMessage({ type: 'function_call', name: toolName, call_id: callId, arguments: args } as any);
+  const response = new ResponseMessage({ output: [toolCall.toPlain() as any] } as any);
+  return {
+    messages: [response],
+    meta: {},
+    context: { messageIds: [], memory: [] },
+  } as unknown as LLMState;
+};
+
+const createContext = () => ({
+  threadId: 'thread-mcp',
+  runId: 'run-mcp',
+  finishSignal: new Signal(),
+  terminateSignal: new Signal(),
+  callerAgent: { getAgentNodeId: () => 'agent-node' },
+});
+
+const createNode = (callTool: ReturnType<typeof vi.fn>) =>
+  ({
+    config: { namespace: 'demo' },
+    callTool,
+  }) as unknown as LocalMCPServerNode;
+
+describe('CallToolsLLMReducer MCP error mapping', () => {
+  it('marks MCP tool failures as error events and publishes updates', async () => {
+    const callTool = vi.fn(async () => ({
+      isError: true,
+      structuredContent: { message: 'apply_patch failed', code: 'PATCH_FAIL', retriable: false },
+    }));
+    const node = createNode(callTool);
+    const tool = new LocalMCPServerTool('codex_apply_patch', 'Codex patch', z.object({}), node);
+
+    const runEvents = createRunEventsStub();
+    const eventsBus = createEventsBusStub();
+
+    const reducer = new CallToolsLLMReducer(runEvents as any, eventsBus as any).init({ tools: [tool as any] });
+    const state = buildState(tool.name, 'call-err', JSON.stringify({}));
+    const ctx = createContext();
+
+    const result = await reducer.invoke(state, ctx as any);
+
+    expect(callTool).toHaveBeenCalledTimes(1);
+
+    expect(runEvents.startToolExecution).toHaveBeenCalledTimes(1);
+    expect(eventsBus.publishEvent).toHaveBeenCalledTimes(2);
+    expect(eventsBus.publishEvent.mock.calls[0][1]).toBe('append');
+    expect(eventsBus.publishEvent.mock.calls[1][1]).toBe('update');
+
+    expect(runEvents.completeToolExecution).toHaveBeenCalledTimes(1);
+    const [completionPayload] = runEvents.completeToolExecution.mock.calls[0];
+    expect(completionPayload.status).toBe('error');
+    expect(completionPayload.errorMessage).toContain('apply_patch failed (code=PATCH_FAIL retriable=false)');
+
+    const lastMessage = result.messages.at(-1) as ToolCallOutputMessage;
+    expect(lastMessage).toBeInstanceOf(ToolCallOutputMessage);
+    const payload = JSON.parse(lastMessage.text);
+    expect(payload.status).toBe('error');
+    expect(payload.error_code).toBe('MCP_CALL_ERROR');
+    expect(payload.message).toContain(
+      `Tool ${tool.name} execution failed: apply_patch failed (code=PATCH_FAIL retriable=false)`,
+    );
+  });
+});

--- a/packages/platform-server/src/nodes/mcp/types.ts
+++ b/packages/platform-server/src/nodes/mcp/types.ts
@@ -67,11 +67,14 @@ export interface JsonRpcTransport {
 }
 
 export class McpError extends Error {
-  constructor(
-    message: string,
-    public code?: string,
-  ) {
-    super(message);
+  public code?: string;
+
+  constructor(message: string, codeOrOptions?: string | { code?: string; cause?: unknown }) {
+    const hasOptionsObject = typeof codeOrOptions === 'object' && codeOrOptions !== null;
+    const cause = hasOptionsObject ? (codeOrOptions as { cause?: unknown }).cause : undefined;
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.code = hasOptionsObject ? (codeOrOptions as { code?: string }).code : codeOrOptions;
+    this.name = 'McpError';
   }
 }
 


### PR DESCRIPTION
## Summary
- throw `McpError` with structured context when local MCP calls fail so reducers see tool errors
- prefer returning structured content on success and extend `McpError` to capture error causes
- add coverage for LocalMCPServerTool failures and reducer event/error propagation

Fixes #1111

## Testing
- pnpm --filter @agyn/platform-server lint
- pnpm --filter @agyn/platform-server exec vitest run --reporter=json --outputFile=/tmp/vitest.json
