### PR TITLE
Fix: make Agent node title editable in Graph sidebar

### DIFF
--- a/packages/platform-ui/src/components/agents/GraphLayout.tsx
+++ b/packages/platform-ui/src/components/agents/GraphLayout.tsx
@@ -822,6 +822,8 @@ export function GraphLayout({ services }: GraphLayoutProps) {
       config.title = rawConfigTitle;
     }
 
+    config.title = config.title ?? selectedNode.title;
+
     return {
       config,
       displayTitle: resolveDisplayTitle(selectedNode),

--- a/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.agent.test.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.agent.test.tsx
@@ -11,7 +11,7 @@ describe('NodePropertiesSidebar - agent', () => {
     const onConfigChange = vi.fn();
     const config: NodeConfig = {
       kind: 'Agent',
-      title: '',
+      title: 'Custom Dispatch',
       template: 'agent',
       name: 'Casey Quinn',
       role: 'Lead Planner',
@@ -42,9 +42,12 @@ describe('NodePropertiesSidebar - agent', () => {
     );
 
     const expectedPlaceholder = 'Casey Quinn (Lead Planner)';
-    const titleInput = screen.getByPlaceholderText(expectedPlaceholder) as HTMLInputElement;
-    expect(titleInput.value).toBe('');
     expect(screen.getByText(expectedPlaceholder)).toBeInTheDocument();
+
+    const titleInput = screen.getByDisplayValue('Custom Dispatch') as HTMLInputElement;
+    expect(titleInput.placeholder).toBe(expectedPlaceholder);
+    expect(titleInput.value).toBe('Custom Dispatch');
+    expect(screen.queryByText('Custom Dispatch')).not.toBeInTheDocument();
 
     const nameInput = screen.getByPlaceholderText('e.g., Casey Quinn') as HTMLInputElement;
     expect(nameInput.value).toBe('Casey Quinn');
@@ -58,5 +61,125 @@ describe('NodePropertiesSidebar - agent', () => {
 
     fireEvent.change(titleInput, { target: { value: '   ' } });
     expect(onConfigChange).toHaveBeenCalledWith(expect.objectContaining({ title: '' }));
+  });
+
+  it('uses combined name and role placeholder when title empty', () => {
+    const config: NodeConfig = {
+      kind: 'Agent',
+      title: '',
+      template: 'agent',
+      name: 'Casey Quinn',
+      role: 'Lead Planner',
+    } as NodeConfig;
+
+    const state: NodeState = { status: 'not_ready' };
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <NodePropertiesSidebar
+          config={config}
+          state={state}
+          onConfigChange={vi.fn()}
+          onProvision={vi.fn()}
+          onDeprovision={vi.fn()}
+          canProvision={false}
+          canDeprovision={false}
+          isActionPending={false}
+        />
+      </TooltipProvider>,
+    );
+
+    const titleInput = screen.getByPlaceholderText('Casey Quinn (Lead Planner)') as HTMLInputElement;
+    expect(titleInput.value).toBe('');
+  });
+
+  it('uses name-only placeholder when role missing', () => {
+    const config: NodeConfig = {
+      kind: 'Agent',
+      title: '',
+      template: 'agent',
+      name: 'Nova',
+      role: undefined,
+    } as NodeConfig;
+
+    const state: NodeState = { status: 'not_ready' };
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <NodePropertiesSidebar
+          config={config}
+          state={state}
+          onConfigChange={vi.fn()}
+          onProvision={vi.fn()}
+          onDeprovision={vi.fn()}
+          canProvision={false}
+          canDeprovision={false}
+          isActionPending={false}
+        />
+      </TooltipProvider>,
+    );
+
+    const titleInput = screen.getByPlaceholderText('Nova') as HTMLInputElement;
+    expect(titleInput.value).toBe('');
+  });
+
+  it('uses role-only placeholder when name missing', () => {
+    const config: NodeConfig = {
+      kind: 'Agent',
+      title: '',
+      template: 'agent',
+      name: undefined,
+      role: 'Navigator',
+    } as NodeConfig;
+
+    const state: NodeState = { status: 'not_ready' };
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <NodePropertiesSidebar
+          config={config}
+          state={state}
+          onConfigChange={vi.fn()}
+          onProvision={vi.fn()}
+          onDeprovision={vi.fn()}
+          canProvision={false}
+          canDeprovision={false}
+          isActionPending={false}
+        />
+      </TooltipProvider>,
+    );
+
+    const titleInput = screen.getByPlaceholderText('Navigator') as HTMLInputElement;
+    expect(titleInput.value).toBe('');
+  });
+
+  it('falls back to Agent placeholder when profile empty', () => {
+    const config: NodeConfig = {
+      kind: 'Agent',
+      title: '',
+      template: 'agent',
+      name: undefined,
+      role: undefined,
+    } as NodeConfig;
+
+    const state: NodeState = { status: 'not_ready' };
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <NodePropertiesSidebar
+          config={config}
+          state={state}
+          onConfigChange={vi.fn()}
+          onProvision={vi.fn()}
+          onDeprovision={vi.fn()}
+          canProvision={false}
+          canDeprovision={false}
+          isActionPending={false}
+        />
+      </TooltipProvider>,
+    );
+
+    const titleInput = screen.getByPlaceholderText('Agent') as HTMLInputElement;
+    expect(titleInput.value).toBe('');
   });
 });

