### PR TITLE
feat: enforce assigned agent node usage

### DIFF
--- a/packages/platform-server/__tests__/agents.threads.controller.send-message.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.send-message.test.ts
@@ -18,7 +18,6 @@ const runEventsStub = {
 
 type SetupOptions = {
   thread?: { id: string; status: ThreadStatus; assignedAgentNodeId?: string | null } | null;
-  latestAgentNodeId?: string | null;
   nodes?: Array<{ id: string; template: string; instance: { status: string; invoke: ReturnType<typeof vi.fn> } }>;
   templateMeta?: Record<string, { kind: 'agent' | 'tool'; title: string }>;
 };
@@ -27,19 +26,17 @@ async function setup(options: SetupOptions = {}) {
   const invoke = vi.fn(async () => 'queued');
   const thread =
     options.thread === undefined
-      ? { id: 'thread-1', status: 'open' as ThreadStatus, assignedAgentNodeId: null }
+      ? { id: 'thread-1', status: 'open' as ThreadStatus, assignedAgentNodeId: 'agent-1' }
       : options.thread;
-  const latestAgentNodeId =
-    options.latestAgentNodeId === undefined ? (thread ? 'agent-1' : null) : options.latestAgentNodeId;
   const nodes =
     options.nodes === undefined
-      ? latestAgentNodeId
-        ? [{ id: latestAgentNodeId, template: 'agent', instance: { status: 'ready', invoke } }]
+      ? thread?.assignedAgentNodeId
+        ? [{ id: thread.assignedAgentNodeId, template: 'agent', instance: { status: 'ready', invoke } }]
         : []
       : options.nodes;
 
   const getThreadById = vi.fn(async () => thread);
-  const getLatestAgentNodeIdForThread = vi.fn(async () => latestAgentNodeId);
+  const getLatestAgentNodeIdForThread = vi.fn(async () => null);
   const ensureAssignedAgent = vi.fn(async () => {});
   const templateRegistryStub = {
     getMeta: (template: string) => options.templateMeta?.[template] ?? (template === 'agent' ? { kind: 'agent', title: 'Agent' } : undefined),
@@ -88,26 +85,13 @@ describe('AgentsThreadsController POST /api/agents/threads/:threadId/messages', 
     const result = await controller.sendThreadMessage('thread-1', { text: '  hello world  ' });
 
     expect(result).toEqual({ ok: true });
-    expect(getLatestAgentNodeIdForThread).toHaveBeenCalledWith('thread-1', { candidateNodeIds: ['agent-1'] });
-    expect(ensureAssignedAgent).toHaveBeenCalledWith('thread-1', 'agent-1');
+    expect(getLatestAgentNodeIdForThread).not.toHaveBeenCalled();
+    expect(ensureAssignedAgent).not.toHaveBeenCalled();
     expect(invoke).toHaveBeenCalledTimes(1);
     const args = invoke.mock.calls[0];
     expect(args[0]).toBe('thread-1');
     expect(Array.isArray(args[1])).toBe(true);
     expect(args[1][0]).toMatchObject({ text: 'hello world' });
-  });
-
-  it('uses assigned agent without falling back when available', async () => {
-    const { controller, invoke, getLatestAgentNodeIdForThread, ensureAssignedAgent } = await setup({
-      thread: { id: 'thread-1', status: 'open' as ThreadStatus, assignedAgentNodeId: 'agent-1' },
-      latestAgentNodeId: 'agent-1',
-    });
-
-    await controller.sendThreadMessage('thread-1', { text: 'hello' });
-
-    expect(getLatestAgentNodeIdForThread).not.toHaveBeenCalled();
-    expect(ensureAssignedAgent).not.toHaveBeenCalled();
-    expect(invoke).toHaveBeenCalledTimes(1);
   });
 
   it('rejects when message body is invalid', async () => {
@@ -139,7 +123,10 @@ describe('AgentsThreadsController POST /api/agents/threads/:threadId/messages', 
   });
 
   it('rejects when no agent node is available', async () => {
-    const { controller } = await setup({ latestAgentNodeId: null });
+    const { controller } = await setup({
+      thread: { id: 'thread-1', status: 'open' as ThreadStatus, assignedAgentNodeId: 'agent-1' },
+      nodes: [],
+    });
     expect.assertions(2);
     try {
       await controller.sendThreadMessage('thread-1', { text: 'hello' });
@@ -148,6 +135,14 @@ describe('AgentsThreadsController POST /api/agents/threads/:threadId/messages', 
       expect(error).toBeInstanceOf(ServiceUnavailableException);
       expect((error as ServiceUnavailableException).getResponse()).toEqual({ error: 'agent_unavailable' });
     }
+  });
+
+  it('rejects when thread is missing an assigned agent', async () => {
+    const { controller } = await setup({ thread: { id: 'thread-1', status: 'open' as ThreadStatus, assignedAgentNodeId: null } });
+    await expect(controller.sendThreadMessage('thread-1', { text: 'hello' })).rejects.toMatchObject({
+      status: 503,
+      response: { error: 'agent_unavailable' },
+    });
   });
 
   it('rejects when agent is not ready', async () => {
@@ -164,15 +159,15 @@ describe('AgentsThreadsController POST /api/agents/threads/:threadId/messages', 
   it('detects agent nodes registered under custom template names', async () => {
     const invoke = vi.fn(async () => 'queued');
     const { controller, getLatestAgentNodeIdForThread, ensureAssignedAgent } = await setup({
-      latestAgentNodeId: 'custom-agent-node',
+      thread: { id: 'thread-1', status: 'open' as ThreadStatus, assignedAgentNodeId: 'custom-agent-node' },
       nodes: [{ id: 'custom-agent-node', template: 'custom.agent', instance: { status: 'ready', invoke } }],
       templateMeta: { 'custom.agent': { kind: 'agent', title: 'Custom Agent' } },
     });
 
     await controller.sendThreadMessage('thread-1', { text: 'hello meta agent' });
 
-    expect(getLatestAgentNodeIdForThread).toHaveBeenCalledWith('thread-1', { candidateNodeIds: ['custom-agent-node'] });
-    expect(ensureAssignedAgent).toHaveBeenCalledWith('thread-1', 'custom-agent-node');
+    expect(getLatestAgentNodeIdForThread).not.toHaveBeenCalled();
+    expect(ensureAssignedAgent).not.toHaveBeenCalled();
     expect(invoke).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/platform-server/src/agents/threads.controller.ts
+++ b/packages/platform-server/src/agents/threads.controller.ts
@@ -470,18 +470,12 @@ export class AgentsThreadsController {
       throw new ServiceUnavailableException({ error: 'agent_unavailable' });
     }
 
-    let agentNodeId = thread.assignedAgentNodeId ?? null;
-    if (!agentNodeId) {
-      const candidateNodeIds = agentNodes.map((node) => node.id);
-      const fallbackAgentNodeId = await this.persistence.getLatestAgentNodeIdForThread(threadId, { candidateNodeIds });
-      if (!fallbackAgentNodeId) {
-        throw new ServiceUnavailableException({ error: 'agent_unavailable' });
-      }
-      agentNodeId = fallbackAgentNodeId;
-      await this.persistence.ensureAssignedAgent(threadId, agentNodeId);
+    const normalizedAgentNodeId = thread.assignedAgentNodeId?.trim();
+    if (!normalizedAgentNodeId) {
+      throw new ServiceUnavailableException({ error: 'agent_unavailable' });
     }
 
-    const liveAgentNode = agentNodes.find((node) => node.id === agentNodeId);
+    const liveAgentNode = agentNodes.find((node) => node.id === normalizedAgentNodeId);
     if (!liveAgentNode) {
       throw new ServiceUnavailableException({ error: 'agent_unavailable' });
     }
@@ -499,7 +493,7 @@ export class AgentsThreadsController {
       void invocation.catch((error) => {
         const stack = error instanceof Error ? error.stack : undefined;
         this.logger.error(
-          `sendThreadMessage invoke failed thread=${threadId} agent=${agentNodeId}`,
+          `sendThreadMessage invoke failed thread=${threadId} agent=${normalizedAgentNodeId}`,
           stack,
           AgentsThreadsController.name,
         );
@@ -507,7 +501,7 @@ export class AgentsThreadsController {
     } catch (error) {
       const stack = error instanceof Error ? error.stack : undefined;
       this.logger.error(
-        `sendThreadMessage immediate failure thread=${threadId} agent=${agentNodeId}`,
+        `sendThreadMessage immediate failure thread=${threadId} agent=${normalizedAgentNodeId}`,
         stack,
         AgentsThreadsController.name,
       );

--- a/packages/platform-server/tools/backfill-assigned-agent.ts
+++ b/packages/platform-server/tools/backfill-assigned-agent.ts
@@ -1,0 +1,207 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+
+type BackfillResult = {
+  assignedCount: number;
+  totalThreads: number;
+};
+
+type BackfillOptions = {
+  dryRun: boolean;
+  batchSize: number;
+};
+
+type CallAgentMetadata = {
+  childThreadId?: unknown;
+};
+
+const CALL_AGENT_TOOL_NAMES = ['call_agent', 'call_engineer'] as const;
+
+function parseBool(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'true') return true;
+  if (normalized === 'false') return false;
+  return fallback;
+}
+
+function parseNumber(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseMetadata(value: Prisma.JsonValue): CallAgentMetadata | null {
+  if (!isRecord(value)) return null;
+  return value as CallAgentMetadata;
+}
+
+async function buildCandidateAgentNodeSet(prisma: PrismaClient): Promise<Set<string>> {
+  const known = new Set<string>();
+
+  const assigned = await prisma.thread.findMany({
+    where: { assignedAgentNodeId: { not: null } },
+    select: { assignedAgentNodeId: true },
+  });
+  for (const row of assigned) {
+    const nodeId = row.assignedAgentNodeId;
+    if (typeof nodeId === 'string' && nodeId.trim().length > 0) {
+      known.add(nodeId.trim());
+    }
+  }
+
+  const toolEvents = await prisma.runEvent.findMany({
+    where: {
+      type: 'tool_execution',
+      toolExecution: { toolName: { in: CALL_AGENT_TOOL_NAMES } },
+      nodeId: { not: null },
+    },
+    select: { nodeId: true },
+    distinct: ['nodeId'],
+  });
+  for (const event of toolEvents) {
+    const nodeId = event.nodeId;
+    if (typeof nodeId === 'string' && nodeId.trim().length > 0) {
+      known.add(nodeId.trim());
+    }
+  }
+
+  return known;
+}
+
+async function backfillAssignedAgents(prisma: PrismaClient, options: BackfillOptions): Promise<BackfillResult> {
+  const candidates = await buildCandidateAgentNodeSet(prisma);
+
+  const pendingThreads = await prisma.thread.findMany({
+    where: { assignedAgentNodeId: null },
+    select: { id: true },
+  });
+
+  if (pendingThreads.length === 0) {
+    return { assignedCount: 0, totalThreads: 0 };
+  }
+
+  const allThreadIds = pendingThreads.map((row) => row.id);
+  const assignments = new Map<string, string>();
+
+  const conversationStates = await prisma.conversationState.findMany({
+    where:
+      candidates.size > 0
+        ? {
+            threadId: { in: allThreadIds },
+            nodeId: { in: Array.from(candidates) },
+          }
+        : {
+            threadId: { in: allThreadIds },
+          },
+    orderBy: { updatedAt: 'desc' },
+  });
+
+  for (const state of conversationStates) {
+    const threadId = state.threadId;
+    if (assignments.has(threadId)) continue;
+    const nodeId = state.nodeId;
+    if (typeof nodeId !== 'string') continue;
+    const normalized = nodeId.trim();
+    if (!normalized) continue;
+    if (candidates.size > 0 && !candidates.has(normalized)) continue;
+    assignments.set(threadId, normalized);
+  }
+
+  const unresolved = allThreadIds.filter((id) => !assignments.has(id));
+  await assignFromCallAgentLinking(prisma, unresolved, candidates, assignments);
+
+  if (assignments.size === 0) {
+    return { assignedCount: 0, totalThreads: allThreadIds.length };
+  }
+
+  const updates = Array.from(assignments.entries());
+  let applied = 0;
+  const batchSize = Math.max(1, options.batchSize);
+
+  for (let i = 0; i < updates.length; i += batchSize) {
+    const batch = updates.slice(i, i + batchSize);
+    if (options.dryRun) {
+      for (const [threadId, nodeId] of batch) {
+        console.info(`[dry-run] Would assign thread ${threadId} -> agent node ${nodeId}`);
+      }
+      applied += batch.length;
+      continue;
+    }
+
+    await prisma.$transaction(
+      batch.map(([threadId, nodeId]) =>
+        prisma.thread.update({ where: { id: threadId }, data: { assignedAgentNodeId: nodeId } }),
+      ),
+    );
+    applied += batch.length;
+  }
+
+  return { assignedCount: applied, totalThreads: allThreadIds.length };
+}
+
+async function assignFromCallAgentLinking(
+  prisma: PrismaClient,
+  unresolved: string[],
+  candidates: Set<string>,
+  assignments: Map<string, string>,
+): Promise<void> {
+  if (unresolved.length === 0) return;
+
+  const clauses = unresolved
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    .map((id) => ({ metadata: { path: ['childThreadId'], equals: id } }));
+
+  if (clauses.length === 0) return;
+
+  const linkEvents = await prisma.runEvent.findMany({
+    where: {
+      type: 'tool_execution',
+      toolExecution: { toolName: { in: CALL_AGENT_TOOL_NAMES } },
+      OR: clauses,
+    },
+    orderBy: { ts: 'desc' },
+    select: { metadata: true, nodeId: true },
+  });
+
+  for (const event of linkEvents) {
+    const nodeId = typeof event.nodeId === 'string' ? event.nodeId.trim() : '';
+    if (!nodeId) continue;
+    if (candidates.size > 0 && !candidates.has(nodeId)) continue;
+
+    const metadata = parseMetadata(event.metadata);
+    const threadId = metadata && typeof metadata.childThreadId === 'string' ? metadata.childThreadId : '';
+    if (!threadId || assignments.has(threadId)) continue;
+
+    assignments.set(threadId, nodeId);
+  }
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.AGENTS_DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('AGENTS_DATABASE_URL must be set');
+    process.exitCode = 1;
+    return;
+  }
+
+  const dryRun = parseBool(process.env.DRY_RUN, false) || process.argv.includes('--dry-run');
+  const batchSize = parseNumber(process.env.BACKFILL_BATCH_SIZE, 25);
+
+  const prisma = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
+
+  try {
+    const { assignedCount, totalThreads } = await backfillAssignedAgents(prisma, { dryRun, batchSize });
+    console.info(`Backfill complete. Threads evaluated: ${totalThreads}, assignments ${dryRun ? 'proposed' : 'applied'}: ${assignedCount}.`);
+  } catch (error) {
+    console.error('Backfill failed', error);
+    process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- require threads to have an assigned agent node before sending messages
- derive agent descriptors directly from assigned assignments
- add backfill utility to populate assigned nodes for legacy threads

## Testing
- pnpm --filter @agyn/platform-server lint
- pnpm --filter @agyn/platform-server exec vitest run --pool=threads --poolOptions.threads.maxThreads=1 --poolOptions.threads.minThreads=1 --reporter=json --outputFile=/tmp/server-tests.json

Closes #1117
