### PR TITLE
fix: send_message fallback and event cleanup

### DIFF
--- a/docs/tools/send_message.md
+++ b/docs/tools/send_message.md
@@ -14,9 +14,11 @@ Schema
 Behavior
 
 - Requires `ctx.threadId`. Uses `ThreadTransportService.sendTextToThread` to look up the persisted `channelNodeId` for the current thread and delegate delivery to the resolved node.
+- When a thread has no `channelNodeId` (e.g., created in the web UI without an ingress trigger), the transport falls back to persisting the assistant reply and returns success without invoking any external adapter.
 - The channel node must implement `sendToChannel(threadId, text)`; Manage, SlackTrigger, and any future channel adapters satisfy this interface.
-- Returns `message sent successfully` when the transport succeeds; otherwise returns the error string produced by the transport service (e.g. `missing_channel_node`, `channel_node_unavailable`, `unsupported_channel_node`, or adapter-specific failures).
+- Returns `message sent successfully` when the transport succeeds or when the persistence-only fallback is used; otherwise returns the error string produced by the transport service (e.g. `channel_node_unavailable`, `unsupported_channel_node`, or adapter-specific failures).
 - Validation: rejects missing thread context or empty `message` payload at the schema layer (min length 1).
+- Run events: tool executions triggered via `send_message` emit only the standard `tool_execution` events; no additional `invocation_message` event is appended.
 
 Notes
 

--- a/packages/platform-server/README.md
+++ b/packages/platform-server/README.md
@@ -106,6 +106,7 @@ Persistent conversation state (Prisma)
 
 Messaging (Slack-only v1)
 
-- `send_message` routes replies to Slack using `Thread.channel` (descriptor written by `SlackTrigger`).
+- `send_message` routes replies to Slack using `Thread.channel` (descriptor written by `SlackTrigger`) when a channel node is registered, and falls back to persisting the reply when no channel node exists (e.g., web-created threads).
+- Runs triggered via `send_message` emit only `tool_execution` run events; no additional `invocation_message` entry is created for the persisted transport message.
 - SlackTrigger requires bot_token in node config; token is resolved during provision; no global Slack config or tokens.
 - No other adapters are supported in v1; attachments/ephemeral not supported.

--- a/packages/platform-server/__tests__/messaging/threadTransport.service.spec.ts
+++ b/packages/platform-server/__tests__/messaging/threadTransport.service.spec.ts
@@ -85,4 +85,19 @@ describe('ThreadTransportService', () => {
       source: null,
     });
   });
+
+  it('persists locally when channel node missing', async () => {
+    threadFindUnique.mockResolvedValue(null);
+
+    const result = await service.sendTextToThread('thread-5', 'offline');
+
+    expect(result).toEqual({ ok: true, threadId: 'thread-5' });
+    expect(recordTransportAssistantMessage).toHaveBeenCalledWith({
+      threadId: 'thread-5',
+      text: 'offline',
+      runId: null,
+      source: null,
+    });
+    expect(getNodeInstance).not.toHaveBeenCalled();
+  });
 });

--- a/packages/platform-server/__tests__/messaging/threadTransport.service.spec.ts
+++ b/packages/platform-server/__tests__/messaging/threadTransport.service.spec.ts
@@ -87,7 +87,7 @@ describe('ThreadTransportService', () => {
   });
 
   it('persists locally when channel node missing', async () => {
-    threadFindUnique.mockResolvedValue(null);
+    threadFindUnique.mockResolvedValue({ id: 'thread-5', channelNodeId: null });
 
     const result = await service.sendTextToThread('thread-5', 'offline');
 
@@ -98,6 +98,16 @@ describe('ThreadTransportService', () => {
       runId: null,
       source: null,
     });
+    expect(getNodeInstance).not.toHaveBeenCalled();
+  });
+
+  it('returns missing_thread when thread not found', async () => {
+    threadFindUnique.mockResolvedValue(null);
+
+    const result = await service.sendTextToThread('thread-6', 'hello');
+
+    expect(result).toEqual({ ok: false, error: 'missing_thread' });
+    expect(recordTransportAssistantMessage).not.toHaveBeenCalled();
     expect(getNodeInstance).not.toHaveBeenCalled();
   });
 });