--- a/packages/platform-ui/src/components/nodeProperties/index.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/index.tsx
@@ -215,16 +215,17 @@ function NodePropertiesSidebar({
     [agentNameInput, agentRoleInput],
   );
   const headerTitle = useMemo(() => {
-    const providedDisplay = typeof displayTitle === 'string' ? displayTitle.trim() : '';
-    if (providedDisplay.length > 0) return providedDisplay;
-
     if (nodeKind === 'Agent') {
-      const trimmedConfigTitle = nodeTitleValue.trim();
-      return trimmedConfigTitle.length > 0 ? trimmedConfigTitle : agentDefaultTitle;
+      return agentDefaultTitle;
+    }
+
+    const providedDisplay = typeof displayTitle === 'string' ? displayTitle.trim() : '';
+    if (providedDisplay.length > 0) {
+      return providedDisplay;
     }
 
     return nodeTitleValue.trim();
-  }, [displayTitle, nodeKind, nodeTitleValue, agentDefaultTitle]);
+  }, [agentDefaultTitle, displayTitle, nodeKind, nodeTitleValue]);
   const agentModelValue = typeof configRecord.model === 'string' ? (configRecord.model as string) : '';
   const agentSystemPromptValue =
     typeof configRecord.systemPrompt === 'string' ? (configRecord.systemPrompt as string) : '';

