### PR TITLE
feat: preload depth-2 thread trees

### DIFF
--- a/packages/platform-server/__tests__/agents.threads.tree.spec.ts
+++ b/packages/platform-server/__tests__/agents.threads.tree.spec.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
+import { StubPrismaService, createPrismaStub } from './helpers/prisma.stub';
+import { createRunEventsStub } from './helpers/runEvents.stub';
+import { createEventsBusStub } from './helpers/eventsBus.stub';
+import { CallAgentLinkingService } from '../src/agents/call-agent-linking.service';
+
+const metricsStub = { getThreadsMetrics: async () => ({}) } as any;
+const templateRegistryStub = { toSchema: async () => [], getMeta: () => undefined } as any;
+const graphRepoStub = {
+  get: async () => ({ name: 'main', version: 1, updatedAt: new Date().toISOString(), nodes: [], edges: [] }),
+} as any;
+
+const createLinkingStub = () =>
+  ({
+    buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
+      tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+      parentThreadId: params.parentThreadId,
+      childThreadId: params.childThreadId,
+      childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },
+      childRunId: null,
+      childRunStatus: 'queued',
+      childRunLinkEnabled: false,
+      childMessageId: null,
+    }),
+    registerParentToolExecution: async () => null,
+    onChildRunStarted: async () => null,
+    onChildRunMessage: async () => null,
+    onChildRunCompleted: async () => null,
+    resolveLinkedAgentNodes: async () => ({}),
+  }) as unknown as CallAgentLinkingService;
+
+function createService() {
+  const prismaStub = createPrismaStub();
+  const svc = new AgentsPersistenceService(
+    new StubPrismaService(prismaStub) as any,
+    metricsStub,
+    templateRegistryStub,
+    graphRepoStub,
+    createRunEventsStub() as any,
+    createLinkingStub(),
+    createEventsBusStub(),
+  );
+  return { prismaStub, svc };
+}
+
+function makeMetrics(ids: string[]): Record<string, { remindersCount: number; containersCount: number; activity: 'working' | 'waiting' | 'idle'; runsCount: number }> {
+  const out: Record<string, { remindersCount: number; containersCount: number; activity: 'working' | 'waiting' | 'idle'; runsCount: number }> = {};
+  for (const id of ids) {
+    const numeric = Number(id.split('-')[1] ?? '0');
+    const activity = numeric % 3 === 0 ? 'working' : numeric % 3 === 1 ? 'waiting' : 'idle';
+    out[id] = { remindersCount: numeric, containersCount: numeric + 1, activity, runsCount: numeric + 2 };
+  }
+  return out;
+}
+
+function makeDescriptors(ids: string[]): Record<string, { title: string; role?: string; name?: string }> {
+  const out: Record<string, { title: string; role?: string; name?: string }> = {};
+  for (const id of ids) {
+    out[id] = { title: `Agent ${id}`, role: `Role ${id}`, name: `Name ${id}` };
+  }
+  return out;
+}
+
+describe('AgentsPersistenceService.listThreadsTree', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns nested roots, children, and grandchildren with metrics and descriptors', async () => {
+    const { prismaStub, svc } = createService();
+
+    const rootA = await prismaStub.thread.create({ data: { alias: 'root-a', parentId: null, summary: 'Root A', status: 'open' } });
+    const rootB = await prismaStub.thread.create({ data: { alias: 'root-b', parentId: null, summary: 'Root B', status: 'open' } });
+
+    const childA1 = await prismaStub.thread.create({ data: { alias: 'child-a1', parentId: rootA.id, summary: 'Child A1', status: 'open' } });
+    const childA2 = await prismaStub.thread.create({ data: { alias: 'child-a2', parentId: rootA.id, summary: 'Child A2', status: 'open' } });
+    const childB1 = await prismaStub.thread.create({ data: { alias: 'child-b1', parentId: rootB.id, summary: 'Child B1', status: 'closed' } });
+
+    const grandA1 = await prismaStub.thread.create({ data: { alias: 'grand-a1', parentId: childA1.id, summary: 'Grand A1', status: 'open' } });
+    const grandA2 = await prismaStub.thread.create({ data: { alias: 'grand-a2', parentId: childA1.id, summary: 'Grand A2', status: 'closed' } });
+    const grandA3 = await prismaStub.thread.create({ data: { alias: 'grand-a3', parentId: childA2.id, summary: 'Grand A3', status: 'open' } });
+    await prismaStub.thread.create({ data: { alias: 'great-a1', parentId: grandA1.id, summary: 'Great A1', status: 'open' } });
+
+    vi.spyOn(svc, 'getThreadsMetrics').mockImplementation(async (ids: string[]) => makeMetrics(ids));
+    vi.spyOn(svc as any, 'getThreadsAgentDescriptors').mockImplementation(async (ids: string[]) => makeDescriptors(ids));
+
+    const result = await svc.listThreadsTree({
+      status: 'all',
+      limit: 10,
+      depth: 2,
+      includeMetrics: true,
+      includeAgentTitles: true,
+      childrenStatus: 'all',
+      perParentChildrenLimit: 10,
+    });
+
+    expect(result.map((node) => node.id)).toEqual([rootB.id, rootA.id]);
+
+    const latestRoot = result[0];
+    expect(latestRoot.id).toBe(rootB.id);
+    expect(latestRoot.children?.map((child) => child.id)).toEqual([childB1.id]);
+    expect(latestRoot.hasChildren).toBe(true);
+    expect(latestRoot.metrics).toMatchObject(makeMetrics([rootB.id])[rootB.id]);
+    expect(latestRoot.agentTitle).toBe(`Agent ${rootB.id}`);
+    expect(latestRoot.agentRole).toBe(`Role ${rootB.id}`);
+    expect(latestRoot.agentName).toBe(`Name ${rootB.id}`);
+
+    const root = result[1];
+    expect(root.children?.map((child) => child.id)).toEqual([childA2.id, childA1.id]);
+    expect(root.hasChildren).toBe(true);
+    expect(root.metrics).toMatchObject(makeMetrics([rootA.id])[rootA.id]);
+    const child1 = root.children?.find((child) => child.id === childA1.id);
+    const child2 = root.children?.find((child) => child.id === childA2.id);
+    expect(child2?.children?.map((grand) => grand.id)).toEqual([grandA3.id]);
+    expect(child2?.hasChildren).toBe(true);
+    expect(child2?.metrics).toMatchObject(makeMetrics([childA2.id])[childA2.id]);
+    expect(child2?.agentTitle).toBe(`Agent ${childA2.id}`);
+
+    expect(child1?.children?.map((grand) => grand.id)).toEqual([grandA2.id, grandA1.id]);
+    expect(child1?.hasChildren).toBe(true);
+    const grand1 = child1?.children?.find((grand) => grand.id === grandA1.id);
+    const grand2 = child1?.children?.find((grand) => grand.id === grandA2.id);
+    expect(grand1?.hasChildren).toBe(true);
+    expect(grand1?.children).toBeUndefined();
+    expect(grand2?.hasChildren).toBe(false);
+    expect(grand1?.metrics).toMatchObject(makeMetrics([grandA1.id])[grandA1.id]);
+    expect(grand1?.agentTitle).toBe(`Agent ${grandA1.id}`);
+    expect(grand2?.agentTitle).toBe(`Agent ${grandA2.id}`);
+  });
+
+  it('respects depth and children status filters', async () => {
+    const { prismaStub, svc } = createService();
+
+    const root = await prismaStub.thread.create({ data: { alias: 'root', parentId: null, summary: 'Root', status: 'open' } });
+    const openChild1 = await prismaStub.thread.create({ data: { alias: 'open-1', parentId: root.id, summary: 'Open 1', status: 'open' } });
+    const openChild2 = await prismaStub.thread.create({ data: { alias: 'open-2', parentId: root.id, summary: 'Open 2', status: 'open' } });
+    const closedChild = await prismaStub.thread.create({ data: { alias: 'closed-1', parentId: root.id, summary: 'Closed', status: 'closed' } });
+
+    vi.spyOn(svc, 'getThreadsMetrics').mockImplementation(async () => ({}));
+    vi.spyOn(svc as any, 'getThreadsAgentDescriptors').mockImplementation(async (ids: string[]) => makeDescriptors(ids));
+
+    const openOnly = await svc.listThreadsTree({
+      status: 'all',
+      limit: 5,
+      depth: 1,
+      includeMetrics: false,
+      includeAgentTitles: false,
+      childrenStatus: 'open',
+      perParentChildrenLimit: 1,
+    });
+
+    expect(openOnly).toHaveLength(1);
+    const rootNode = openOnly[0];
+    expect(rootNode.children?.length).toBe(1);
+    expect(rootNode.children?.[0]?.id).toBe(openChild2.id);
+    expect(rootNode.hasChildren).toBe(true);
+    expect(rootNode.children?.[0]?.hasChildren).toBe(false);
+    expect(rootNode.children?.[0]?.agentTitle).toBeUndefined();
+    expect(rootNode.children?.[0]?.agentRole).toBe(`Role ${openChild2.id}`);
+    expect(rootNode.children?.[0]?.agentName).toBe(`Name ${openChild2.id}`);
+
+    const closedOnly = await svc.listThreadsTree({
+      status: 'all',
+      limit: 5,
+      depth: 1,
+      includeMetrics: false,
+      includeAgentTitles: true,
+      childrenStatus: 'closed',
+      perParentChildrenLimit: 5,
+    });
+
+    expect(closedOnly[0].children?.map((child) => child.id)).toEqual([closedChild.id]);
+    expect(closedOnly[0].hasChildren).toBe(true);
+
+    const none = await svc.listThreadsTree({
+      status: 'all',
+      limit: 5,
+      depth: 0,
+      includeMetrics: false,
+      includeAgentTitles: false,
+      childrenStatus: 'closed',
+      perParentChildrenLimit: 5,
+    });
+
+    expect(none[0].children).toBeUndefined();
+    expect(none[0].hasChildren).toBe(true);
+  });
+});

