### PR TITLE
feat: refresh Threads status UI

### DIFF
--- a/packages/platform-ui/__tests__/AgentsThreads.layout.test.tsx
+++ b/packages/platform-ui/__tests__/AgentsThreads.layout.test.tsx
@@ -17,9 +17,8 @@ describe('AgentsThreads layout', () => {
 
     expect(await screen.findByTestId('threads-list')).toBeInTheDocument();
     expect(screen.getByText('Select a thread to view details')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Open/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Closed/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /All/i })).toBeInTheDocument();
+    const filterButtons = screen.getAllByRole('button', { name: /^(Open|Resolved|All)$/ });
+    expect(filterButtons.map((button) => button.textContent)).toEqual(['Open', 'Resolved', 'All']);
     expect(screen.getByTitle('New thread')).toBeInTheDocument();
   });
 });

--- a/packages/platform-ui/__tests__/ThreadsScreen.toggle.test.tsx
+++ b/packages/platform-ui/__tests__/ThreadsScreen.toggle.test.tsx
@@ -51,7 +51,7 @@ describe('ThreadsScreen thread status toggle', () => {
       />,
     );
 
-    const statusTrigger = screen.getByRole('button', { name: 'Thread status' });
+    const statusTrigger = screen.getByRole('button', { name: /Thread status/i });
     expect(statusTrigger).not.toBeDisabled();
 
     await user.click(statusTrigger);
@@ -87,7 +87,7 @@ describe('ThreadsScreen thread status toggle', () => {
       />,
     );
 
-    const statusTrigger = screen.getByRole('button', { name: 'Thread status' });
+    const statusTrigger = screen.getByRole('button', { name: /Thread status/i });
     expect(statusTrigger).toBeDisabled();
     expect(statusTrigger).toHaveAttribute('aria-busy', 'true');
   });
