### PR TITLE
Fix: Manage tool logger error handling to prevent TypeError

### DIFF
--- a/packages/platform-server/__tests__/nodes/manage.node.channel.spec.ts
+++ b/packages/platform-server/__tests__/nodes/manage.node.channel.spec.ts
@@ -27,6 +27,19 @@ describe('ManageToolNode sendToChannel', () => {
     expect(resolved).toBe('ready to go');
   });
 
+  it('waits indefinitely when timeout is disabled', async () => {
+    await node.setConfig({ mode: 'sync', timeoutMs: 0 } as unknown as ManageToolNode['config']);
+    const waiter = node.awaitChildResponse('child-thread-zero', 0);
+
+    await new Promise((resolve) => setTimeout(resolve, 75));
+
+    const sendResult = await node.sendToChannel('child-thread-zero', 'delayed response');
+    const resolved = await waiter;
+
+    expect(sendResult.ok).toBe(true);
+    expect(resolved).toBe('delayed response');
+  });
+
   it('forwards messages to parent thread in async mode', async () => {
     await node.setConfig({ mode: 'async', timeoutMs: 1000 } as unknown as ManageToolNode['config']);
     const parentInvoke = vi.fn().mockResolvedValue(undefined);

--- a/packages/platform-server/__tests__/tools/manage.function.tool.spec.ts
+++ b/packages/platform-server/__tests__/tools/manage.function.tool.spec.ts
@@ -135,6 +135,45 @@ ${text}`),
     });
   });
 
+  it('logs async non-error object rejections using message field', async () => {
+    const persistence = {
+      getOrCreateSubthreadByAlias: vi.fn().mockResolvedValue('child-thread-object'),
+      setThreadChannelNode: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentsPersistenceService;
+
+    const diagnostic = { message: 'custom diagnostic', code: 'X' };
+    const workerInvoke = vi.fn().mockRejectedValue(diagnostic);
+    const manageNode = {
+      nodeId: 'manage-node-object',
+      listWorkers: vi.fn().mockReturnValue(['Async Worker']),
+      getWorkerByTitle: vi.fn().mockReturnValue({ invoke: workerInvoke }),
+      registerInvocation: vi.fn().mockResolvedValue(undefined),
+      awaitChildResponse: vi.fn(),
+      getMode: vi.fn().mockReturnValue('async'),
+      getTimeoutMs: vi.fn(),
+      renderWorkerResponse: vi.fn(),
+      renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
+    } as unknown as ManageToolNode;
+
+    const tool = new ManageFunctionTool(persistence);
+    tool.init(manageNode, { persistence });
+
+    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+
+    const ctx = createCtx();
+    const result = await tool.execute(
+      { command: 'send_message', worker: 'Async Worker', message: 'hello async', threadAlias: undefined },
+      ctx,
+    );
+
+    expect(result).toBe('async acknowledgement');
+    await vi.waitFor(() => {
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Manage: async send_message failed {"worker":"Async Worker","childThreadId":"child-thread-object","error":"custom diagnostic"}',
+      );
+    });
+  });
+
   it('rethrows non-error rejections and logs safely', async () => {
     const persistence = {
       getOrCreateSubthreadByAlias: vi.fn().mockResolvedValue('child-thread-sync'),
@@ -166,6 +205,41 @@ ${text}`),
 
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       'Manage: send_message failed {"worker":"Fail Worker","childThreadId":"child-thread-sync","error":"boom"}',
+    );
+  });
+
+  it('rethrows non-error objects while logging their message', async () => {
+    const persistence = {
+      getOrCreateSubthreadByAlias: vi.fn().mockResolvedValue('child-thread-sync-object'),
+      setThreadChannelNode: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentsPersistenceService;
+
+    const diagnostic = { message: 'sync diagnostic', code: 'Y' };
+    const workerInvoke = vi.fn().mockRejectedValue(diagnostic);
+    const manageNode = {
+      nodeId: 'manage-node-sync-object',
+      listWorkers: vi.fn().mockReturnValue(['Fail Worker']),
+      getWorkerByTitle: vi.fn().mockReturnValue({ invoke: workerInvoke }),
+      registerInvocation: vi.fn().mockResolvedValue(undefined),
+      awaitChildResponse: vi.fn().mockResolvedValue('ignored'),
+      getMode: vi.fn().mockReturnValue('sync'),
+      getTimeoutMs: vi.fn().mockReturnValue(64000),
+      renderWorkerResponse: vi.fn(),
+      renderAsyncAcknowledgement: vi.fn(),
+    } as unknown as ManageToolNode;
+
+    const tool = new ManageFunctionTool(persistence);
+    tool.init(manageNode, { persistence });
+
+    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+
+    const ctx = createCtx();
+    await expect(
+      tool.execute({ command: 'send_message', worker: 'Fail Worker', message: 'fail', threadAlias: undefined }, ctx),
+    ).rejects.toEqual(diagnostic);
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Manage: send_message failed {"worker":"Fail Worker","childThreadId":"child-thread-sync-object","error":"sync diagnostic"}',
     );
   });
 });