--- a/packages/platform-ui/__tests__/AgentsThreads.cache.integration.test.tsx
+++ b/packages/platform-ui/__tests__/AgentsThreads.cache.integration.test.tsx
@@ -112,6 +112,7 @@ function registerThreadHandlers(threads: ThreadDescriptor[], options?: { message
   }));
 
   const threadById = new Map(threadList.map((item) => [item.id, item]));
+  const treeItems = threadList.map((item) => ({ ...item, children: [], hasChildren: false }));
   const runMetaByThread = new Map(
     threads.map((thread) => [thread.id, { id: thread.runId, threadId: thread.id, status: 'finished', createdAt: thread.createdAt, updatedAt: thread.createdAt }]),
   );
@@ -138,6 +139,14 @@ function registerThreadHandlers(threads: ThreadDescriptor[], options?: { message
     http.get(abs('/api/agents/threads'), ({ request }) => {
       listRequestLog.push(request.url);
       return HttpResponse.json({ items: threadList });
+    }),
+    http.get('/api/agents/threads/tree', ({ request }) => {
+      listRequestLog.push(request.url);
+      return HttpResponse.json({ items: treeItems });
+    }),
+    http.get(abs('/api/agents/threads/tree'), ({ request }) => {
+      listRequestLog.push(request.url);
+      return HttpResponse.json({ items: treeItems });
     }),
     http.get('/api/agents/threads/:threadId', ({ params }) => HttpResponse.json(threadById.get(params.threadId as string) ?? threadList[0])),
     http.get(abs('/api/agents/threads/:threadId'), ({ params }) => HttpResponse.json(threadById.get(params.threadId as string) ?? threadList[0])),

--- a/packages/platform-ui/__tests__/AgentsThreads.placeholder.test.tsx
+++ b/packages/platform-ui/__tests__/AgentsThreads.placeholder.test.tsx
@@ -16,12 +16,20 @@ describe('AgentsThreads placeholder for missing summary', () => {
   afterAll(() => server.close());
 
   it('renders (no summary yet) when summary is null', async () => {
+    const thread = { id: 'th1', alias: 'ignored-alias', summary: null, createdAt: t(0), metrics: { runsCount: 0 } };
     server.use(
-      http.get('/api/agents/threads', () =>
-        HttpResponse.json({ items: [{ id: 'th1', alias: 'ignored-alias', summary: null, createdAt: t(0) }] }),
-      ),
-      http.get(abs('/api/agents/threads'), () =>
-        HttpResponse.json({ items: [{ id: 'th1', alias: 'ignored-alias', summary: null, createdAt: t(0) }] }),
+      http.get('/api/agents/threads', () => HttpResponse.json({ items: [thread] })),
+      http.get(abs('/api/agents/threads'), () => HttpResponse.json({ items: [thread] })),
+      http.get('*/api/agents/threads/tree', () =>
+        HttpResponse.json({
+          items: [
+            {
+              ...thread,
+              hasChildren: false,
+              children: [],
+            },
+          ],
+        }),
       ),
     );
     render(

--- a/packages/platform-ui/__tests__/AgentsThreads.realtime.test.tsx
+++ b/packages/platform-ui/__tests__/AgentsThreads.realtime.test.tsx
@@ -26,10 +26,23 @@ describe('AgentsThreads realtime updates', () => {
     const threadsHandler = () => HttpResponse.json({ items: [thread] });
     const runsHandler = () => HttpResponse.json({ items: runs });
     const messagesHandler = () => HttpResponse.json({ items: [] });
+    const treeHandler = () =>
+      HttpResponse.json({
+        items: [
+          {
+            ...thread,
+            metrics: { remindersCount: 0, containersCount: 0, activity: 'idle', runsCount: runs.length },
+            hasChildren: false,
+            children: [],
+          },
+        ],
+      });
 
     server.use(
       http.get('/api/agents/threads', threadsHandler),
       http.get(abs('/api/agents/threads'), threadsHandler),
+      http.get('/api/agents/threads/tree', treeHandler),
+      http.get(abs('/api/agents/threads/tree'), treeHandler),
       http.get('/api/agents/threads/th1', () => HttpResponse.json({ ...thread, parentId: null, metrics: { remindersCount: 0, containersCount: 0, activity: 'idle', runsCount: runs.length } })),
       http.get(abs('/api/agents/threads/th1'), () => HttpResponse.json({ ...thread, parentId: null, metrics: { remindersCount: 0, containersCount: 0, activity: 'idle', runsCount: runs.length } })),
       http.get('/api/agents/threads/th1/runs', runsHandler),

--- a/packages/platform-ui/__tests__/ThreadsScreen.toggle.test.tsx
+++ b/packages/platform-ui/__tests__/ThreadsScreen.toggle.test.tsx
@@ -147,6 +147,9 @@ describe('AgentsThreads status toggle integration', () => {
     let serverStatus: 'open' | 'closed' = 'open';
     let patchCalls = 0;
     let rootsRequestCount = 0;
+    const recordRootFetch = () => {
+      rootsRequestCount += 1;
+    };
 
     const threadNode = () => ({
       id: 'th1',
@@ -160,7 +163,7 @@ describe('AgentsThreads status toggle integration', () => {
     });
 
     const respondWithThreads = () => {
-      rootsRequestCount += 1;
+      recordRootFetch();
       return HttpResponse.json({ items: [threadNode()] });
     };
 
@@ -177,9 +180,24 @@ describe('AgentsThreads status toggle integration', () => {
       return new HttpResponse(null, { status: 204 });
     };
 
+    const treeHandler = () => {
+      recordRootFetch();
+      return HttpResponse.json({
+        items: [
+          {
+            ...threadNode(),
+            hasChildren: false,
+            children: [],
+          },
+        ],
+      });
+    };
+
     server.use(
       http.get('/api/agents/threads', respondWithThreads),
       http.get(abs('/api/agents/threads'), respondWithThreads),
+      http.get('/api/agents/threads/tree', treeHandler),
+      http.get(abs('/api/agents/threads/tree'), treeHandler),
       http.get('/api/agents/threads/th1', () => HttpResponse.json(threadNode())),
       http.get(abs('/api/agents/threads/th1'), () => HttpResponse.json(threadNode())),
       http.get('/api/agents/threads/th1/children', () => HttpResponse.json({ items: [] })),

--- a/packages/platform-ui/src/api/modules/threads.ts
+++ b/packages/platform-ui/src/api/modules/threads.ts
@@ -9,11 +9,29 @@ const clampTake = (value: number | undefined, fallback = 200) => {
   return Math.min(1000, Math.max(1, coerced));
 };
 
+export type ThreadTreeItem = ThreadNode & {
+  children?: ThreadTreeItem[];
+  hasChildren?: boolean;
+};
+
 export const threads = {
   roots: (status: 'open' | 'closed' | 'all' = 'open', limit = 100) =>
     asData<{ items: ThreadNode[] }>(
       http.get<{ items: ThreadNode[] }>(`/api/agents/threads`, {
         params: { rootsOnly: true, status, limit, includeMetrics: true, includeAgentTitles: true },
+      }),
+    ),
+  treeRoots: (status: 'open' | 'closed' | 'all' = 'open', limit = 100, depth = 2) =>
+    asData<{ items: ThreadTreeItem[] }>(
+      http.get<{ items: ThreadTreeItem[] }>(`/api/agents/threads/tree`, {
+        params: {
+          status,
+          limit,
+          depth,
+          includeMetrics: true,
+          includeAgentTitles: true,
+          childrenStatus: status,
+        },
       }),
     ),
   children: (id: string, status: 'open' | 'closed' | 'all' = 'open') =>

--- a/packages/platform-ui/src/pages/__tests__/AgentsThreads.tree.spec.tsx
+++ b/packages/platform-ui/src/pages/__tests__/AgentsThreads.tree.spec.tsx
@@ -1,0 +1,459 @@
+import React from 'react';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AgentsThreads } from '../AgentsThreads';
+import { TestProviders, server, abs } from '../../../__tests__/integration/testUtils';
+
+type ThreadMock = {
+  id: string;
+  alias: string;
+  summary: string;
+  status: 'open' | 'closed';
+  createdAt: string;
+  parentId: string | null;
+  metrics: { remindersCount: number; containersCount: number; activity: 'idle' | 'waiting' | 'working'; runsCount: number };
+  agentTitle?: string | null;
+  agentRole?: string | null;
+  agentName?: string | null;
+  children?: ThreadMock[];
+  hasChildren?: boolean;
+};
+
+const BASE_TIME = 1700000000000;
+
+const originalIntersectionObserver = globalThis.IntersectionObserver;
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  private callback: IntersectionObserverCallback;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  trigger(entries: Partial<IntersectionObserverEntry>[] = [{ isIntersecting: true }]) {
+    const normalized = entries.map((entry) =>
+      ({
+        time: 0,
+        target: document.body,
+        isIntersecting: true,
+        intersectionRatio: 1,
+        boundingClientRect: {} as DOMRectReadOnly,
+        intersectionRect: {} as DOMRectReadOnly,
+        rootBounds: null,
+        ...entry,
+      }) as IntersectionObserverEntry,
+    );
+    this.callback(normalized, this as unknown as IntersectionObserver);
+  }
+
+  static reset() {
+    MockIntersectionObserver.instances.length = 0;
+  }
+}
+
+function t(offset: number): string {
+  return new Date(BASE_TIME + offset).toISOString();
+}
+
+function makeThread(overrides: Partial<ThreadMock> = {}): ThreadMock {
+  return {
+    id: 'thread-1',
+    alias: 'alias-1',
+    summary: 'Thread',
+    status: 'open',
+    createdAt: t(0),
+    parentId: null,
+    metrics: { remindersCount: 0, containersCount: 0, activity: 'idle', runsCount: 0 },
+    agentTitle: 'Agent',
+    agentRole: 'Role',
+    agentName: 'Agent Name',
+    children: undefined,
+    hasChildren: undefined,
+    ...overrides,
+  };
+}
+
+function buildTreeResponse(threads: ThreadMock[]): { items: ThreadMock[] } {
+  return {
+    items: threads.map((thread) => ({
+      ...thread,
+      children: thread.children?.map((child) => ({ ...child })),
+    })),
+  };
+}
+
+function renderAt(path: string) {
+  return render(
+    <TestProviders>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/agents/threads">
+            <Route index element={<AgentsThreads />} />
+            <Route path=":threadId" element={<AgentsThreads />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </TestProviders>,
+  );
+}
+
+describe('AgentsThreads tree preload', () => {
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'error' });
+    (globalThis as typeof globalThis & { IntersectionObserver: typeof MockIntersectionObserver }).IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+    if (typeof window !== 'undefined') {
+      (window as typeof window & { IntersectionObserver: typeof MockIntersectionObserver }).IntersectionObserver =
+        MockIntersectionObserver as unknown as typeof IntersectionObserver;
+    }
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    vi.clearAllMocks();
+    MockIntersectionObserver.reset();
+  });
+
+  afterAll(() => {
+    server.close();
+    if (originalIntersectionObserver) {
+      globalThis.IntersectionObserver = originalIntersectionObserver;
+      if (typeof window !== 'undefined') {
+        window.IntersectionObserver = originalIntersectionObserver;
+      }
+    } else {
+      delete (globalThis as Partial<typeof globalThis>).IntersectionObserver;
+      if (typeof window !== 'undefined') {
+        delete (window as Partial<typeof window>).IntersectionObserver;
+      }
+    }
+  });
+
+  it('preloads root and first-level children from tree response', async () => {
+    const root = makeThread({ id: 'root-1', summary: 'Root Thread' });
+    const child = makeThread({ id: 'child-1', parentId: root.id, summary: 'Child Thread', createdAt: t(10) });
+    const grandchild = makeThread({ id: 'grand-1', parentId: child.id, summary: 'Grandchild Thread', createdAt: t(20) });
+
+    let childrenRequests = 0;
+
+    server.use(
+      http.get('*/api/agents/threads/tree', () =>
+        HttpResponse.json(
+          buildTreeResponse([
+            {
+              ...root,
+              hasChildren: true,
+              children: [
+                {
+                  ...child,
+                  hasChildren: true,
+                  children: [
+                    {
+                      ...grandchild,
+                      hasChildren: false,
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ]),
+        ),
+      ),
+      http.get(abs('/api/agents/threads/tree'), () =>
+        HttpResponse.json(
+          buildTreeResponse([
+            {
+              ...root,
+              hasChildren: true,
+              children: [
+                {
+                  ...child,
+                  hasChildren: true,
+                  children: [
+                    {
+                      ...grandchild,
+                      hasChildren: false,
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ]),
+        ),
+      ),
+      http.get('*/api/agents/threads', () => HttpResponse.json({ items: [root] })),
+      http.get(abs('/api/agents/threads'), () => HttpResponse.json({ items: [root] })),
+      http.get('*/api/agents/threads/:threadId', () => HttpResponse.json(root)),
+      http.get(abs('/api/agents/threads/:threadId'), () => HttpResponse.json(root)),
+      http.get('*/api/agents/threads/:threadId/children', () => {
+        childrenRequests += 1;
+        return HttpResponse.json({ items: [] });
+      }),
+      http.get(abs('/api/agents/threads/:threadId/children'), () => {
+        childrenRequests += 1;
+        return HttpResponse.json({ items: [] });
+      }),
+      http.get('*/api/agents/threads/:threadId/runs', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/agents/threads/:threadId/runs'), () => HttpResponse.json({ items: [] })),
+      http.get('*/api/agents/reminders', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/agents/reminders'), () => HttpResponse.json({ items: [] })),
+      http.options('*/api/agents/reminders', () => new HttpResponse(null, { status: 200 })),
+      http.options(abs('/api/agents/reminders'), () => new HttpResponse(null, { status: 200 })),
+      http.get('*/api/containers', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/containers'), () => HttpResponse.json({ items: [] })),
+      http.options('*/api/containers', () => new HttpResponse(null, { status: 200 })),
+      http.options(abs('/api/containers'), () => new HttpResponse(null, { status: 200 })),
+      http.options('*/api/containers', () => new HttpResponse(null, { status: 200 })),
+      http.options(abs('/api/containers'), () => new HttpResponse(null, { status: 200 })),
+      http.options('*/api/containers', () => new HttpResponse(null, { status: 200 })),
+      http.options(abs('/api/containers'), () => new HttpResponse(null, { status: 200 })),
+    );
+
+    const user = userEvent.setup();
+    renderAt('/agents/threads');
+
+    const rootToggle = await screen.findByRole('button', { name: /Show 1 subthread/i });
+    await user.click(rootToggle);
+    expect(await screen.findByText('Child Thread')).toBeInTheDocument();
+    expect(childrenRequests).toBe(0);
+
+    const childToggle = await screen.findByRole('button', { name: /Show 1 subthread/i });
+    await user.click(childToggle);
+    expect(await screen.findByText('Grandchild Thread')).toBeInTheDocument();
+    expect(childrenRequests).toBe(0);
+  });
+
+  it('fetches when expanding beyond preloaded depth', async () => {
+    const root = makeThread({ id: 'root-1', summary: 'Root Thread' });
+    const child = makeThread({ id: 'child-1', parentId: root.id, summary: 'Child Thread', createdAt: t(10) });
+    const grandchild = makeThread({ id: 'grand-1', parentId: child.id, summary: 'Grandchild Thread', createdAt: t(20), hasChildren: true });
+    const greatGrandchild = makeThread({ id: 'great-1', parentId: grandchild.id, summary: 'Great Grandchild', createdAt: t(30) });
+
+    let childrenRequests = 0;
+
+    server.use(
+      http.get('*/api/agents/threads/tree', () =>
+        HttpResponse.json(
+          buildTreeResponse([
+            {
+              ...root,
+              hasChildren: true,
+              children: [
+                {
+                  ...child,
+                  hasChildren: true,
+                  children: [
+                    {
+                      ...grandchild,
+                      hasChildren: true,
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ]),
+        ),
+      ),
+      http.get(abs('/api/agents/threads/tree'), () =>
+        HttpResponse.json(
+          buildTreeResponse([
+            {
+              ...root,
+              hasChildren: true,
+              children: [
+                {
+                  ...child,
+                  hasChildren: true,
+                  children: [
+                    {
+                      ...grandchild,
+                      hasChildren: true,
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ]),
+        ),
+      ),
+      http.get('*/api/agents/threads', () => HttpResponse.json({ items: [root] })),
+      http.get(abs('/api/agents/threads'), () => HttpResponse.json({ items: [root] })),
+      http.get('*/api/agents/threads/:threadId', () => HttpResponse.json(root)),
+      http.get(abs('/api/agents/threads/:threadId'), () => HttpResponse.json(root)),
+      http.get('*/api/agents/threads/:threadId/children', ({ params }) => {
+        childrenRequests += 1;
+        if (params.threadId === grandchild.id) {
+          return HttpResponse.json({ items: [greatGrandchild] });
+        }
+        return HttpResponse.json({ items: [] });
+      }),
+      http.get(abs('/api/agents/threads/:threadId/children'), ({ params }) => {
+        childrenRequests += 1;
+        if (params.threadId === grandchild.id) {
+          return HttpResponse.json({ items: [greatGrandchild] });
+        }
+        return HttpResponse.json({ items: [] });
+      }),
+      http.get('*/api/agents/threads/:threadId/runs', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/agents/threads/:threadId/runs'), () => HttpResponse.json({ items: [] })),
+      http.get('*/api/agents/reminders', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/agents/reminders'), () => HttpResponse.json({ items: [] })),
+      http.options('*/api/agents/reminders', () => new HttpResponse(null, { status: 200 })),
+      http.options(abs('/api/agents/reminders'), () => new HttpResponse(null, { status: 200 })),
+      http.get('*/api/containers', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/containers'), () => HttpResponse.json({ items: [] })),
+    );
+
+    const user = userEvent.setup();
+    renderAt('/agents/threads');
+
+    const rootToggle = await screen.findByRole('button', { name: /Show 1 subthread/i });
+    await user.click(rootToggle);
+    const childToggle = await screen.findByRole('button', { name: /Show 1 subthread/i });
+    await user.click(childToggle);
+    expect(await screen.findByText('Grandchild Thread')).toBeInTheDocument();
+    expect(childrenRequests).toBe(0);
+
+    const grandchildToggle = await screen.findByRole('button', { name: 'Show subthreads' });
+    await user.click(grandchildToggle);
+
+    await waitFor(() => expect(screen.getByText('Great Grandchild')).toBeInTheDocument());
+    expect(childrenRequests).toBeGreaterThanOrEqual(1);
+  });
+
+  it('merges children state when pagination extends the tree', async () => {
+    const primaryRoot = makeThread({ id: 'root-primary', summary: 'Primary Root', createdAt: t(0) });
+    const primaryChild = makeThread({ id: 'child-primary', parentId: primaryRoot.id, summary: 'Primary Child', createdAt: t(10) });
+    const extraRoots = Array.from({ length: 49 }).map((_, index) =>
+      makeThread({ id: `root-${index}`, summary: `Root ${index}`, createdAt: t(100 + index * 10) }),
+    );
+    const pageOneItems: ThreadMock[] = [
+      {
+        ...primaryRoot,
+        hasChildren: true,
+        children: [
+          {
+            ...primaryChild,
+            hasChildren: false,
+            children: [],
+          },
+        ],
+      },
+      ...extraRoots.map((thread) => ({ ...thread, hasChildren: false, children: [] })),
+    ];
+
+    const newRoot = makeThread({ id: 'root-new', summary: 'New Root', createdAt: t(1000) });
+    const newChild = makeThread({ id: 'child-new', parentId: newRoot.id, summary: 'New Child', createdAt: t(1010) });
+    const pageTwoItems: ThreadMock[] = [
+      {
+        ...primaryRoot,
+        hasChildren: true,
+        children: [
+          {
+            ...primaryChild,
+            hasChildren: false,
+            children: [],
+          },
+        ],
+      },
+      ...extraRoots.map((thread) => ({ ...thread, hasChildren: false, children: [] })),
+      {
+        ...newRoot,
+        hasChildren: true,
+        children: [
+          {
+            ...newChild,
+            hasChildren: false,
+            children: [],
+          },
+        ],
+      },
+    ];
+
+    let childrenRequests = 0;
+
+    server.use(
+      http.get('*/api/agents/threads/tree', ({ request }) => {
+        const url = new URL(request.url);
+        const limit = Number.parseInt(url.searchParams.get('limit') ?? '0', 10);
+        if (!Number.isFinite(limit) || limit <= 50) {
+          return HttpResponse.json(buildTreeResponse(pageOneItems));
+        }
+        return HttpResponse.json(buildTreeResponse(pageTwoItems));
+      }),
+      http.get(abs('/api/agents/threads/tree'), ({ request }) => {
+        const url = new URL(request.url);
+        const limit = Number.parseInt(url.searchParams.get('limit') ?? '0', 10);
+        if (!Number.isFinite(limit) || limit <= 50) {
+          return HttpResponse.json(buildTreeResponse(pageOneItems));
+        }
+        return HttpResponse.json(buildTreeResponse(pageTwoItems));
+      }),
+      http.get('*/api/agents/threads', () => HttpResponse.json({ items: pageTwoItems })),
+      http.get(abs('/api/agents/threads'), () => HttpResponse.json({ items: pageTwoItems })),
+      http.get('*/api/agents/threads/:threadId', ({ params }) => {
+        const match = pageTwoItems.find((item) => item.id === params.threadId);
+        if (match) return HttpResponse.json(match);
+        return new HttpResponse(null, { status: 404 });
+      }),
+      http.get(abs('/api/agents/threads/:threadId'), ({ params }) => {
+        const match = pageTwoItems.find((item) => item.id === params.threadId);
+        if (match) return HttpResponse.json(match);
+        return new HttpResponse(null, { status: 404 });
+      }),
+      http.get('*/api/agents/threads/:threadId/children', () => {
+        childrenRequests += 1;
+        return HttpResponse.json({ items: [] });
+      }),
+      http.get(abs('/api/agents/threads/:threadId/children'), () => {
+        childrenRequests += 1;
+        return HttpResponse.json({ items: [] });
+      }),
+      http.get('*/api/agents/reminders', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/agents/reminders'), () => HttpResponse.json({ items: [] })),
+      http.options('*/api/agents/reminders', () => new HttpResponse(null, { status: 200 })),
+      http.options(abs('/api/agents/reminders'), () => new HttpResponse(null, { status: 200 })),
+      http.get('*/api/containers', () => HttpResponse.json({ items: [] })),
+      http.get(abs('/api/containers'), () => HttpResponse.json({ items: [] })),
+    );
+
+    const user = userEvent.setup();
+    renderAt('/agents/threads');
+
+    const rootToggle = await screen.findByRole('button', { name: /Show 1 subthread/i });
+    await user.click(rootToggle);
+    expect(await screen.findByText('Primary Child')).toBeInTheDocument();
+
+    act(() => {
+      MockIntersectionObserver.instances.forEach((instance) => instance.trigger());
+    });
+
+    await waitFor(() => expect(screen.getByText('New Root')).toBeInTheDocument());
+
+    expect(childrenRequests).toBe(0);
+
+    const newRootToggle = await screen.findByRole('button', { name: /Show 1 subthread/i });
+    await user.click(newRootToggle);
+
+    expect(await screen.findByText('New Child')).toBeInTheDocument();
+
+    const primaryChildVisible = screen.getByText('Primary Child');
+    expect(primaryChildVisible).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- extend agents threads persistence/controller to preload tree depth-2 and expose children counts
- add depth-2 tree integration tests plus frontend tree coverage for AgentsThreads view
- update AgentsThreads UI state management to avoid redundant child fetches and align MSW handlers

## Testing
- pnpm --filter @agyn/platform-ui test
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-server test -- --runInBand --watch=false

Resolves #1119