--- a/packages/platform-server/__tests__/tools.send_message.integration.test.ts
+++ b/packages/platform-server/__tests__/tools.send_message.integration.test.ts
@@ -35,15 +35,16 @@ vi.mock('@slack/web-api', () => {
 });
 
 describe('send_message tool', () => {
-  const makePrismaStub = (options: { channelNodeId?: string | null; channel?: unknown | null }) => {
+  const makePrismaStub = (options: { channelNodeId?: string | null; channel?: unknown | null; exists?: boolean }) => {
     const state = {
+      exists: options.exists === undefined ? true : options.exists,
       channelNodeId: options.channelNodeId === undefined ? 'channel-node' : options.channelNodeId,
       channel: options.channel === undefined ? null : options.channel,
     };
     const threadFindUnique = vi.fn(async ({ select }: { select: Record<string, boolean> }) => {
+      if (!state.exists) return null;
       if (select.channelNodeId) {
-        if (!state.channelNodeId) return null;
-        return { channelNodeId: state.channelNodeId };
+        return { channelNodeId: state.channelNodeId ?? null };
       }
       if (select.channel) {
         return { channel: state.channel };
@@ -114,6 +115,16 @@ describe('send_message tool', () => {
       runId: null,
       source: 'send_message',
     });
+  });
+
+  it('returns missing_thread when thread cannot be looked up', async () => {
+    const { prismaService } = makePrismaStub({ exists: false });
+    const runtime = makeRuntimeStub();
+    const { transport, persistence: transportPersistence } = makeTransport(prismaService, runtime);
+    const tool = new SendMessageFunctionTool(transport);
+    const res = await tool.execute({ message: 'hello' }, { threadId: 'missing-thread' } as any);
+    expect(res).toBe('missing_thread');
+    expect(transportPersistence.recordTransportAssistantMessage).not.toHaveBeenCalled();
   });
 
   it('returns error when runtime instance missing', async () => {

--- a/packages/platform-server/__tests__/tools.send_message.integration.test.ts
+++ b/packages/platform-server/__tests__/tools.send_message.integration.test.ts
@@ -101,14 +101,19 @@ describe('send_message tool', () => {
     return { trigger, slackSend };
   };
 
-  it('returns error when thread channel mapping missing', async () => {
+  it('persists message when thread has no channel node', async () => {
     const { prismaService } = makePrismaStub({ channelNodeId: null });
     const runtime = makeRuntimeStub();
     const { transport, persistence: transportPersistence } = makeTransport(prismaService, runtime);
     const tool = new SendMessageFunctionTool(transport);
     const res = await tool.execute({ message: 'hello' }, { threadId: 't1' } as any);
-    expect(res).toBe('missing_channel_node');
-    expect(transportPersistence.recordTransportAssistantMessage).not.toHaveBeenCalled();
+    expect(res).toBe('message sent successfully');
+    expect(transportPersistence.recordTransportAssistantMessage).toHaveBeenCalledWith({
+      threadId: 't1',
+      text: 'hello',
+      runId: null,
+      source: 'send_message',
+    });
   });
 
   it('returns error when runtime instance missing', async () => {

--- a/packages/platform-server/src/messaging/threadTransport.service.ts
+++ b/packages/platform-server/src/messaging/threadTransport.service.ts
@@ -38,8 +38,12 @@ export class ThreadTransportService {
     }
 
     const prisma = this.prismaService.getClient();
-    const thread = await prisma.thread.findUnique({ where: { id: normalizedThreadId }, select: { channelNodeId: true } });
-    const channelNodeId = thread?.channelNodeId ?? null;
+    const thread = await prisma.thread.findUnique({ where: { id: normalizedThreadId }, select: { id: true, channelNodeId: true } });
+    if (!thread) {
+      return { ok: false, error: 'missing_thread' };
+    }
+
+    const channelNodeId = thread.channelNodeId ?? null;
     const runId = options?.runId ?? null;
     const source = options?.source ?? null;
 

--- a/packages/platform-server/src/messaging/threadTransport.service.ts
+++ b/packages/platform-server/src/messaging/threadTransport.service.ts
@@ -40,8 +40,26 @@ export class ThreadTransportService {
     const prisma = this.prismaService.getClient();
     const thread = await prisma.thread.findUnique({ where: { id: normalizedThreadId }, select: { channelNodeId: true } });
     const channelNodeId = thread?.channelNodeId ?? null;
+    const runId = options?.runId ?? null;
+    const source = options?.source ?? null;
+
     if (!channelNodeId) {
-      return { ok: false, error: 'missing_channel_node' };
+      try {
+        await this.persistence.recordTransportAssistantMessage({
+          threadId: normalizedThreadId,
+          text,
+          runId,
+          source,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.error(
+          `ThreadTransportService: failed to persist assistant message${this.format({ threadId: normalizedThreadId, channelNodeId: null, error: message })}`,
+        );
+        return { ok: false, error: 'persist_failed', threadId: normalizedThreadId };
+      }
+
+      return { ok: true, threadId: normalizedThreadId };
     }
 
     const node = this.runtime.getNodeInstance(channelNodeId);
@@ -69,8 +87,8 @@ export class ThreadTransportService {
         await this.persistence.recordTransportAssistantMessage({
           threadId: normalizedThreadId,
           text,
-          runId: options?.runId ?? null,
-          source: options?.source ?? null,
+          runId,
+          source,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- add a persistence-only fallback in `ThreadTransportService` when a thread has no `channelNodeId`
- avoid creating `invocation_message` run events for `send_message` sources
- update tests and docs to cover the fallback behavior and run-event expectations

## Testing
- `pnpm -C packages/platform-server lint`
- `pnpm -C packages/platform-server test -- --runInBand --reporter=dot --silent`

Resolves #1124.
