### PR TITLE
feat: surface manage tool run links

### DIFF
--- a/packages/platform-server/__tests__/agents.persistence.ensureThreadByAlias.test.ts
+++ b/packages/platform-server/__tests__/agents.persistence.ensureThreadByAlias.test.ts
@@ -13,8 +13,8 @@ const graphRepoStub = {
 
 const createLinkingStub = () =>
   ({
-    buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-      tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+    buildInitialMetadata: (params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+      tool: params.tool,
       parentThreadId: params.parentThreadId,
       childThreadId: params.childThreadId,
       childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/agents.persistence.extractKindText.test.ts
+++ b/packages/platform-server/__tests__/agents.persistence.extractKindText.test.ts
@@ -69,8 +69,8 @@ const graphRepoStub = {
 
 const createLinkingStub = () =>
   ({
-    buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-      tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+    buildInitialMetadata: (params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+      tool: params.tool,
       parentThreadId: params.parentThreadId,
       childThreadId: params.childThreadId,
       childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/agents.persistence.metrics_titles.test.ts
+++ b/packages/platform-server/__tests__/agents.persistence.metrics_titles.test.ts
@@ -7,8 +7,8 @@ import { CallAgentLinkingService } from '../src/agents/call-agent-linking.servic
 
 const createLinkingStub = (overrides?: Partial<CallAgentLinkingService>) =>
   ({
-    buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-      tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+    buildInitialMetadata: (params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+      tool: params.tool,
       parentThreadId: params.parentThreadId,
       childThreadId: params.childThreadId,
       childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/agents.reminders.controller.test.ts
+++ b/packages/platform-server/__tests__/agents.reminders.controller.test.ts
@@ -16,8 +16,8 @@ const graphRepoStub = {
 
 const createLinkingStub = () =>
   ({
-    buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-      tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+    buildInitialMetadata: (params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+      tool: params.tool,
       parentThreadId: params.parentThreadId,
       childThreadId: params.childThreadId,
       childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/agents.threads.filters.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.filters.test.ts
@@ -13,8 +13,8 @@ const graphRepoStub = {
 
 const createLinkingStub = () =>
   ({
-    buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-      tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+    buildInitialMetadata: (params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+      tool: params.tool,
       parentThreadId: params.parentThreadId,
       childThreadId: params.childThreadId,
       childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/agents.threads.tree.spec.ts
+++ b/packages/platform-server/__tests__/agents.threads.tree.spec.ts
@@ -13,8 +13,8 @@ const graphRepoStub = {
 
 const createLinkingStub = () =>
   ({
-    buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-      tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+    buildInitialMetadata: (params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+      tool: params.tool,
       parentThreadId: params.parentThreadId,
       childThreadId: params.childThreadId,
       childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
+++ b/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
@@ -175,8 +175,8 @@ describe('CallToolsLLMReducer call_agent metadata', () => {
     } as unknown as AgentsPersistenceService;
 
     const linkingMock = {
-      buildInitialMetadata: vi.fn((params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-        tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+      buildInitialMetadata: vi.fn((params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+        tool: params.tool,
         parentThreadId: params.parentThreadId,
         childThreadId: params.childThreadId,
         childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/call_agent.parentId.integration.test.ts
+++ b/packages/platform-server/__tests__/call_agent.parentId.integration.test.ts
@@ -34,8 +34,8 @@ describe('call_agent integration: creates child thread with parentId', () => {
       graphRepoStub,
       createRunEventsStub() as any,
       {
-        buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-          tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+        buildInitialMetadata: (params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+          tool: params.tool,
           parentThreadId: params.parentThreadId,
           childThreadId: params.childThreadId,
           childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },
@@ -52,8 +52,8 @@ describe('call_agent integration: creates child thread with parentId', () => {
       eventsBus as any,
     );
     const linking = {
-      buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-        tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+      buildInitialMetadata: (params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+        tool: params.tool,
         parentThreadId: params.parentThreadId,
         childThreadId: params.childThreadId,
         childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/call_agent.tool.test.ts
+++ b/packages/platform-server/__tests__/call_agent.tool.test.ts
@@ -18,8 +18,8 @@ const graphRepoStub = {
 
 const createLinkingStub = () => {
   const spies = {
-    buildInitialMetadata: vi.fn((params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-      tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+    buildInitialMetadata: vi.fn((params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+      tool: params.tool,
       parentThreadId: params.parentThreadId,
       childThreadId: params.childThreadId,
       childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/manage.tool.test.ts
+++ b/packages/platform-server/__tests__/manage.tool.test.ts
@@ -5,6 +5,7 @@ import { ModuleRef } from '@nestjs/core';
 import { ResponseMessage, AIMessage } from '@agyn/llm';
 
 import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
+import { CallAgentLinkingService } from '../src/agents/call-agent-linking.service';
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { ConfigService, configSchema } from '../src/core/services/config.service';
 import { Signal } from '../src/signal';
@@ -59,6 +60,9 @@ async function createHarness(options: { persistence?: AgentsPersistenceService }
         getOrCreateSubthreadByAlias: defaultSpy,
         setThreadChannelNode: defaultSetThreadChannel,
       } as unknown as AgentsPersistenceService);
+  const linking = {
+    registerParentToolExecution: vi.fn().mockResolvedValue('evt-manage'),
+  };
 
   const module = await Test.createTestingModule({
     providers: [
@@ -74,6 +78,7 @@ async function createHarness(options: { persistence?: AgentsPersistenceService }
       FakeAgent,
       { provide: AgentsPersistenceService, useValue: persistence },
       RunSignalsRegistry,
+      { provide: CallAgentLinkingService, useValue: linking },
       { provide: ReferenceResolverService, useValue: createReferenceResolverStub().stub },
     ],
   }).compile();
@@ -104,6 +109,7 @@ async function createHarness(options: { persistence?: AgentsPersistenceService }
     defaultSetThreadChannel,
     setAwaitedResponse,
     awaitSpy,
+    linking,
   };
 }
 
@@ -144,6 +150,12 @@ describe('ManageTool unit', () => {
       '',
     );
     expect(setThreadChannelNode).toHaveBeenCalledWith('child-explicit', 'manage');
+    expect(harness.linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: 'run',
+      parentThreadId: 'parent',
+      childThreadId: 'child-explicit',
+      toolName: 'manage',
+    });
   });
 
   it('send_message: derives sanitized alias when omitted', async () => {
@@ -165,6 +177,12 @@ describe('ManageTool unit', () => {
     expect(res).toBe('Response from: Alpha Worker\nok-child-derived');
     expect(getOrCreateSubthreadByAlias).toHaveBeenCalledWith('manage', 'alpha-worker', 'parent', '');
     expect(setThreadChannelNode).toHaveBeenCalledWith('child-derived', 'manage');
+    expect(harness.linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: 'run',
+      parentThreadId: 'parent',
+      childThreadId: 'child-derived',
+      toolName: 'manage',
+    });
   });
 
   it('send_message: prefixes multi-line worker response preserving content', async () => {
@@ -332,6 +350,7 @@ describe('ManageTool unit', () => {
           } as unknown as AgentsPersistenceService,
         },
         RunSignalsRegistry,
+        { provide: CallAgentLinkingService, useValue: { registerParentToolExecution: vi.fn() } },
       ],
     }).compile();
 
@@ -380,6 +399,7 @@ describe('ManageTool graph wiring', () => {
           useValue: { getOrCreateSubthreadByAlias: async () => 'child-t' } as unknown as AgentsPersistenceService,
         },
         RunSignalsRegistry,
+        { provide: CallAgentLinkingService, useValue: { registerParentToolExecution: vi.fn() } },
       ],
     }).compile();
 

--- a/packages/platform-server/__tests__/manage.tool.test.ts
+++ b/packages/platform-server/__tests__/manage.tool.test.ts
@@ -257,16 +257,6 @@ describe('ManageTool unit', () => {
     ).rejects.toThrow('Unknown worker: unknown');
   });
 
-  it('send_message: persistence unavailable guard', async () => {
-    const harness = await createHarness({ persistence: undefined as unknown as AgentsPersistenceService });
-    await addWorker(harness.module, harness.node, 'Worker Y');
-    const ctx = buildCtx();
-
-    await expect(
-      harness.tool.execute({ command: 'send_message', worker: 'Worker Y', message: 'msg' }, ctx),
-    ).rejects.toThrow('Manage: persistence unavailable');
-  });
-
   it('execute: missing threadId guard', async () => {
     const harness = await createHarness();
     await addWorker(harness.module, harness.node, 'Worker Z');

--- a/packages/platform-server/__tests__/nodes/manage.node.channel.spec.ts
+++ b/packages/platform-server/__tests__/nodes/manage.node.channel.spec.ts
@@ -2,17 +2,17 @@ import 'reflect-metadata';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { ManageToolNode } from '../../src/nodes/tools/manage/manage.node';
-import type { ManageFunctionTool } from '../../src/nodes/tools/manage/manage.tool';
 import type { AgentsPersistenceService } from '../../src/agents/agents.persistence.service';
+import type { CallAgentLinkingService } from '../../src/agents/call-agent-linking.service';
 import { HumanMessage } from '@agyn/llm';
 
 describe('ManageToolNode sendToChannel', () => {
   let node: ManageToolNode;
 
   beforeEach(async () => {
-    const fakeTool = { init: vi.fn().mockReturnValue({}) } as unknown as ManageFunctionTool;
     const fakePersistence = {} as unknown as AgentsPersistenceService;
-    node = new ManageToolNode(fakeTool, fakePersistence);
+    const fakeLinking = {} as unknown as CallAgentLinkingService;
+    node = new ManageToolNode(fakePersistence, fakeLinking);
     node.init({ nodeId: 'manage-node-test' });
     await node.setConfig({ mode: 'sync', timeoutMs: 1000 } as unknown as ManageToolNode['config']);
   });

--- a/packages/platform-server/__tests__/nodes/node-di.helper.ts
+++ b/packages/platform-server/__tests__/nodes/node-di.helper.ts
@@ -21,7 +21,6 @@ import { NcpsKeyService } from '../../src/infra/ncps/ncpsKey.service';
 import { LLMProvisioner } from '../../src/llm/provisioners/llm.provisioner';
 import { SlackAdapter } from '../../src/messaging/slack/slack.adapter';
 import { ThreadTransportService } from '../../src/messaging/threadTransport.service';
-import { ManageFunctionTool } from '../../src/nodes/tools/manage/manage.tool';
 import { VaultService } from '../../src/vault/vault.service';
 import { ReferenceResolverService } from '../../src/utils/reference-resolver.service';
 import { createReferenceResolverStub } from '../helpers/reference-resolver.stub';
@@ -108,14 +107,6 @@ const DEFAULT_TOKEN_FACTORIES = new Map<InjectionToken, () => unknown>([
       const { stub } = createReferenceResolverStub();
       return stub;
     },
-  ],
-  [
-    ManageFunctionTool,
-    () =>
-      new ManageFunctionTool(
-        createDefaultStub('AgentsPersistenceService') as AgentsPersistenceService,
-        createDefaultStub('CallAgentLinkingService') as CallAgentLinkingService,
-      ),
   ],
 ]);
 

--- a/packages/platform-server/__tests__/nodes/node-di.helper.ts
+++ b/packages/platform-server/__tests__/nodes/node-di.helper.ts
@@ -114,6 +114,7 @@ const DEFAULT_TOKEN_FACTORIES = new Map<InjectionToken, () => unknown>([
     () =>
       new ManageFunctionTool(
         createDefaultStub('AgentsPersistenceService') as AgentsPersistenceService,
+        createDefaultStub('CallAgentLinkingService') as CallAgentLinkingService,
       ),
   ],
 ]);

--- a/packages/platform-server/__tests__/socket.realtime.integration.test.ts
+++ b/packages/platform-server/__tests__/socket.realtime.integration.test.ts
@@ -64,8 +64,8 @@ const createPrismaStub = () =>
 
 const createLinkingStub = () =>
   ({
-    buildInitialMetadata: (params: { toolName: string; parentThreadId: string; childThreadId: string }) => ({
-      tool: params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent',
+    buildInitialMetadata: (params: { tool: 'call_agent' | 'call_engineer'; parentThreadId: string; childThreadId: string }) => ({
+      tool: params.tool,
       parentThreadId: params.parentThreadId,
       childThreadId: params.childThreadId,
       childRun: { id: null, status: 'queued', linkEnabled: false, latestMessageId: null },

--- a/packages/platform-server/__tests__/tools/manage.function.tool.spec.ts
+++ b/packages/platform-server/__tests__/tools/manage.function.tool.spec.ts
@@ -6,14 +6,32 @@ import type { ManageToolNode } from '../../src/nodes/tools/manage/manage.node';
 import type { AgentsPersistenceService } from '../../src/agents/agents.persistence.service';
 import type { LLMContext } from '../../src/llm/types';
 import { HumanMessage } from '@agyn/llm';
+import type { CallAgentLinkingService } from '../../src/agents/call-agent-linking.service';
 
 const createCtx = (overrides: Partial<LLMContext> = {}): LLMContext => ({
   threadId: 'parent-thread',
+  runId: 'parent-run',
   callerAgent: {
     invoke: vi.fn().mockResolvedValue(undefined),
   },
   ...overrides,
 } as unknown as LLMContext);
+
+const createToolInstance = (
+  persistence: AgentsPersistenceService,
+  manageNode: ManageToolNode,
+  linking?: { registerParentToolExecution: ReturnType<typeof vi.fn> },
+) => {
+  const linkingMock = linking ?? {
+    registerParentToolExecution: vi.fn().mockResolvedValue('evt-manage'),
+  };
+  const tool = new ManageFunctionTool(
+    persistence,
+    linkingMock as unknown as CallAgentLinkingService,
+  );
+  tool.init(manageNode, { persistence });
+  return { tool, linking: linkingMock };
+};
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -41,14 +59,19 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn(),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const ctx = createCtx();
     const result = await tool.execute({ command: 'send_message', worker: 'Worker Alpha', message: 'hello', threadAlias: undefined }, ctx);
 
     expect(persistence.getOrCreateSubthreadByAlias).toHaveBeenCalledWith('manage', 'worker-alpha', 'parent-thread', '');
     expect(persistence.setThreadChannelNode).toHaveBeenCalledWith('child-thread-1', 'manage-node-1');
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-1',
+      toolName: 'manage',
+    });
     expect(manageNode.registerInvocation).toHaveBeenCalledWith({
       childThreadId: 'child-thread-1',
       parentThreadId: 'parent-thread',
@@ -63,6 +86,47 @@ ${text}`),
     expect((messages[0] as HumanMessage).text).toBe('hello');
     expect(manageNode.renderWorkerResponse).toHaveBeenCalledWith('Worker Alpha', 'child response text');
     expect(result).toBe('Response from: Worker Alpha\nchild response text');
+  });
+
+  it('logs warning when parent run linking fails but continues execution', async () => {
+    const persistence = {
+      getOrCreateSubthreadByAlias: vi.fn().mockResolvedValue('child-thread-link-fail'),
+      setThreadChannelNode: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentsPersistenceService;
+
+    const workerInvoke = vi.fn().mockResolvedValue({ text: 'invoke result' });
+    const manageNode = {
+      nodeId: 'manage-node-link-fail',
+      listWorkers: vi.fn().mockReturnValue(['Worker Alpha']),
+      getWorkerByTitle: vi.fn().mockReturnValue({ invoke: workerInvoke }),
+      registerInvocation: vi.fn().mockResolvedValue(undefined),
+      awaitChildResponse: vi.fn().mockResolvedValue('child response text'),
+      getMode: vi.fn().mockReturnValue('sync'),
+      getTimeoutMs: vi.fn().mockReturnValue(64000),
+      renderWorkerResponse: vi.fn().mockReturnValue('formatted'),
+      renderAsyncAcknowledgement: vi.fn(),
+    } as unknown as ManageToolNode;
+
+    const linking = {
+      registerParentToolExecution: vi.fn().mockRejectedValue(new Error('link service down')),
+    };
+
+    const { tool } = createToolInstance(persistence, manageNode, linking);
+
+    const loggerWarnSpy = vi.spyOn((tool as any).logger, 'warn');
+
+    const ctx = createCtx({ runId: 'run-link-fail' });
+    await tool.execute({ command: 'send_message', worker: 'Worker Alpha', message: 'hello', threadAlias: undefined }, ctx);
+
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: 'run-link-fail',
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-link-fail',
+      toolName: 'manage',
+    });
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      'Manage: failed to register parent tool execution {"parentThreadId":"parent-thread","childThreadId":"child-thread-link-fail","runId":"run-link-fail","error":{"name":"Error","message":"link service down"}}',
+    );
   });
 
   it('reuses provided threadAlias without altering case when accepted', async () => {
@@ -84,8 +148,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const ctx = createCtx();
     const rawAlias = '  Mixed.Alias-Case_123  ';
@@ -99,6 +162,12 @@ ${text}`),
       '',
     );
     expect(manageNode.renderAsyncAcknowledgement).toHaveBeenCalledWith('Worker Alpha');
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-alias',
+      toolName: 'manage',
+    });
   });
 
   it('falls back to sanitized alias when provided alias is rejected', async () => {
@@ -123,8 +192,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const loggerWarnSpy = vi.spyOn((tool as any).logger, 'warn');
 
@@ -140,6 +208,12 @@ ${text}`),
       'Manage: provided threadAlias invalid, using sanitized fallback {"worker":"Worker Alpha","parentThreadId":"parent-thread","providedAlias":"Invalid Alias!","fallbackAlias":"invalid-alias"}',
     );
     expect(manageNode.renderAsyncAcknowledgement).toHaveBeenCalledWith('Worker Alpha');
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-fallback',
+      toolName: 'manage',
+    });
   });
 
   it('fallback alias enforces 64 character limit', async () => {
@@ -164,8 +238,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const ctx = createCtx();
     const rawAlias = 'A'.repeat(100);
@@ -177,6 +250,12 @@ ${text}`),
     expect(fallbackAlias.length).toBeLessThanOrEqual(64);
     expect(fallbackAlias).toBe('a'.repeat(64));
     expect(manageNode.renderAsyncAcknowledgement).toHaveBeenCalledWith('Worker Alpha');
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-long',
+      toolName: 'manage',
+    });
   });
 
   it('returns acknowledgement in async mode without awaiting child response', async () => {
@@ -198,8 +277,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const ctx = createCtx();
     const result = await tool.execute({ command: 'send_message', worker: 'Async Worker', message: 'hello async', threadAlias: undefined }, ctx);
@@ -210,6 +288,12 @@ ${text}`),
     expect(manageNode.renderAsyncAcknowledgement).toHaveBeenCalledWith('Async Worker');
     expect(workerInvoke).toHaveBeenCalledTimes(1);
     expect(result).toBe('async acknowledgement');
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-2',
+      toolName: 'manage',
+    });
   });
 
   it('logs and continues when async invoke returns non-promise', async () => {
@@ -231,8 +315,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
 
@@ -243,6 +326,12 @@ ${text}`),
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       'Manage: async send_message invoke returned non-promise {"worker":"Async Worker","childThreadId":"child-thread-non-promise","resultType":"object","promiseLike":false}',
     );
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-non-promise',
+      toolName: 'manage',
+    });
   });
 
   it('returns acknowledgement immediately for delayed async invocation and logs no errors', async () => {
@@ -270,8 +359,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
 
@@ -286,6 +374,12 @@ ${text}`),
     await Promise.resolve();
 
     expect(loggerErrorSpy).not.toHaveBeenCalled();
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-delayed',
+      toolName: 'manage',
+    });
   });
 
   it('logs async non-error rejections without crashing', async () => {
@@ -307,8 +401,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
 
@@ -323,6 +416,12 @@ ${text}`),
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         'Manage: async send_message failed {"worker":"Async Worker","childThreadId":"child-thread-async","error":{"code":"unknown_error","message":"boom","retriable":false}}',
       );
+    });
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-async',
+      toolName: 'manage',
     });
   });
 
@@ -345,8 +444,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
 
@@ -361,6 +459,12 @@ ${text}`),
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         'Manage: async send_message failed {"worker":"Async Worker","childThreadId":"child-thread-undefined","error":{"code":"unknown_error","message":"undefined","retriable":false}}',
       );
+    });
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-undefined',
+      toolName: 'manage',
     });
   });
 
@@ -384,8 +488,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn().mockReturnValue('async acknowledgement'),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
 
@@ -400,6 +503,12 @@ ${text}`),
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         'Manage: async send_message failed {"worker":"Async Worker","childThreadId":"child-thread-object","error":{"code":"X","message":"custom diagnostic","retriable":false}}',
       );
+    });
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-object',
+      toolName: 'manage',
     });
   });
 
@@ -422,8 +531,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn(),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
 
@@ -435,6 +543,12 @@ ${text}`),
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       'Manage: send_message failed {"worker":"Fail Worker","childThreadId":"child-thread-sync","error":{"code":"unknown_error","message":"boom","retriable":false}}',
     );
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-sync',
+      toolName: 'manage',
+    });
   });
 
   it('rethrows non-error objects while logging their message', async () => {
@@ -457,8 +571,7 @@ ${text}`),
       renderAsyncAcknowledgement: vi.fn(),
     } as unknown as ManageToolNode;
 
-    const tool = new ManageFunctionTool(persistence);
-    tool.init(manageNode, { persistence });
+    const { tool, linking } = createToolInstance(persistence, manageNode);
 
     const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
 
@@ -470,5 +583,11 @@ ${text}`),
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       'Manage: send_message failed {"worker":"Fail Worker","childThreadId":"child-thread-sync-object","error":{"code":"Y","message":"sync diagnostic","retriable":false}}',
     );
+    expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
+      runId: ctx.runId,
+      parentThreadId: 'parent-thread',
+      childThreadId: 'child-thread-sync-object',
+      toolName: 'manage',
+    });
   });
 });

--- a/packages/platform-server/__tests__/tools/manage.function.tool.spec.ts
+++ b/packages/platform-server/__tests__/tools/manage.function.tool.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { describe, expect, it, vi, afterEach } from 'vitest';
+import { Logger } from '@nestjs/common';
 
 import { ManageFunctionTool } from '../../src/nodes/tools/manage/manage.tool';
 import type { ManageToolNode } from '../../src/nodes/tools/manage/manage.node';
@@ -113,7 +114,7 @@ ${text}`),
 
     const { tool } = createToolInstance(persistence, manageNode, linking);
 
-    const loggerWarnSpy = vi.spyOn((tool as any).logger, 'warn');
+    const loggerWarnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
 
     const ctx = createCtx({ runId: 'run-link-fail' });
     await tool.execute({ command: 'send_message', worker: 'Worker Alpha', message: 'hello', threadAlias: undefined }, ctx);
@@ -126,6 +127,7 @@ ${text}`),
     });
     expect(loggerWarnSpy).toHaveBeenCalledWith(
       'Manage: failed to register parent tool execution {"parentThreadId":"parent-thread","childThreadId":"child-thread-link-fail","runId":"run-link-fail","error":{"name":"Error","message":"link service down"}}',
+      ManageFunctionTool.name,
     );
   });
 
@@ -194,7 +196,7 @@ ${text}`),
 
     const { tool, linking } = createToolInstance(persistence, manageNode);
 
-    const loggerWarnSpy = vi.spyOn((tool as any).logger, 'warn');
+    const loggerWarnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
 
     const ctx = createCtx();
     const rawAlias = 'Invalid Alias!';
@@ -206,6 +208,7 @@ ${text}`),
     expect(aliasMock).toHaveBeenNthCalledWith(2, 'manage', 'invalid-alias', 'parent-thread', '');
     expect(loggerWarnSpy).toHaveBeenCalledWith(
       'Manage: provided threadAlias invalid, using sanitized fallback {"worker":"Worker Alpha","parentThreadId":"parent-thread","providedAlias":"Invalid Alias!","fallbackAlias":"invalid-alias"}',
+      ManageFunctionTool.name,
     );
     expect(manageNode.renderAsyncAcknowledgement).toHaveBeenCalledWith('Worker Alpha');
     expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
@@ -317,7 +320,7 @@ ${text}`),
 
     const { tool, linking } = createToolInstance(persistence, manageNode);
 
-    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+    const loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => undefined);
 
     const ctx = createCtx();
     const result = await tool.execute({ command: 'send_message', worker: 'Async Worker', message: 'hello async', threadAlias: undefined }, ctx);
@@ -325,6 +328,7 @@ ${text}`),
     expect(result).toBe('async acknowledgement');
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       'Manage: async send_message invoke returned non-promise {"worker":"Async Worker","childThreadId":"child-thread-non-promise","resultType":"object","promiseLike":false}',
+      ManageFunctionTool.name,
     );
     expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
       runId: ctx.runId,
@@ -361,7 +365,7 @@ ${text}`),
 
     const { tool, linking } = createToolInstance(persistence, manageNode);
 
-    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+    const loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => undefined);
 
     const ctx = createCtx();
     await expect(
@@ -403,7 +407,7 @@ ${text}`),
 
     const { tool, linking } = createToolInstance(persistence, manageNode);
 
-    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+    const loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => undefined);
 
     const ctx = createCtx();
     const result = await tool.execute(
@@ -415,6 +419,7 @@ ${text}`),
     await vi.waitFor(() => {
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         'Manage: async send_message failed {"worker":"Async Worker","childThreadId":"child-thread-async","error":{"code":"unknown_error","message":"boom","retriable":false}}',
+        ManageFunctionTool.name,
       );
     });
     expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
@@ -446,7 +451,7 @@ ${text}`),
 
     const { tool, linking } = createToolInstance(persistence, manageNode);
 
-    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+    const loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => undefined);
 
     const ctx = createCtx();
     const result = await tool.execute(
@@ -458,6 +463,7 @@ ${text}`),
     await vi.waitFor(() => {
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         'Manage: async send_message failed {"worker":"Async Worker","childThreadId":"child-thread-undefined","error":{"code":"unknown_error","message":"undefined","retriable":false}}',
+        ManageFunctionTool.name,
       );
     });
     expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
@@ -490,7 +496,7 @@ ${text}`),
 
     const { tool, linking } = createToolInstance(persistence, manageNode);
 
-    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+    const loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => undefined);
 
     const ctx = createCtx();
     const result = await tool.execute(
@@ -502,6 +508,7 @@ ${text}`),
     await vi.waitFor(() => {
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         'Manage: async send_message failed {"worker":"Async Worker","childThreadId":"child-thread-object","error":{"code":"X","message":"custom diagnostic","retriable":false}}',
+        ManageFunctionTool.name,
       );
     });
     expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
@@ -533,7 +540,7 @@ ${text}`),
 
     const { tool, linking } = createToolInstance(persistence, manageNode);
 
-    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+    const loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => undefined);
 
     const ctx = createCtx();
     await expect(
@@ -542,6 +549,7 @@ ${text}`),
 
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       'Manage: send_message failed {"worker":"Fail Worker","childThreadId":"child-thread-sync","error":{"code":"unknown_error","message":"boom","retriable":false}}',
+      ManageFunctionTool.name,
     );
     expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
       runId: ctx.runId,
@@ -573,7 +581,7 @@ ${text}`),
 
     const { tool, linking } = createToolInstance(persistence, manageNode);
 
-    const loggerErrorSpy = vi.spyOn((tool as any).logger, 'error');
+    const loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => undefined);
 
     const ctx = createCtx();
     await expect(
@@ -582,6 +590,7 @@ ${text}`),
 
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       'Manage: send_message failed {"worker":"Fail Worker","childThreadId":"child-thread-sync-object","error":{"code":"Y","message":"sync diagnostic","retriable":false}}',
+      ManageFunctionTool.name,
     );
     expect(linking.registerParentToolExecution).toHaveBeenCalledWith({
       runId: ctx.runId,

--- a/packages/platform-server/src/agents/call-agent-linking.service.ts
+++ b/packages/platform-server/src/agents/call-agent-linking.service.ts
@@ -8,8 +8,13 @@ import { EventsBusService } from '../events/events-bus.service';
 
 type Tx = PrismaClient | Prisma.TransactionClient;
 
-type CallAgentToolName = 'call_agent' | 'call_engineer';
-const CALL_AGENT_TOOL_NAMES: CallAgentToolName[] = ['call_agent', 'call_engineer'];
+type CanonicalToolName = 'call_agent' | 'call_engineer' | 'manage';
+const TOOL_NAME_ALIASES: Record<CanonicalToolName, string[]> = {
+  call_agent: ['call_agent'],
+  call_engineer: ['call_engineer'],
+  manage: ['manage', 'manage_agent'],
+};
+const LINKABLE_TOOL_NAMES: string[] = ['call_agent', 'call_engineer', 'manage', 'manage_agent'];
 
 export type CallAgentChildRunStatus = 'queued' | RunStatus;
 
@@ -21,7 +26,7 @@ export interface CallAgentChildRunLink {
 }
 
 export interface CallAgentLinkMetadata {
-  tool: CallAgentToolName;
+  tool: CanonicalToolName;
   parentThreadId: string;
   childThreadId: string;
   childRun: CallAgentChildRunLink;
@@ -60,8 +65,18 @@ export class CallAgentLinkingService {
     return this.prismaService.getClient();
   }
 
-  buildInitialMetadata(params: { toolName: string; parentThreadId: string; childThreadId: string }): CallAgentLinkMetadata {
-    const canonical: CallAgentToolName = params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent';
+  private canonicalizeToolName(toolName: string): CanonicalToolName | null {
+    if (toolName === 'call_agent') return 'call_agent';
+    if (toolName === 'call_engineer') return 'call_engineer';
+    if (toolName === 'manage' || toolName === 'manage_agent') return 'manage';
+    return null;
+  }
+
+  private toolSearchNames(tool: CanonicalToolName): string[] {
+    return TOOL_NAME_ALIASES[tool];
+  }
+
+  buildInitialMetadata(params: { tool: CanonicalToolName; parentThreadId: string; childThreadId: string }): CallAgentLinkMetadata {
     const childRun: CallAgentChildRunLink = {
       id: null,
       status: 'queued',
@@ -69,7 +84,7 @@ export class CallAgentLinkingService {
       latestMessageId: null,
     };
     return {
-      tool: canonical,
+      tool: params.tool,
       parentThreadId: params.parentThreadId,
       childThreadId: params.childThreadId,
       childRun,
@@ -86,14 +101,16 @@ export class CallAgentLinkingService {
     childThreadId: string;
     toolName: string;
   }): Promise<string | null> {
-    const canonical: CallAgentToolName = params.toolName === 'call_engineer' ? 'call_engineer' : 'call_agent';
+    const canonical = this.canonicalizeToolName(params.toolName);
+    if (!canonical) return null;
+    const toolNames = this.toolSearchNames(canonical);
     try {
       const eventId = await this.prisma.$transaction(async (tx) => {
-        const event = await this.findLatestToolEvent(tx, params.runId, canonical);
+        const event = await this.findLatestToolEvent(tx, params.runId, toolNames);
         if (!event) return null;
 
         const metadata = this.buildInitialMetadata({
-          toolName: canonical,
+          tool: canonical,
           parentThreadId: params.parentThreadId,
           childThreadId: params.childThreadId,
         });
@@ -108,6 +125,7 @@ export class CallAgentLinkingService {
         `call_agent_linking: failed to register parent tool execution${this.format({
           runId: params.runId,
           childThreadId: params.childThreadId,
+          tool: canonical,
           error: this.errorInfo(err),
         })}`,
       );
@@ -218,7 +236,7 @@ export class CallAgentLinkingService {
       const events = await this.prisma.runEvent.findMany({
         where: {
           type: 'tool_execution',
-          toolExecution: { toolName: { in: CALL_AGENT_TOOL_NAMES } },
+          toolExecution: { toolName: { in: LINKABLE_TOOL_NAMES } },
           OR: clauses,
         },
         orderBy: { ts: 'desc' },
@@ -277,7 +295,7 @@ export class CallAgentLinkingService {
   private parseMetadata(raw: Prisma.JsonValue | null): CallAgentLinkMetadata | null {
     if (!isRecord(raw)) return null;
     const toolRaw = typeof raw.tool === 'string' ? raw.tool : 'call_agent';
-    const tool: CallAgentToolName = toolRaw === 'call_engineer' ? 'call_engineer' : 'call_agent';
+    const tool = this.canonicalizeToolName(toolRaw) ?? 'call_agent';
     const parentThreadId = typeof raw.parentThreadId === 'string' ? raw.parentThreadId : null;
     const childThreadId = typeof raw.childThreadId === 'string' ? raw.childThreadId : null;
     if (!parentThreadId || !childThreadId) return null;
@@ -317,7 +335,7 @@ export class CallAgentLinkingService {
     return tx.runEvent.findFirst({
       where: {
         type: 'tool_execution',
-        toolExecution: { toolName: { in: CALL_AGENT_TOOL_NAMES } },
+        toolExecution: { toolName: { in: LINKABLE_TOOL_NAMES } },
         metadata: { path: ['childThreadId'], equals: childThreadId },
       },
       orderBy: { ts: 'desc' },
@@ -329,7 +347,7 @@ export class CallAgentLinkingService {
     return tx.runEvent.findFirst({
       where: {
         type: 'tool_execution',
-        toolExecution: { toolName: { in: CALL_AGENT_TOOL_NAMES } },
+        toolExecution: { toolName: { in: LINKABLE_TOOL_NAMES } },
         metadata: { path: ['childRunId'], equals: runId },
       },
       orderBy: { ts: 'desc' },
@@ -337,14 +355,14 @@ export class CallAgentLinkingService {
     });
   }
 
-  private async findLatestToolEvent(tx: Tx, runId: string, tool: CallAgentToolName) {
+  private async findLatestToolEvent(tx: Tx, runId: string, toolNames: readonly string[]) {
     return tx.runEvent.findFirst({
       where: {
         runId,
         type: 'tool_execution',
         toolExecution: {
           is: {
-            toolName: tool,
+            toolName: { in: toolNames },
           },
         },
       },

--- a/packages/platform-server/src/agents/call-agent-linking.service.ts
+++ b/packages/platform-server/src/agents/call-agent-linking.service.ts
@@ -362,7 +362,7 @@ export class CallAgentLinkingService {
         type: 'tool_execution',
         toolExecution: {
           is: {
-            toolName: { in: toolNames },
+            toolName: { in: [...toolNames] },
           },
         },
       },

--- a/packages/platform-server/src/nodes/nodes.module.ts
+++ b/packages/platform-server/src/nodes/nodes.module.ts
@@ -15,7 +15,6 @@ import { SlackAdapter } from '../messaging/slack/slack.adapter';
 import { ThreadTransportService } from '../messaging/threadTransport.service';
 import { LocalMCPServerNode } from './mcp';
 import { ManageToolNode } from './tools/manage/manage.node';
-import { ManageFunctionTool } from './tools/manage/manage.tool';
 import { CallAgentNode } from './tools/call_agent/call_agent.node';
 import { FinishNode } from './tools/finish/finish.node';
 import { MemoryToolNode } from './tools/memory/memory.node';
@@ -57,7 +56,6 @@ class NodesTemplateRegistrar implements OnModuleInit {
     SlackTrigger,
     LocalMCPServerNode,
     ManageToolNode,
-    ManageFunctionTool,
     CallAgentNode,
     FinishNode,
     MemoryToolNode,
@@ -89,7 +87,6 @@ class NodesTemplateRegistrar implements OnModuleInit {
     SlackTrigger,
     LocalMCPServerNode,
     ManageToolNode,
-    ManageFunctionTool,
     CallAgentNode,
     FinishNode,
     MemoryToolNode,

--- a/packages/platform-server/src/nodes/tools/manage/manage.node.ts
+++ b/packages/platform-server/src/nodes/tools/manage/manage.node.ts
@@ -5,6 +5,7 @@ import { BaseToolNode } from '../baseToolNode';
 import { ManageFunctionTool } from './manage.tool';
 import { AgentNode } from '../../agent/agent.node';
 import { AgentsPersistenceService } from '../../../agents/agents.persistence.service';
+import { CallAgentLinkingService } from '../../../agents/call-agent-linking.service';
 import type { SendResult } from '../../../messaging/types';
 import { ThreadChannelNode } from '../../../messaging/threadTransport.service';
 import type { CallerAgent } from '../../../llm/types';
@@ -42,8 +43,8 @@ export class ManageToolNode extends BaseToolNode<z.infer<typeof ManageToolStatic
   private readonly queuedMessages: Map<string, string[]> = new Map();
 
   constructor(
-    @Inject(ManageFunctionTool) private readonly manageTool: ManageFunctionTool,
     @Inject(AgentsPersistenceService) private readonly persistence: AgentsPersistenceService,
+    @Inject(CallAgentLinkingService) private readonly linking: CallAgentLinkingService,
   ) {
     super();
   }
@@ -105,7 +106,7 @@ export class ManageToolNode extends BaseToolNode<z.infer<typeof ManageToolStatic
   }
 
   protected createTool() {
-    return this.manageTool.init(this, { persistence: this.persistence });
+    return new ManageFunctionTool(this.persistence, this.linking).init(this);
   }
 
   getTool() {

--- a/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
+++ b/packages/platform-server/src/nodes/tools/manage/manage.tool.ts
@@ -71,20 +71,24 @@ export class ManageFunctionTool extends FunctionTool<typeof ManageInvocationSche
     return context ? ` ${JSON.stringify(context)}` : '';
   }
 
-  private safeWarn(msg: string) {
-    if ((this as any)?.logger?.warn) {
-      (this as any).logger.warn(msg);
-    } else {
-      console.warn(msg);
+  private getLogger(): Pick<Logger, 'warn' | 'error'> {
+    const candidate = (this as Partial<{ logger: Pick<Logger, 'warn' | 'error'> }>).logger;
+    if (candidate && typeof candidate.warn === 'function' && typeof candidate.error === 'function') {
+      return candidate;
     }
+
+    return {
+      warn: (msg: string) => Logger.warn(msg, ManageFunctionTool.name),
+      error: (msg: string) => Logger.error(msg, ManageFunctionTool.name),
+    };
+  }
+
+  private safeWarn(msg: string) {
+    this.getLogger().warn(msg);
   }
 
   private safeError(msg: string) {
-    if ((this as any)?.logger?.error) {
-      (this as any).logger.error(msg);
-    } else {
-      console.error(msg);
-    }
+    this.getLogger().error(msg);
   }
 
   private sanitizeAlias(raw: string | undefined): string {

--- a/packages/platform-ui/src/components/__tests__/RunEventDetails.manage.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/RunEventDetails.manage.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import { RunEventDetails, type RunEvent } from '../RunEventDetails';
+
+describe('RunEventDetails – manage tool view', () => {
+  it('renders thread and run links from child identifiers', () => {
+    const event: RunEvent = {
+      id: 'evt-manage-1',
+      type: 'tool',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      duration: '1s',
+      status: 'finished',
+      data: {
+        toolSubtype: 'manage',
+        toolName: 'manage_agent',
+        input: JSON.stringify({ command: 'delegate_task', worker: 'Worker Alpha' }),
+        output: JSON.stringify({ result: 'ok' }),
+        childThreadId: 'thread-123',
+        childRunId: 'run-456',
+      },
+    };
+
+    render(
+      <MemoryRouter>
+        <RunEventDetails event={event} />
+      </MemoryRouter>,
+    );
+
+    const threadLink = screen.getByRole('link', { name: /View thread/i });
+    expect(threadLink).toHaveAttribute('href', '/agents/threads/thread-123');
+
+    const runLink = screen.getByRole('link', { name: /View run/i });
+    expect(runLink).toHaveAttribute('href', '/agents/threads/thread-123/runs/run-456/timeline');
+  });
+});

--- a/packages/platform-ui/stories/RunEventDetails.stories.tsx
+++ b/packages/platform-ui/stories/RunEventDetails.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { MemoryRouter } from 'react-router-dom';
 import { RunEventDetails, type EventType } from '../src/components/RunEventDetails';
 import type { RunEvent } from '../src/components/RunEventsList';
 
@@ -9,6 +10,13 @@ const meta: Meta<typeof RunEventDetails> = {
     layout: 'centered',
   },
   tags: ['!autodocs'],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
 };
 
 export default meta;


### PR DESCRIPTION
## Summary
- register manage tool runs with the call-agent linking service using manage/manage_agent canonicalization
- extend backend link queries and metadata normalization to propagate child thread/run ids into run events
- surface View thread/View run links for manage tool events in Agents Run UI with new tests

## Testing
- pnpm --filter @agyn/platform-server lint
- AGENTS_DATABASE_URL=postgres://agents@localhost:5432/agents pnpm --filter @agyn/platform-server test
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test

Fixes #1133