@@ -229,7 +229,7 @@ describe('AgentsThreads status toggle integration', () => {
     const threadRow = await screen.findByText('Investigate production error logs');
     await user.click(threadRow);
 
-    let statusTrigger = await screen.findByRole('button', { name: 'Thread status' });
+    let statusTrigger = await screen.findByRole('button', { name: /Thread status/i });
     expect(within(statusTrigger).getByText('Open')).toBeInTheDocument();
 
     const initialRoots = rootsRequestCount;
@@ -240,7 +240,7 @@ describe('AgentsThreads status toggle integration', () => {
 
     await waitFor(() => expect(patchCalls).toBeGreaterThan(0));
     await waitFor(() => expect(rootsRequestCount).toBeGreaterThan(initialRoots));
-    statusTrigger = await screen.findByRole('button', { name: 'Thread status' });
+    statusTrigger = await screen.findByRole('button', { name: /Thread status/i });
     expect(within(statusTrigger).getByText('Resolved')).toBeInTheDocument();
 
     const beforeSecondToggleRoots = rootsRequestCount;
@@ -251,7 +251,7 @@ describe('AgentsThreads status toggle integration', () => {
 
     await waitFor(() => expect(patchCalls).toBeGreaterThan(1));
     await waitFor(() => expect(rootsRequestCount).toBeGreaterThan(beforeSecondToggleRoots));
-    statusTrigger = await screen.findByRole('button', { name: 'Thread status' });
+    statusTrigger = await screen.findByRole('button', { name: /Thread status/i });
     expect(within(statusTrigger).getByText('Open')).toBeInTheDocument();
   });
 });

--- a/packages/platform-ui/src/components/agents/ThreadHeader.tsx
+++ b/packages/platform-ui/src/components/agents/ThreadHeader.tsx
@@ -127,7 +127,11 @@ export function ThreadHeader({ thread, runsCount }: { thread: ThreadNode | undef
   const createdAt = thread?.createdAt ? new Date(thread.createdAt) : null;
   const createdAtLabel = createdAt && Number.isFinite(createdAt.getTime()) ? createdAt.toLocaleString() : null;
   const createdRelative = createdAt && Number.isFinite(createdAt.getTime()) ? formatDistanceToNow(createdAt, { addSuffix: true }) : null;
-  const statusLabel = thread?.status ? thread.status.charAt(0).toUpperCase() + thread.status.slice(1) : 'Open';
+  const statusLabel = thread?.status === 'closed'
+    ? 'Resolved'
+    : thread?.status
+      ? thread.status.charAt(0).toUpperCase() + thread.status.slice(1)
+      : 'Open';
 
   if (!thread) {
     return (

--- a/packages/platform-ui/src/components/agents/ThreadStatusFilterSwitch.tsx
+++ b/packages/platform-ui/src/components/agents/ThreadStatusFilterSwitch.tsx
@@ -1,6 +1,12 @@
 
 export type ThreadStatusFilter = 'open' | 'closed' | 'all';
 
+const labelForValue = (value: ThreadStatusFilter): string => {
+  if (value === 'closed') return 'Resolved';
+  if (value === 'open') return 'Open';
+  return 'All';
+};
+
 export function ThreadStatusFilterSwitch({ value, onChange }: { value: ThreadStatusFilter; onChange: (v: ThreadStatusFilter) => void }) {
   const opts: ThreadStatusFilter[] = ['open', 'closed', 'all'];
   return (
@@ -13,7 +19,7 @@ export function ThreadStatusFilterSwitch({ value, onChange }: { value: ThreadSta
           aria-pressed={value === v}
           onClick={() => onChange(v)}
         >
-          {v[0].toUpperCase() + v.slice(1)}
+          {labelForValue(v)}
         </button>
       ))}
     </div>

--- a/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
+++ b/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
@@ -388,7 +388,7 @@ export default function ThreadsScreen({
                       value="open"
                       disabled={statusSelectionDisabled}
                       hideIndicator
-                      className="flex items-center gap-2 rounded-[6px] px-3 py-2 text-sm text-[var(--agyn-dark)] transition-colors hover:bg-[var(--agyn-bg-light)] focus:bg-[var(--agyn-bg-light)] data-[state=checked]:bg-[var(--agyn-bg-light)] data-[state=checked]:font-medium"
+                      className="data-[state=checked]:font-medium"
                     >
                       <Circle className="h-4 w-4 text-[var(--agyn-gray)] group-data-[state=checked]:text-[var(--agyn-blue)]" />
                       <span>Open</span>
@@ -397,7 +397,7 @@ export default function ThreadsScreen({
                       value="closed"
                       disabled={statusSelectionDisabled}
                       hideIndicator
-                      className="flex items-center gap-2 rounded-[6px] px-3 py-2 text-sm text-[var(--agyn-dark)] transition-colors hover:bg-[var(--agyn-bg-light)] focus:bg-[var(--agyn-bg-light)] data-[state=checked]:bg-[var(--agyn-bg-light)] data-[state=checked]:font-medium"
+                      className="data-[state=checked]:font-medium"
                     >
                       <CheckCircle className="h-4 w-4 text-[var(--agyn-gray)] group-data-[state=checked]:text-[var(--agyn-blue)]" />
                       <span>Resolved</span>

--- a/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
+++ b/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
@@ -376,22 +376,31 @@ export default function ThreadsScreen({
                     <ChevronDown className="h-4 w-4 text-[var(--agyn-gray)]" />
                   </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-[160px]" align="start">
+                <DropdownMenuContent
+                  className="w-[160px] rounded-[10px] border border-[var(--agyn-border-subtle)] bg-white p-1 shadow-lg"
+                  align="start"
+                >
                   <DropdownMenuRadioGroup
                     value={currentStatusValue}
                     onValueChange={(value) => handleStatusChange(value as 'open' | 'closed')}
                   >
-                    <DropdownMenuRadioItem value="open" disabled={statusSelectionDisabled}>
-                      <div className="flex items-center gap-2">
-                        <Circle className="h-4 w-4 text-[var(--agyn-gray)]" />
-                        <span className="text-sm text-[var(--agyn-dark)]">Open</span>
-                      </div>
+                    <DropdownMenuRadioItem
+                      value="open"
+                      disabled={statusSelectionDisabled}
+                      hideIndicator
+                      className="flex items-center gap-2 rounded-[6px] px-3 py-2 text-sm text-[var(--agyn-dark)] transition-colors hover:bg-[var(--agyn-bg-light)] focus:bg-[var(--agyn-bg-light)] data-[state=checked]:bg-[var(--agyn-bg-light)] data-[state=checked]:font-medium"
+                    >
+                      <Circle className="h-4 w-4 text-[var(--agyn-gray)] group-data-[state=checked]:text-[var(--agyn-blue)]" />
+                      <span>Open</span>
                     </DropdownMenuRadioItem>
-                    <DropdownMenuRadioItem value="closed" disabled={statusSelectionDisabled}>
-                      <div className="flex items-center gap-2">
-                        <CheckCircle className="h-4 w-4 text-[var(--agyn-gray)]" />
-                        <span className="text-sm text-[var(--agyn-dark)]">Resolved</span>
-                      </div>
+                    <DropdownMenuRadioItem
+                      value="closed"
+                      disabled={statusSelectionDisabled}
+                      hideIndicator
+                      className="flex items-center gap-2 rounded-[6px] px-3 py-2 text-sm text-[var(--agyn-dark)] transition-colors hover:bg-[var(--agyn-bg-light)] focus:bg-[var(--agyn-bg-light)] data-[state=checked]:bg-[var(--agyn-bg-light)] data-[state=checked]:font-medium"
+                    >
+                      <CheckCircle className="h-4 w-4 text-[var(--agyn-gray)] group-data-[state=checked]:text-[var(--agyn-blue)]" />
+                      <span>Resolved</span>
                     </DropdownMenuRadioItem>
                   </DropdownMenuRadioGroup>
                 </DropdownMenuContent>

--- a/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
+++ b/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
@@ -365,7 +365,7 @@ export default function ThreadsScreen({
                   <button
                     type="button"
                     className="flex items-center gap-2 rounded-[6px] px-2 py-1 transition-colors hover:bg-[var(--agyn-bg-light)]"
-                    aria-label="Thread status"
+                    aria-label={`Thread status: ${currentStatusLabel}`}
                     aria-busy={isToggleThreadStatusPending || undefined}
                     aria-haspopup="menu"
                     aria-expanded={isStatusMenuOpen}

--- a/packages/platform-ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/platform-ui/src/components/ui/dropdown-menu.tsx
@@ -6,6 +6,15 @@ import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "./utils";
 
+const dropdownItemBaseClasses =
+  "group relative flex cursor-default select-none items-center gap-2 rounded-[6px] px-3 py-2 text-sm text-[var(--agyn-dark)] outline-hidden transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 dark:text-[var(--agyn-white)] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground";
+
+const dropdownItemInteractiveClasses =
+  "hover:bg-[var(--agyn-bg-light)] focus:bg-[var(--agyn-bg-light)] data-[highlighted]:bg-[var(--agyn-bg-light)] data-[state=checked]:bg-[var(--agyn-bg-light)] data-[state=open]:bg-[var(--agyn-bg-light)] hover:text-[var(--agyn-dark)] focus:text-[var(--agyn-dark)] data-[highlighted]:text-[var(--agyn-dark)] data-[state=checked]:text-[var(--agyn-dark)] data-[state=open]:text-[var(--agyn-dark)] dark:hover:bg-white/10 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10 dark:data-[state=checked]:bg-white/10 dark:data-[state=open]:bg-white/10 dark:hover:text-[var(--agyn-white)] dark:focus:text-[var(--agyn-white)] dark:data-[highlighted]:text-[var(--agyn-white)] dark:data-[state=checked]:text-[var(--agyn-white)] dark:data-[state=open]:text-[var(--agyn-white)]";
+
+const dropdownItemDestructiveClasses =
+  "data-[variant=destructive]:text-destructive data-[variant=destructive]:hover:text-destructive data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:data-[highlighted]:text-destructive data-[variant=destructive]:data-[state=checked]:text-destructive data-[variant=destructive]:hover:bg-destructive/10 data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:hover:bg-destructive/20 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:*:[svg]:!text-destructive";
+
 function DropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
@@ -74,7 +83,9 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        dropdownItemBaseClasses,
+        dropdownItemInteractiveClasses,
+        dropdownItemDestructiveClasses,
         className,
       )}
       {...props}
@@ -92,7 +103,9 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        dropdownItemBaseClasses,
+        dropdownItemInteractiveClasses,
+        "pl-8 pr-3",
         className,
       )}
       checked={checked}
@@ -132,8 +145,9 @@ function DropdownMenuRadioItem({
       data-slot="dropdown-menu-radio-item"
       data-indicator={hideIndicator ? "hidden" : undefined}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground group relative flex cursor-default items-center gap-2 rounded-sm text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        hideIndicator ? "px-3 py-2" : "py-1.5 pr-2 pl-8",
+        dropdownItemBaseClasses,
+        dropdownItemInteractiveClasses,
+        hideIndicator ? "pl-3 pr-3" : "pl-8 pr-3",
         className,
       )}
       {...props}
@@ -218,7 +232,9 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        dropdownItemBaseClasses,
+        dropdownItemInteractiveClasses,
+        "pr-3 data-[state=open]:font-medium",
         className,
       )}
       {...props}

--- a/packages/platform-ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/platform-ui/src/components/ui/dropdown-menu.tsx
@@ -122,22 +122,29 @@ function DropdownMenuRadioGroup({
 function DropdownMenuRadioItem({
   className,
   children,
+  hideIndicator = false,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  hideIndicator?: boolean;
+}) {
   return (
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
+      data-indicator={hideIndicator ? "hidden" : undefined}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground group relative flex cursor-default items-center gap-2 rounded-sm text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        hideIndicator ? "px-3 py-2" : "py-1.5 pr-2 pl-8",
         className,
       )}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
+      {hideIndicator ? null : (
+        <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+          <DropdownMenuPrimitive.ItemIndicator>
+            <CircleIcon className="size-2 fill-current" />
+          </DropdownMenuPrimitive.ItemIndicator>
+        </span>
+      )}
       {children}
     </DropdownMenuPrimitive.RadioItem>
   );

--- a/packages/platform-ui/src/pages/AgentsThreads.tsx
+++ b/packages/platform-ui/src/pages/AgentsThreads.tsx
@@ -154,7 +154,7 @@ const THREAD_MESSAGE_MAX_LENGTH = 8000;
 const sendMessageErrorMap: Record<string, string> = {
   bad_message_payload: 'Please enter a message up to 8000 characters.',
   thread_not_found: 'Thread not found. It may have been removed.',
-  thread_closed: 'This thread is closed. Reopen it to send messages.',
+  thread_closed: 'This thread is resolved. Reopen it to send messages.',
   agent_unavailable: 'Agent is not currently available for this thread.',
   agent_unready: 'Agent is starting up. Try again shortly.',
   send_failed: 'Failed to send the message. Please retry.',


### PR DESCRIPTION
## Summary
- replace the Threads header toggle with a dropdown status chip and add open/resolved radio options
- surface "Resolved" instead of "Closed" across the Threads screen controls and thread header details
- update tests and copy to cover the new status chip, segmented control order, and resolved error messaging

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui typecheck
- pnpm test -- --runInBand
- pnpm dev (manual UI verification)

Closes #1131