--- a/packages/platform-server/__tests__/tools/manage.function.tool.spec.ts
+++ b/packages/platform-server/__tests__/tools/manage.function.tool.spec.ts
@@ -96,4 +96,76 @@ ${text}`),
     expect(workerInvoke).toHaveBeenCalledTimes(1);
     expect(result).toBe('async acknowledgement');
   });
+
+  it('logs async non-error rejections without crashing', async () => {
+    const persistence = {
+      getOrCreateSubthreadByAlias: vi.fn().mockResolvedValue('child-thread-async'),
+      setThreadChannelNode: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentsPersistenceService;
+
+    const workerInvoke = vi.fn().mockRejectedValue('boom');
+    const manageNode = {
+      nodeId: 'manage-node-async',
+      listWorkers: vi.fn().mockReturnValue(['Async Worker']),
+      getWorkerByTitle: vi.fn().mockReturnValue({ invoke: workerInvoke }),
+      registerInvocation: vi.fn().mockResolvedValue(undefined),
+      awaitChildResponse: vi.fn(),
+      getMode: vi.fn().mockReturnValue('async'),
+      getTimeoutMs: vi.fn(),
+      renderWorkerResponse: vi.fn(),
+      renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
+    } as unknown as ManageToolNode;
+
+    const tool = new ManageFunctionTool(persistence);
+    tool.init(manageNode, { persistence });
+
+    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+
+    const ctx = createCtx();
+    const result = await tool.execute(
+      { command: 'send_message', worker: 'Async Worker', message: 'hello async', threadAlias: undefined },
+      ctx,
+    );
+
+    expect(result).toBe('async acknowledgement');
+    await vi.waitFor(() => {
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Manage: async send_message failed {"worker":"Async Worker","childThreadId":"child-thread-async","error":"boom"}',
+      );
+    });
+  });
+
+  it('rethrows non-error rejections and logs safely', async () => {
+    const persistence = {
+      getOrCreateSubthreadByAlias: vi.fn().mockResolvedValue('child-thread-sync'),
+      setThreadChannelNode: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentsPersistenceService;
+
+    const workerInvoke = vi.fn().mockRejectedValue('boom');
+    const manageNode = {
+      nodeId: 'manage-node-sync',
+      listWorkers: vi.fn().mockReturnValue(['Fail Worker']),
+      getWorkerByTitle: vi.fn().mockReturnValue({ invoke: workerInvoke }),
+      registerInvocation: vi.fn().mockResolvedValue(undefined),
+      awaitChildResponse: vi.fn().mockResolvedValue('ignored'),
+      getMode: vi.fn().mockReturnValue('sync'),
+      getTimeoutMs: vi.fn().mockReturnValue(64000),
+      renderWorkerResponse: vi.fn(),
+      renderAsyncAcknowledgement: vi.fn(),
+    } as unknown as ManageToolNode;
+
+    const tool = new ManageFunctionTool(persistence);
+    tool.init(manageNode, { persistence });
+
+    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+
+    const ctx = createCtx();
+    await expect(
+      tool.execute({ command: 'send_message', worker: 'Fail Worker', message: 'fail', threadAlias: undefined }, ctx),
+    ).rejects.toBe('boom');
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Manage: send_message failed {"worker":"Fail Worker","childThreadId":"child-thread-sync","error":"boom"}',
+    );
+  });
 });

--- a/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
+++ b/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
@@ -60,6 +60,15 @@ export class ManageFunctionTool extends FunctionTool<typeof ManageInvocationSche
     return context ? ` ${JSON.stringify(context)}` : '';
   }
 
+  private extractMessage(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    if (err && typeof err === 'object' && 'message' in err) {
+      const value = (err as Record<string, unknown>).message;
+      if (typeof value === 'string') return value;
+    }
+    return String(err);
+  }
+
   private sanitizeAlias(raw: string | undefined): string {
     const normalized = (raw ?? '').toLowerCase();
     const withHyphen = normalized.replace(/\s+/g, '-');
@@ -124,14 +133,14 @@ export class ManageFunctionTool extends FunctionTool<typeof ManageInvocationSche
           return this.node.renderWorkerResponse(targetTitle, responseText);
         }
         invocationPromise!.catch((err) => {
-          const msg = err instanceof Error ? err.message : String(err);
+          const msg = this.extractMessage(err);
           this.logger.error(
             `Manage: async send_message failed${this.format({ worker: targetTitle, childThreadId, error: msg })}`,
           );
         });
         return this.node.renderAsyncAcknowledgement(targetTitle);
       } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
+        const msg = this.extractMessage(err);
         this.logger.error(
           `Manage: send_message failed${this.format({ worker: targetTitle, childThreadId, error: msg })}`,
         );

--- a/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
+++ b/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
@@ -56,6 +56,10 @@ export class ManageFunctionTool extends FunctionTool<typeof ManageInvocationSche
     return this.persistence ?? this.injectedPersistence;
   }
 
+  private format(context?: Record<string, unknown>): string {
+    return context ? ` ${JSON.stringify(context)}` : '';
+  }
+
   private sanitizeAlias(raw: string | undefined): string {
     const normalized = (raw ?? '').toLowerCase();
     const withHyphen = normalized.replace(/\s+/g, '-');
@@ -120,19 +124,17 @@ export class ManageFunctionTool extends FunctionTool<typeof ManageInvocationSche
           return this.node.renderWorkerResponse(targetTitle, responseText);
         }
         invocationPromise!.catch((err) => {
-          this.logger.error('Manage: async send_message failed', {
-            worker: targetTitle,
-            childThreadId,
-            error: (err as { message?: string })?.message || String(err),
-          });
+          const msg = err instanceof Error ? err.message : String(err);
+          this.logger.error(
+            `Manage: async send_message failed${this.format({ worker: targetTitle, childThreadId, error: msg })}`,
+          );
         });
         return this.node.renderAsyncAcknowledgement(targetTitle);
       } catch (err: unknown) {
-        this.logger.error('Manage: send_message failed', {
-          worker: targetTitle,
-          childThreadId,
-          error: (err as { message?: string })?.message || String(err),
-        });
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(
+          `Manage: send_message failed${this.format({ worker: targetTitle, childThreadId, error: msg })}`,
+        );
         if (mode !== 'sync' && invocationPromise) {
           invocationPromise.catch(() => {});
         }


### PR DESCRIPTION
## Summary
- add a dedicated formatter on `ManageFunctionTool` to stringify logger context safely
- update error logging to emit single-string messages with JSON context and safe message extraction
- extend manage tool tests to cover async and sync non-Error rejections without crashing the logger

## Testing
- pnpm --filter @agyn/platform-server lint
- pnpm --filter @agyn/platform-server test -- --runInBand --reporter=dot

Fixes #1113

## Reproduction Steps
1. `pnpm install`
2. `cd packages/platform-server`
3. Run tests that exercise the Manage tool error path, e.g.:
   - `pnpm test -t "ManageTool unit"`
   - or simulate a child agent that rejects/throws so the `send_message` catch path runs.
4. Observe `TypeError: Cannot read properties of undefined (reading 'error')` originating from the logger call.

## Acceptance Criteria
- Manage tool no longer throws `TypeError` in logger when child agent errors occur.
- Original child agent error is surfaced correctly to the caller.
- Tests covering rejection with both Error objects and non-Error values (e.g., strings/undefined) do not crash the logger.
- Logging is consistent with the rest of the codebase (string message + JSON context).