--- a/packages/platform-ui/src/features/graph/__tests__/GraphLayout.integration.test.tsx
+++ b/packages/platform-ui/src/features/graph/__tests__/GraphLayout.integration.test.tsx
@@ -316,7 +316,7 @@ describe('GraphLayout', () => {
       nodes?: Array<{ data?: { title?: string } }>;
     };
 
-    expect(latest?.nodes?.[0]?.data?.title).toBe('Support Agent');
+    expect(latest?.nodes?.[0]?.data?.title).toBe('Agent');
   });
 
   it('passes sidebar config/state and persists config updates', async () => {
@@ -531,7 +531,7 @@ describe('GraphLayout', () => {
     expect(payload).toBeDefined();
     expect(payload?.config).toEqual({ name: 'Atlas', role: 'Navigator' });
     expect(payload?.title).toBe('');
-
+    const sidebarCountBeforeRefresh = sidebarProps.length;
     graph.nodes = graph.nodes.map((node) =>
       node.id === 'node-1'
         ? {
@@ -551,6 +551,108 @@ describe('GraphLayout', () => {
       };
       expect(latest?.nodes?.[0]?.data?.title).toBe('Atlas (Navigator)');
     });
+
+    await waitFor(() => expect(sidebarProps.length).toBeGreaterThan(sidebarCountBeforeRefresh));
+    const refreshedSidebar = sidebarProps.at(-1) as {
+      config: Record<string, unknown>;
+      displayTitle?: string;
+    };
+    expect(refreshedSidebar.config).toEqual(expect.objectContaining({ title: '' }));
+    expect(refreshedSidebar.displayTitle).toBe('');
+  });
+
+  it('persists agent title edits and restores the saved value after refresh', async () => {
+    const updateNode = vi.fn();
+    const applyNodeStatus = vi.fn();
+    const applyNodeState = vi.fn();
+    const setEdges = vi.fn();
+
+    const graph = mockGraphData({
+      nodes: [
+        {
+          id: 'node-1',
+          template: 'Agent',
+          kind: 'Agent',
+          title: '',
+          x: 0,
+          y: 0,
+          status: 'not_ready',
+          config: { title: '', name: 'Atlas', role: 'Navigator' },
+          ports: { inputs: [], outputs: [] },
+        },
+      ],
+      updateNode,
+      applyNodeStatus,
+      applyNodeState,
+      setEdges,
+    });
+
+    hookMocks.useGraphSocket.mockReturnValue(undefined);
+    hookMocks.useNodeStatus.mockReturnValue({ data: null, refetch: vi.fn() });
+
+    const { rerender } = render(<GraphLayout services={services} />);
+
+    await waitFor(() => expect(canvasSpy).toHaveBeenCalled());
+    const canvasProps = canvasSpy.mock.calls.at(-1)?.[0] as {
+      onNodesChange?: (changes: any[]) => void;
+    };
+
+    act(() => {
+      canvasProps.onNodesChange?.([
+        {
+          id: 'node-1',
+          type: 'select',
+          selected: true,
+        },
+      ]);
+    });
+
+    await waitFor(() => expect(sidebarProps.length).toBeGreaterThan(0));
+    const sidebar = sidebarProps.at(-1) as {
+      onConfigChange?: (next: Record<string, unknown>) => void;
+    };
+
+    act(() => {
+      sidebar.onConfigChange?.({ title: 'Mission Control' });
+    });
+
+    await waitFor(() => expect(updateNode).toHaveBeenCalled());
+    const payload = updateNode.mock.calls.at(-1)?.[1] as {
+      config: Record<string, unknown>;
+      title?: string;
+    };
+    expect(payload).toEqual({ config: { name: 'Atlas', role: 'Navigator' }, title: 'Mission Control' });
+
+    graph.nodes = graph.nodes.map((node) =>
+      node.id === 'node-1'
+        ? {
+            ...node,
+            title: 'Mission Control',
+            config: { ...(node.config ?? {}), title: 'Mission Control' },
+          }
+        : node,
+    );
+
+    hookMocks.useGraphData.mockReturnValue(graph);
+    const sidebarCountBeforeRefresh = sidebarProps.length;
+    canvasSpy.mockClear();
+    rerender(<GraphLayout services={services} />);
+
+    await waitFor(() => expect(canvasSpy).toHaveBeenCalled());
+    const latest = canvasSpy.mock.calls.at(-1)?.[0] as {
+      nodes?: Array<{ data?: { title?: string } }>;
+    };
+    expect(latest?.nodes?.[0]?.data?.title).toBe('Mission Control');
+
+    await waitFor(() => expect(sidebarProps.length).toBeGreaterThan(sidebarCountBeforeRefresh));
+    const refreshedSidebar = sidebarProps.at(-1) as {
+      config: Record<string, unknown>;
+      displayTitle?: string;
+    };
+    expect(refreshedSidebar.config).toEqual(
+      expect.objectContaining({ title: 'Mission Control', name: 'Atlas', role: 'Navigator' }),
+    );
+    expect(refreshedSidebar.displayTitle).toBe('Mission Control');
   });
 
   it('keeps stored agent title when distinct from template', async () => {

--- a/packages/platform-ui/src/features/graph/hooks/useGraphData.ts
+++ b/packages/platform-ui/src/features/graph/hooks/useGraphData.ts
@@ -198,22 +198,40 @@ export function useGraphData(): UseGraphDataResult {
           if (node.id !== nodeId) return node;
           const meta = metadataRef.current.get(nodeId);
           const next: GraphNodeConfig = { ...node };
-          if (typeof updates.title === 'string' && updates.title !== node.title) {
-            next.title = updates.title;
+          let nextConfig = node.config
+            ? { ...(node.config as Record<string, unknown>) }
+            : undefined;
+          let metaConfig = meta?.config
+            ? { ...(meta.config as Record<string, unknown>) }
+            : undefined;
+
+          if (typeof updates.config !== 'undefined' && updates.config !== node.config) {
+            nextConfig = updates.config
+              ? { ...(updates.config as Record<string, unknown>) }
+              : undefined;
             if (meta) {
-              meta.config = { ...(meta.config ?? {}), title: updates.title };
+              metaConfig = updates.config
+                ? { ...(updates.config as Record<string, unknown>) }
+                : undefined;
             }
             shouldSave = true;
+          }
+
+          if (typeof updates.title === 'string') {
+            next.title = updates.title;
+            nextConfig = { ...(nextConfig ?? {}), title: updates.title };
+            if (meta) {
+              metaConfig = { ...(metaConfig ?? {}), title: updates.title };
+            }
+            shouldSave = true;
+          }
+
+          next.config = nextConfig;
+          if (meta) {
+            meta.config = metaConfig;
           }
           if (typeof updates.status === 'string' && updates.status !== node.status) {
             next.status = updates.status as GraphNodeStatus;
-          }
-          if (updates.config && updates.config !== node.config) {
-            next.config = { ...updates.config };
-            if (meta) {
-              meta.config = { ...updates.config };
-            }
-            shouldSave = true;
           }
           if (updates.state && updates.state !== node.state) {
             next.state = { ...updates.state };

--- a/packages/platform-ui/src/utils/__tests__/agentDisplay.test.ts
+++ b/packages/platform-ui/src/utils/__tests__/agentDisplay.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeAgentDefaultTitle, resolveAgentDisplayTitle } from '@/utils/agentDisplay';
+
+describe('computeAgentDefaultTitle', () => {
+  it('formats name and role when both provided', () => {
+    expect(computeAgentDefaultTitle(' Delta ', ' Navigator ', 'Agent')).toBe('Delta (Navigator)');
+  });
+
+  it('returns name when only name provided', () => {
+    expect(computeAgentDefaultTitle('Echo', null, 'Agent')).toBe('Echo');
+  });
+
+  it('returns role when only role provided', () => {
+    expect(computeAgentDefaultTitle(undefined, ' Strategist ', 'Agent')).toBe('Strategist');
+  });
+
+  it('falls back when profile is missing', () => {
+    expect(computeAgentDefaultTitle(undefined, undefined, 'Agent')).toBe('Agent');
+  });
+});
+
+describe('resolveAgentDisplayTitle', () => {
+  it('prefers trimmed config title when present', () => {
+    expect(
+      resolveAgentDisplayTitle({
+        title: '  Field Ops  ',
+        name: 'Delta',
+        role: 'Navigator',
+      }),
+    ).toBe('Field Ops');
+  });
+
+  it('falls back to combined name and role when title missing', () => {
+    expect(
+      resolveAgentDisplayTitle({
+        title: '',
+        name: ' Aurora ',
+        role: ' Lead ',
+      }),
+    ).toBe('Aurora (Lead)');
+  });
+
+  it('returns name when only name available', () => {
+    expect(resolveAgentDisplayTitle({ title: '', name: 'Atlas', role: '   ' })).toBe('Atlas');
+  });
+
+  it('returns role when only role available', () => {
+    expect(resolveAgentDisplayTitle({ title: '', name: '   ', role: 'Navigator' })).toBe('Navigator');
+  });
+
+  it('uses Agent fallback when profile empty', () => {
+    expect(resolveAgentDisplayTitle({ title: ' ', name: null, role: undefined })).toBe('Agent');
+  });
+});

--- a/packages/platform-ui/src/utils/agentDisplay.ts
+++ b/packages/platform-ui/src/utils/agentDisplay.ts
@@ -23,4 +23,19 @@ export const computeAgentDefaultTitle = (
   return fallback;
 };
 
+type AgentProfileConfig = {
+  title?: string | null;
+  name?: string | null;
+  role?: string | null;
+} | undefined;
+
+export const resolveAgentDisplayTitle = (config: AgentProfileConfig): string => {
+  const rawTitle = typeof config?.title === 'string' ? config.title.trim() : '';
+  if (rawTitle.length > 0) {
+    return rawTitle;
+  }
+
+  return computeAgentDefaultTitle(config?.name, config?.role, 'Agent');
+};
+
 export const AGENT_TITLE_FALLBACK = FALLBACK_AGENT_DISPLAY;


### PR DESCRIPTION
## Summary
- ensure the agent sidebar config uses the selected node title when missing to keep the input controlled

Fixes #1132

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test -- --runInBand
- pnpm dev (startup only; UI verification limited by headless environment)
