### PR TITLE
Fix reference handling on graph page

### DIFF
--- a/packages/platform-ui/__tests__/components/configViews/SlackTriggerConfigView.test.tsx
+++ b/packages/platform-ui/__tests__/components/configViews/SlackTriggerConfigView.test.tsx
@@ -1,14 +1,35 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SlackTriggerConfigView from '@/components/configViews/SlackTriggerConfigView';
 
+const pointerProto = Element.prototype as unknown as {
+  hasPointerCapture?: (pointerId: number) => boolean;
+  setPointerCapture?: (pointerId: number) => void;
+  releasePointerCapture?: (pointerId: number) => void;
+};
+
+if (!pointerProto.hasPointerCapture) {
+  pointerProto.hasPointerCapture = () => false;
+}
+if (!pointerProto.setPointerCapture) {
+  pointerProto.setPointerCapture = () => {};
+}
+if (!pointerProto.releasePointerCapture) {
+  pointerProto.releasePointerCapture = () => {};
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
 type SlackTriggerCfg = {
-  app_token?: { value: string; source?: 'static' | 'vault' };
-  bot_token?: { value: string; source?: 'static' | 'vault' };
+  app_token?: unknown;
+  bot_token?: unknown;
 };
 
 describe('SlackTriggerConfigView', () => {
-  it('renders both app_token and bot_token fields and emits normalized shapes', () => {
+  it('renders both app_token and bot_token fields and emits normalized shapes', async () => {
+    const user = userEvent.setup();
     let cfg: SlackTriggerCfg = {};
     render(
       <SlackTriggerConfigView
@@ -24,25 +45,44 @@ describe('SlackTriggerConfigView', () => {
     expect(screen.getByText('App token')).toBeInTheDocument();
     expect(screen.getByText('Bot token')).toBeInTheDocument();
 
-    const sources = screen.getAllByTestId('ref-source') as HTMLSelectElement[];
-    const values = screen.getAllByTestId('ref-value') as HTMLInputElement[];
+    const appField = screen.getByText('App token').parentElement as HTMLElement;
+    const botField = screen.getByText('Bot token').parentElement as HTMLElement;
+    const appInput = within(appField).getAllByRole('textbox')[0];
+    const botInput = within(botField).getAllByRole('textbox')[0];
+    const appTrigger = within(appField).getAllByRole('combobox')[0];
+    const botTrigger = within(botField).getAllByRole('combobox')[0];
 
     // Set app token static value
-    fireEvent.change(values[0], { target: { value: 'xapp-abc' } });
+    await user.type(appInput, 'xapp-abc');
     // Set bot token static value
-    fireEvent.change(values[1], { target: { value: 'xoxb-123' } });
+    await user.type(botInput, 'xoxb-123');
 
-    expect(cfg.app_token).toEqual({ value: 'xapp-abc', source: 'static' });
-    expect(cfg.bot_token).toEqual({ value: 'xoxb-123', source: 'static' });
+    expect(cfg.app_token).toBe('xapp-abc');
+    expect(cfg.bot_token).toBe('xoxb-123');
 
     // Switch bot token to vault and set mount/path/key
-    fireEvent.change(sources[1], { target: { value: 'vault' } });
-    fireEvent.change(values[1], { target: { value: 'mount/path/key' } });
-    expect(cfg.bot_token).toEqual({ value: 'mount/path/key', source: 'vault' });
+    await user.click(botTrigger);
+    const botListbox = await screen.findByRole('listbox');
+    const secretOption = within(botListbox).getByRole('option', { name: /secret/i });
+    await user.click(secretOption);
+    await user.clear(botInput);
+    fireEvent.change(botInput, { target: { value: 'mount/path/key' } });
+    expect(cfg.bot_token).toMatchObject({ kind: 'vault', path: 'mount/path', key: 'key' });
+
+    // Ensure switching back to text works and placeholder updates automatically
+    await user.click(appTrigger);
+    const appListbox = await screen.findByRole('listbox');
+    const textOption = within(appListbox).getByRole('option', { name: /plain text/i });
+    await user.click(textOption);
+    await user.clear(appInput);
+    await user.type(appInput, 'xapp-xyz');
+    expect(cfg.app_token).toBe('xapp-xyz');
   });
 
-  it('validates prefixes and vault refs', () => {
+  it('validates prefixes and vault refs', async () => {
+    const user = userEvent.setup();
     let errors: string[] = [];
+    const history: string[][] = [];
     render(
       <SlackTriggerConfigView
         templateName="slackTrigger"
@@ -50,29 +90,57 @@ describe('SlackTriggerConfigView', () => {
         onChange={() => {}}
         readOnly={false}
         disabled={false}
-        onValidate={(e) => (errors = e)}
+        onValidate={(e) => {
+          errors = e;
+          history.push(e);
+        }}
       />,
     );
 
-    const sources = screen.getAllByTestId('ref-source') as HTMLSelectElement[];
-    const values = screen.getAllByTestId('ref-value') as HTMLInputElement[];
+    const appField = screen.getByText('App token').parentElement as HTMLElement;
+    const botField = screen.getByText('Bot token').parentElement as HTMLElement;
+    const appInput = within(appField).getAllByRole('textbox')[0];
+    const botInput = within(botField).getAllByRole('textbox')[0];
+    const appTrigger = within(appField).getAllByRole('combobox')[0];
+    const botTrigger = within(botField).getAllByRole('combobox')[0];
 
     // Invalid prefixes initially (empty) should report required errors once touched
-    fireEvent.change(values[0], { target: { value: 'bad-app' } });
-    fireEvent.change(values[1], { target: { value: 'bad-bot' } });
-    expect(errors.includes('app_token must start with xapp-')).toBe(true);
-    expect(errors.includes('bot_token must start with xoxb-')).toBe(true);
+    await user.type(appInput, 'bad-app');
+    await waitFor(() => {
+      expect(history.some((batch) => batch.includes('app_token must start with xapp-'))).toBe(true);
+    });
+
+    await user.type(botInput, 'bad-bot');
+    await waitFor(() => {
+      expect(history.some((batch) => batch.includes('bot_token must start with xoxb-'))).toBe(true);
+    });
 
     // Switch to vault and test regex
-    fireEvent.change(sources[0], { target: { value: 'vault' } });
-    fireEvent.change(values[0], { target: { value: 'mount/app/TOKEN' } });
-    expect(errors.some((e) => e.includes('app_token'))).toBe(false);
+    await user.click(appTrigger);
+    const appListbox = await screen.findByRole('listbox');
+    const secretOption = within(appListbox).getByRole('option', { name: /secret/i });
+    await user.click(secretOption);
+    await user.clear(appInput);
+    fireEvent.change(appInput, { target: { value: 'mount/app/TOKEN' } });
+    await waitFor(() => {
+      expect(errors.some((e) => e.includes('app_token must start'))).toBe(false);
+      expect(errors.some((e) => e.includes('app_token vault ref'))).toBe(false);
+    });
 
-    fireEvent.change(sources[1], { target: { value: 'vault' } });
-    fireEvent.change(values[1], { target: { value: 'bad' } });
-    expect(errors.includes('bot_token vault ref must be mount/path/key')).toBe(true);
-    fireEvent.change(values[1], { target: { value: 'm/p/k' } });
-    expect(errors.includes('bot_token vault ref must be mount/path/key')).toBe(false);
+    await user.click(botTrigger);
+    const botListbox = await screen.findByRole('listbox');
+    const botSecretOption = within(botListbox).getByRole('option', { name: /secret/i });
+    await user.click(botSecretOption);
+    await user.clear(botInput);
+    fireEvent.change(botInput, { target: { value: 'bad' } });
+    await waitFor(() => {
+      expect(history.some((batch) => batch.includes('bot_token vault ref must be mount/path/key'))).toBe(true);
+    });
+    await user.clear(botInput);
+    fireEvent.change(botInput, { target: { value: 'm/p/k' } });
+    await waitFor(() => {
+      expect(errors.includes('bot_token vault ref must be mount/path/key')).toBe(false);
+    });
 
     // No masking behavior asserted (out of scope)
   });

--- a/packages/platform-ui/__tests__/components/configViews/SlackTriggerConfigView.test.tsx
+++ b/packages/platform-ui/__tests__/components/configViews/SlackTriggerConfigView.test.tsx
@@ -80,7 +80,7 @@ describe('SlackTriggerConfigView', () => {
     await user.click(secretOption);
     await user.clear(botInput);
     fireEvent.change(botInput, { target: { value: 'mount/path/key' } });
-    expect(cfg.bot_token).toMatchObject({ kind: 'vault', path: 'mount/path', key: 'key' });
+    expect(cfg.bot_token).toMatchObject({ kind: 'vault', mount: 'mount', path: 'path', key: 'key' });
 
     // Ensure switching back to text works and placeholder updates automatically
     await user.click(appTrigger);

--- a/packages/platform-ui/__tests__/components/configViews/WorkspaceConfigView.payload.test.tsx
+++ b/packages/platform-ui/__tests__/components/configViews/WorkspaceConfigView.payload.test.tsx
@@ -1,7 +1,36 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import WorkspaceConfigView from '@/components/configViews/WorkspaceConfigView';
+
+vi.mock('@/features/secrets/utils/flatVault', () => ({
+  listAllSecretPaths: () => Promise.resolve(['kv/workspace/db', 'kv/workspace/api']),
+}));
+
+vi.mock('@/features/variables/api', () => ({
+  listVariables: () => Promise.resolve([{ key: 'GLOBAL_TOKEN' }, { key: 'SOME_VAR' }]),
+}));
+
+const pointerProto = Element.prototype as unknown as {
+  hasPointerCapture?: (pointerId: number) => boolean;
+  setPointerCapture?: (pointerId: number) => void;
+  releasePointerCapture?: (pointerId: number) => void;
+};
+
+if (!pointerProto.hasPointerCapture) {
+  pointerProto.hasPointerCapture = () => false;
+}
+if (!pointerProto.setPointerCapture) {
+  pointerProto.setPointerCapture = () => {};
+}
+if (!pointerProto.releasePointerCapture) {
+  pointerProto.releasePointerCapture = () => {};
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
 
 describe('WorkspaceConfigView payload', () => {
   it('emits aligned schema shape', () => {
@@ -43,5 +72,42 @@ describe('WorkspaceConfigView payload', () => {
     expect(cfg.enableDinD).toBe(true);
     expect(cfg.ttlSeconds).toBe(123);
     expect(cfg.volumes).toEqual({ enabled: true, mountPath: '/data' });
+  });
+
+  it('supports selecting variable suggestions for env entries', async () => {
+    const user = userEvent.setup();
+    let cfg: any = {};
+    render(
+      <TooltipProvider delayDuration={0}>
+        <WorkspaceConfigView
+          templateName="workspace"
+          value={{}}
+          onChange={(v) => (cfg = v)}
+          readOnly={false}
+          disabled={false}
+        />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Add env'));
+    fireEvent.change(screen.getByTestId('env-name-0'), { target: { value: 'APP_TOKEN' } });
+
+    const envField = screen.getByTestId('env-value-0').parentElement?.parentElement;
+    if (!envField) throw new Error('Env field container not found');
+    const sourceTrigger = within(envField).getByRole('combobox');
+    await user.click(sourceTrigger);
+    const variableOption = await screen.findByRole('option', { name: /variable/i });
+    await user.click(variableOption);
+
+    const valueInput = screen.getByTestId('env-value-0');
+    await user.click(valueInput);
+    const suggestion = await screen.findByText('GLOBAL_TOKEN');
+    await user.click(suggestion);
+
+    expect(cfg.env?.[0]).toMatchObject({
+      name: 'APP_TOKEN',
+      source: 'variable',
+    });
+    expect(cfg.env?.[0]?.value).toEqual({ kind: 'var', name: 'GLOBAL_TOKEN' });
   });
 });

--- a/packages/platform-ui/__tests__/components/configViews/WorkspaceConfigView.secrets.test.tsx
+++ b/packages/platform-ui/__tests__/components/configViews/WorkspaceConfigView.secrets.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, vi } from 'vitest';
+
+vi.mock('@/features/secrets/utils/flatVault', () => ({
+  listAllSecretPaths: () => Promise.resolve(['kv/workspace/db', 'kv/workspace/api']),
+}));
+
+vi.mock('@/features/variables/api', () => ({
+  listVariables: () => Promise.resolve([]),
+}));
+
+import WorkspaceConfigView from '@/components/configViews/WorkspaceConfigView';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+const pointerTargets: Array<Partial<Record<string, unknown>>> = [
+  Element.prototype as Partial<Record<string, unknown>>,
+  HTMLElement.prototype as Partial<Record<string, unknown>>,
+  Document.prototype as Partial<Record<string, unknown>>,
+];
+
+if (typeof SVGElement !== 'undefined') {
+  pointerTargets.push(SVGElement.prototype as Partial<Record<string, unknown>>);
+}
+
+if (typeof Window !== 'undefined') {
+  pointerTargets.push(Window.prototype as Partial<Record<string, unknown>>);
+}
+
+pointerTargets.forEach((proto) => {
+  if (!('setPointerCapture' in proto)) {
+    Object.defineProperty(proto, 'setPointerCapture', {
+      value: () => {},
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  if (!('releasePointerCapture' in proto)) {
+    Object.defineProperty(proto, 'releasePointerCapture', {
+      value: () => {},
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  if (!('hasPointerCapture' in proto)) {
+    Object.defineProperty(proto, 'hasPointerCapture', {
+      value: () => false,
+      configurable: true,
+      writable: true,
+    });
+  }
+});
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+describe('WorkspaceConfigView secret suggestions', () => {
+  it('selects a secret suggestion and preserves canonical value', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    let cfg: Record<string, unknown> = {};
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <WorkspaceConfigView
+          templateName="workspace"
+          value={{}}
+          onChange={(v) => (cfg = v)}
+          readOnly={false}
+          disabled={false}
+        />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Add env'));
+    fireEvent.change(screen.getByTestId('env-name-0'), { target: { value: 'DB_SECRET' } });
+
+    const envField = screen.getByTestId('env-value-0').parentElement?.parentElement;
+    if (!envField) throw new Error('Env field container not found');
+    const sourceTrigger = within(envField).getByRole('combobox');
+    sourceTrigger.focus();
+    await user.keyboard('{ArrowDown}');
+    const secretOption = await screen.findByRole('option', { name: /secret/i });
+    await user.click(secretOption);
+
+    const valueInput = screen.getByTestId('env-value-0');
+    await user.click(valueInput);
+    const suggestion = await screen.findByText('kv/workspace/db');
+    await user.click(suggestion);
+
+    expect(cfg.env?.[0]).toMatchObject({
+      name: 'DB_SECRET',
+      source: 'vault',
+    });
+    expect(cfg.env?.[0]?.value).toEqual({ kind: 'vault', mount: 'kv', path: 'workspace', key: 'db' });
+  });
+});

--- a/packages/platform-ui/src/components/ReferenceInput.tsx
+++ b/packages/platform-ui/src/components/ReferenceInput.tsx
@@ -52,11 +52,11 @@ export function ReferenceInput({
 
   // Filter keys based on input value
   const inputValue = (props.value as string) || '';
-  const filteredKeys = sourceType === 'secret' && inputValue
-    ? secretKeys.filter(key => key.toLowerCase().includes(inputValue.toLowerCase()))
-    : sourceType === 'variable' && inputValue
-    ? variableKeys.filter(key => key.toLowerCase().includes(inputValue.toLowerCase()))
-    : [];
+  const baseKeys = sourceType === 'secret' ? secretKeys : sourceType === 'variable' ? variableKeys : [];
+  const normalizedInput = inputValue.trim().toLowerCase();
+  const filteredKeys = normalizedInput.length === 0
+    ? baseKeys
+    : baseKeys.filter((key) => key.toLowerCase().includes(normalizedInput));
 
   // Handle click outside to close autocomplete
   useEffect(() => {

--- a/packages/platform-ui/src/components/__tests__/ReferenceInput.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/ReferenceInput.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { useState } from 'react';
+
+import { ReferenceInput } from '../ReferenceInput';
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+describe('ReferenceInput', () => {
+  const secretKeys = ['secret/app/token', 'secret/app/alt'];
+  const variableKeys = ['SLACK_APP_TOKEN', 'SLACK_BOT_TOKEN'];
+
+  function SecretWrapper() {
+    const [value, setValue] = useState('');
+    return (
+      <ReferenceInput
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        sourceType="secret"
+        secretKeys={secretKeys}
+        placeholder="Enter secret"
+      />
+    );
+  }
+
+  function ModeWrapper() {
+    const [value, setValue] = useState('');
+    const [sourceType, setSourceType] = useState<'text' | 'secret' | 'variable'>('secret');
+    return (
+      <ReferenceInput
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        sourceType={sourceType}
+        onSourceTypeChange={setSourceType}
+        secretKeys={secretKeys}
+        variableKeys={variableKeys}
+        placeholder="Select reference"
+      />
+    );
+  }
+
+  it('shows all suggestions on focus for the active source type', async () => {
+    const user = userEvent.setup();
+    render(<SecretWrapper />);
+
+    const input = screen.getByPlaceholderText('Enter secret');
+    await user.click(input);
+
+    expect(await screen.findByText('secret/app/token')).toBeInTheDocument();
+    expect(screen.getByText('secret/app/alt')).toBeInTheDocument();
+  });
+
+  it('filters suggestions as the user types', async () => {
+    const user = userEvent.setup();
+    render(<SecretWrapper />);
+
+    const input = screen.getByPlaceholderText('Enter secret');
+    await user.click(input);
+    await user.type(input, 'alt');
+
+    expect(await screen.findByText('secret/app/alt')).toBeInTheDocument();
+    expect(screen.queryByText('secret/app/token')).not.toBeInTheDocument();
+  });
+
+  it('switches modes and shows suggestions for the selected source', async () => {
+    const user = userEvent.setup();
+    render(<ModeWrapper />);
+
+    const input = screen.getByPlaceholderText('Select reference');
+    await user.click(input);
+    expect(await screen.findByText('secret/app/token')).toBeInTheDocument();
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    const variableOption = await screen.findByText('Variable');
+    await user.click(variableOption);
+
+    await user.click(input);
+
+    expect(await screen.findByText('SLACK_APP_TOKEN')).toBeInTheDocument();
+    expect(screen.getByText('SLACK_BOT_TOKEN')).toBeInTheDocument();
+    expect(screen.queryByText('secret/app/token')).not.toBeInTheDocument();
+
+    await user.type(input, 'bot');
+    expect(await screen.findByText('SLACK_BOT_TOKEN')).toBeInTheDocument();
+    expect(screen.queryByText('SLACK_APP_TOKEN')).not.toBeInTheDocument();
+  });
+});

--- a/packages/platform-ui/src/components/configViews/GithubCloneRepoToolConfigView.tsx
+++ b/packages/platform-ui/src/components/configViews/GithubCloneRepoToolConfigView.tsx
@@ -8,6 +8,8 @@ import type { StaticConfigViewProps } from './types';
 import ReferenceField from './shared/ReferenceField';
 import { ToolNameLabel } from './shared/ToolNameLabel';
 import { normalizeReferenceValue, readReferenceDetails } from './shared/referenceUtils';
+import { useSecretKeyOptions } from './shared/useSecretKeyOptions';
+import { useVariableKeyOptions } from './shared/useVariableKeyOptions';
 
 function isVaultRef(v: string) {
   // Expect mount/path/key with no leading slash
@@ -17,6 +19,8 @@ function isVaultRef(v: string) {
 export default function GithubCloneRepoToolConfigView({ value, onChange, readOnly, disabled }: StaticConfigViewProps) {
   const tokenRaw = value['token'];
   const nameRaw = value['name'];
+  const secretKeys = useSecretKeyOptions();
+  const variableKeys = useVariableKeyOptions();
 
   const normalizedToken = useMemo(() => normalizeReferenceValue(tokenRaw), [tokenRaw]);
   const [token, setToken] = useState<ReferenceConfigValue>(normalizedToken);
@@ -86,6 +90,8 @@ export default function GithubCloneRepoToolConfigView({ value, onChange, readOnl
         onChange={setToken}
         readOnly={readOnly}
         disabled={disabled}
+        secretKeys={secretKeys}
+        variableKeys={variableKeys}
         helpText="When using vault, value should be 'mount/path/key'."
       />
       {errors.length > 0 && <div className="text-[10px] text-red-600">{errors.join(', ')}</div>}

--- a/packages/platform-ui/src/components/configViews/SendSlackMessageToolConfigView.tsx
+++ b/packages/platform-ui/src/components/configViews/SendSlackMessageToolConfigView.tsx
@@ -2,9 +2,12 @@ import { useEffect, useMemo, useState, type ChangeEvent } from 'react';
 import { Input } from '@/components/ui/input';
 import { getCanonicalToolName } from '@/components/nodeProperties/toolCanonicalNames';
 import { isValidToolName } from '@/components/nodeProperties/utils';
+import type { ReferenceConfigValue } from '@/components/nodeProperties/types';
+import { deepEqual } from '@/lib/utils';
 import type { StaticConfigViewProps } from './types';
-import ReferenceField, { type ReferenceValue } from './shared/ReferenceField';
+import ReferenceField from './shared/ReferenceField';
 import { ToolNameLabel } from './shared/ToolNameLabel';
+import { normalizeReferenceValue, readReferenceDetails } from './shared/referenceUtils';
 
 function isVaultRef(v: string) {
   // Expect mount/path/key
@@ -12,58 +15,74 @@ function isVaultRef(v: string) {
 }
 
 export default function SendSlackMessageToolConfigView({ value, onChange, readOnly, disabled, onValidate }: StaticConfigViewProps) {
-  const init = useMemo(() => ({ ...(value || {}) }), [value]);
-  const [default_channel, setDefaultChannel] = useState<string>(() => {
-    const dc = (init as Record<string, unknown>)['default_channel'];
-    return typeof dc === 'string' ? dc : '';
-  });
-  const [bot_token, setBotToken] = useState<ReferenceValue | string>(() => {
-    const t = (init as Record<string, unknown>)['bot_token'];
-    if (!t) return '';
-    if (typeof t === 'string') return t;
-    if (t && typeof t === 'object' && 'value' in (t as Record<string, unknown>)) return t as ReferenceValue;
-    return '';
-  });
+  const defaultChannelRaw = value['default_channel'];
+  const botTokenRaw = value['bot_token'];
+  const rawName = value['name'];
+  const currentDefaultChannel = typeof defaultChannelRaw === 'string' ? defaultChannelRaw : '';
+  const currentBotToken = botTokenRaw;
+  const currentName = typeof rawName === 'string' ? rawName : undefined;
+
+  const [default_channel, setDefaultChannel] = useState<string>(currentDefaultChannel);
+  const normalizedBotToken = useMemo(() => normalizeReferenceValue(botTokenRaw), [botTokenRaw]);
+  const [bot_token, setBotToken] = useState<ReferenceConfigValue>(normalizedBotToken);
   const [errors, setErrors] = useState<string[]>([]);
-  const [name, setName] = useState<string>((init.name as string) || '');
+  const [name, setName] = useState<string>(currentName ?? '');
   const [nameError, setNameError] = useState<string | null>(null);
   const isDisabled = !!readOnly || !!disabled;
   const namePlaceholder = getCanonicalToolName('sendSlackMessageTool') || 'send_slack_message';
 
   useEffect(() => {
+    setDefaultChannel(currentDefaultChannel);
+  }, [currentDefaultChannel]);
+
+  useEffect(() => {
+    setBotToken(normalizedBotToken);
+  }, [normalizedBotToken]);
+
+  useEffect(() => {
+    setName(currentName ?? '');
+  }, [currentName]);
+
+  const botDetails = useMemo(() => readReferenceDetails(bot_token), [bot_token]);
+
+  useEffect(() => {
     const errors: string[] = [];
-    const bt = typeof bot_token === 'string' ? { value: bot_token, source: 'static' as const } : (bot_token as ReferenceValue);
-    if ((bt.value || '').length === 0) errors.push('bot_token is required');
-    if ((bt.source || 'static') === 'static' && bt.value && !bt.value.startsWith('xoxb-')) errors.push('bot_token must start with xoxb-');
-    if ((bt.source || 'static') === 'vault' && bt.value && !isVaultRef(bt.value)) errors.push('bot_token vault ref must be mount/path/key');
+    const trimmedToken = botDetails.value.trim();
+    if (!trimmedToken.length) errors.push('bot_token is required');
+    if (botDetails.sourceType === 'text' && trimmedToken && !trimmedToken.startsWith('xoxb-')) errors.push('bot_token must start with xoxb-');
+    if (botDetails.sourceType === 'secret' && trimmedToken && !isVaultRef(trimmedToken)) errors.push('bot_token vault ref must be mount/path/key');
+    if (botDetails.sourceType === 'variable' && !trimmedToken.length) errors.push('bot_token variable name is required');
     if (name.trim().length > 0 && !isValidToolName(name.trim())) errors.push('Name must match ^[a-z0-9_]{1,64}$');
     setErrors(errors);
     onValidate?.(errors);
-  }, [bot_token, name, onValidate]);
+  }, [botDetails.value, botDetails.sourceType, name, onValidate]);
 
   useEffect(() => {
-    const token = typeof bot_token === 'string' ? { value: bot_token, source: 'static' as const } : (bot_token as ReferenceValue);
-    const trimmedName = name.trim();
+    const trimmed = name.trim();
+    if (!trimmed.length) {
+      setNameError(null);
+      return;
+    }
+    setNameError(isValidToolName(trimmed) ? null : 'Name must match ^[a-z0-9_]{1,64}$');
+  }, [name]);
+
+  useEffect(() => {
+    const trimmed = name.trim();
     let nextName: string | undefined;
-    if (trimmedName.length === 0) {
-      setNameError(null);
+    if (trimmed.length === 0) {
       nextName = undefined;
-    } else if (isValidToolName(trimmedName)) {
-      setNameError(null);
-      nextName = trimmedName;
+    } else if (isValidToolName(trimmed)) {
+      nextName = trimmed;
     } else {
-      setNameError('Name must match ^[a-z0-9_]{1,64}$');
-      nextName = typeof init.name === 'string' ? (init.name as string) : undefined;
+      nextName = currentName;
     }
 
-    const next = { ...value, bot_token: token, default_channel, name: nextName };
-    if (JSON.stringify(value || {}) !== JSON.stringify(next)) onChange(next);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bot_token, default_channel, name]);
+    if (deepEqual(currentBotToken, bot_token) && currentDefaultChannel === default_channel && currentName === nextName) {
+      return;
+    }
 
-  useEffect(() => {
-    setName((init.name as string) || '');
-  }, [init]);
+    onChange({ ...value, bot_token, default_channel, name: nextName });
+  }, [bot_token, currentBotToken, default_channel, currentDefaultChannel, name, currentName, onChange, value]);
 
   return (
     <div className="space-y-3 text-sm">
@@ -80,10 +99,9 @@ export default function SendSlackMessageToolConfigView({ value, onChange, readOn
       <ReferenceField
         label="Bot token"
         value={bot_token}
-        onChange={(v: ReferenceValue | string) => setBotToken(v)}
+        onChange={setBotToken}
         readOnly={readOnly}
         disabled={disabled}
-        placeholder="xoxb-... or mount/path/key"
         helpText="Use source=vault to reference a secret as mount/path/key."
       />
       {errors.length > 0 && <div className="text-[10px] text-red-600">{errors.join(', ')}</div>}

--- a/packages/platform-ui/src/components/configViews/SendSlackMessageToolConfigView.tsx
+++ b/packages/platform-ui/src/components/configViews/SendSlackMessageToolConfigView.tsx
@@ -8,6 +8,8 @@ import type { StaticConfigViewProps } from './types';
 import ReferenceField from './shared/ReferenceField';
 import { ToolNameLabel } from './shared/ToolNameLabel';
 import { normalizeReferenceValue, readReferenceDetails } from './shared/referenceUtils';
+import { useSecretKeyOptions } from './shared/useSecretKeyOptions';
+import { useVariableKeyOptions } from './shared/useVariableKeyOptions';
 
 function isVaultRef(v: string) {
   // Expect mount/path/key
@@ -18,6 +20,8 @@ export default function SendSlackMessageToolConfigView({ value, onChange, readOn
   const defaultChannelRaw = value['default_channel'];
   const botTokenRaw = value['bot_token'];
   const rawName = value['name'];
+  const secretKeys = useSecretKeyOptions();
+  const variableKeys = useVariableKeyOptions();
   const currentDefaultChannel = typeof defaultChannelRaw === 'string' ? defaultChannelRaw : '';
   const currentBotToken = botTokenRaw;
   const currentName = typeof rawName === 'string' ? rawName : undefined;
@@ -102,6 +106,8 @@ export default function SendSlackMessageToolConfigView({ value, onChange, readOn
         onChange={setBotToken}
         readOnly={readOnly}
         disabled={disabled}
+        secretKeys={secretKeys}
+        variableKeys={variableKeys}
         helpText="Use source=vault to reference a secret as mount/path/key."
       />
       {errors.length > 0 && <div className="text-[10px] text-red-600">{errors.join(', ')}</div>}

--- a/packages/platform-ui/src/components/configViews/SlackTriggerConfigView.tsx
+++ b/packages/platform-ui/src/components/configViews/SlackTriggerConfigView.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
+import type { ReferenceConfigValue } from '@/components/nodeProperties/types';
+import { deepEqual } from '@/lib/utils';
 import type { StaticConfigViewProps } from './types';
-import ReferenceField, { type ReferenceValue } from './shared/ReferenceField';
+import ReferenceField from './shared/ReferenceField';
+import { normalizeReferenceValue, readReferenceDetails } from './shared/referenceUtils';
 
 function isVaultRef(v: string) {
   // Expect mount/path/key
@@ -8,61 +11,66 @@ function isVaultRef(v: string) {
 }
 
 export default function SlackTriggerConfigView({ value, onChange, readOnly, disabled, onValidate }: StaticConfigViewProps) {
-  const init = useMemo(() => ({ ...(value || {}) }), [value]);
-  const [app_token, setAppToken] = useState<ReferenceValue | string>(() => {
-    const t = (init as Record<string, unknown>)['app_token'];
-    if (!t) return '';
-    if (typeof t === 'string') return t;
-    if (t && typeof t === 'object' && 'value' in (t as Record<string, unknown>)) return t as ReferenceValue;
-    return '';
-  });
-  const [bot_token, setBotToken] = useState<ReferenceValue | string>(() => {
-    const t = (init as Record<string, unknown>)['bot_token'];
-    if (!t) return '';
-    if (typeof t === 'string') return t;
-    if (t && typeof t === 'object' && 'value' in (t as Record<string, unknown>)) return t as ReferenceValue;
-    return '';
-  });
+  const appTokenRaw = value['app_token'];
+  const botTokenRaw = value['bot_token'];
+
+  const normalizedAppToken = useMemo(() => normalizeReferenceValue(appTokenRaw), [appTokenRaw]);
+  const normalizedBotToken = useMemo(() => normalizeReferenceValue(botTokenRaw), [botTokenRaw]);
+
+  const [appToken, setAppToken] = useState<ReferenceConfigValue>(normalizedAppToken);
+  const [botToken, setBotToken] = useState<ReferenceConfigValue>(normalizedBotToken);
+
+  useEffect(() => {
+    setAppToken(normalizedAppToken);
+  }, [normalizedAppToken]);
+
+  useEffect(() => {
+    setBotToken(normalizedBotToken);
+  }, [normalizedBotToken]);
+
+  const appDetails = useMemo(() => readReferenceDetails(appToken), [appToken]);
+  const botDetails = useMemo(() => readReferenceDetails(botToken), [botToken]);
 
   useEffect(() => {
     const errors: string[] = [];
-    const at = typeof app_token === 'string' ? { value: app_token, source: 'static' as const } : (app_token as ReferenceValue);
-    if ((at.value || '').length === 0) errors.push('app_token is required');
-    if ((at.source || 'static') === 'static' && at.value && !at.value.startsWith('xapp-')) errors.push('app_token must start with xapp-');
-    if ((at.source || 'static') === 'vault' && at.value && !isVaultRef(at.value)) errors.push('app_token vault ref must be mount/path/key');
-    const bt = typeof bot_token === 'string' ? { value: bot_token, source: 'static' as const } : (bot_token as ReferenceValue);
-    if ((bt.value || '').length === 0) errors.push('bot_token is required');
-    if ((bt.source || 'static') === 'static' && bt.value && !bt.value.startsWith('xoxb-')) errors.push('bot_token must start with xoxb-');
-    if ((bt.source || 'static') === 'vault' && bt.value && !isVaultRef(bt.value)) errors.push('bot_token vault ref must be mount/path/key');
+    const trimmedApp = appDetails.value.trim();
+    const trimmedBot = botDetails.value.trim();
+
+    if (!trimmedApp.length) errors.push('app_token is required');
+    if (appDetails.sourceType === 'text' && trimmedApp && !trimmedApp.startsWith('xapp-')) errors.push('app_token must start with xapp-');
+    if (appDetails.sourceType === 'secret' && trimmedApp && !isVaultRef(trimmedApp)) errors.push('app_token vault ref must be mount/path/key');
+    if (appDetails.sourceType === 'variable' && !trimmedApp.length) errors.push('app_token variable name is required');
+
+    if (!trimmedBot.length) errors.push('bot_token is required');
+    if (botDetails.sourceType === 'text' && trimmedBot && !trimmedBot.startsWith('xoxb-')) errors.push('bot_token must start with xoxb-');
+    if (botDetails.sourceType === 'secret' && trimmedBot && !isVaultRef(trimmedBot)) errors.push('bot_token vault ref must be mount/path/key');
+    if (botDetails.sourceType === 'variable' && !trimmedBot.length) errors.push('bot_token variable name is required');
     onValidate?.(errors);
-  }, [app_token, bot_token, onValidate]);
+  }, [appDetails.value, appDetails.sourceType, botDetails.value, botDetails.sourceType, onValidate]);
 
   useEffect(() => {
-    const at = typeof app_token === 'string' ? { value: app_token, source: 'static' as const } : (app_token as ReferenceValue);
-    const bt = typeof bot_token === 'string' ? { value: bot_token, source: 'static' as const } : (bot_token as ReferenceValue);
-    const next = { ...value, app_token: at, bot_token: bt };
-    if (JSON.stringify(value || {}) !== JSON.stringify(next)) onChange(next);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [app_token, bot_token]);
+    const currentApp = value['app_token'];
+    const currentBot = value['bot_token'];
+    if (deepEqual(currentApp, appToken) && deepEqual(currentBot, botToken)) return;
+    onChange({ ...value, app_token: appToken, bot_token: botToken });
+  }, [appToken, botToken, onChange, value]);
 
   return (
     <div className="space-y-3 text-sm">
       <ReferenceField
         label="App token"
-        value={app_token}
-        onChange={(v) => setAppToken(v)}
+        value={appToken}
+        onChange={setAppToken}
         readOnly={readOnly}
         disabled={disabled}
-        placeholder="xapp-... or mount/path/key"
         helpText="Use source=vault to reference a secret as mount/path/key. Must start with xapp- for static."
       />
       <ReferenceField
         label="Bot token"
-        value={bot_token}
-        onChange={(v) => setBotToken(v)}
+        value={botToken}
+        onChange={setBotToken}
         readOnly={readOnly}
         disabled={disabled}
-        placeholder="xoxb-... or mount/path/key"
         helpText="Use source=vault to reference a secret as mount/path/key. Must start with xoxb- for static."
       />
     </div>

--- a/packages/platform-ui/src/components/configViews/SlackTriggerConfigView.tsx
+++ b/packages/platform-ui/src/components/configViews/SlackTriggerConfigView.tsx
@@ -4,6 +4,8 @@ import { deepEqual } from '@/lib/utils';
 import type { StaticConfigViewProps } from './types';
 import ReferenceField from './shared/ReferenceField';
 import { normalizeReferenceValue, readReferenceDetails } from './shared/referenceUtils';
+import { useSecretKeyOptions } from './shared/useSecretKeyOptions';
+import { useVariableKeyOptions } from './shared/useVariableKeyOptions';
 
 function isVaultRef(v: string) {
   // Expect mount/path/key
@@ -13,6 +15,8 @@ function isVaultRef(v: string) {
 export default function SlackTriggerConfigView({ value, onChange, readOnly, disabled, onValidate }: StaticConfigViewProps) {
   const appTokenRaw = value['app_token'];
   const botTokenRaw = value['bot_token'];
+  const secretKeys = useSecretKeyOptions();
+  const variableKeys = useVariableKeyOptions();
 
   const normalizedAppToken = useMemo(() => normalizeReferenceValue(appTokenRaw), [appTokenRaw]);
   const normalizedBotToken = useMemo(() => normalizeReferenceValue(botTokenRaw), [botTokenRaw]);
@@ -63,6 +67,8 @@ export default function SlackTriggerConfigView({ value, onChange, readOnly, disa
         onChange={setAppToken}
         readOnly={readOnly}
         disabled={disabled}
+        secretKeys={secretKeys}
+        variableKeys={variableKeys}
         helpText="Use source=vault to reference a secret as mount/path/key. Must start with xapp- for static."
       />
       <ReferenceField
@@ -71,6 +77,8 @@ export default function SlackTriggerConfigView({ value, onChange, readOnly, disa
         onChange={setBotToken}
         readOnly={readOnly}
         disabled={disabled}
+        secretKeys={secretKeys}
+        variableKeys={variableKeys}
         helpText="Use source=vault to reference a secret as mount/path/key. Must start with xoxb- for static."
       />
     </div>

--- a/packages/platform-ui/src/components/configViews/WorkspaceConfigView.tsx
+++ b/packages/platform-ui/src/components/configViews/WorkspaceConfigView.tsx
@@ -4,6 +4,8 @@ import type { EnvVar } from '@/components/nodeProperties/types';
 import { readEnvList, serializeEnvVars } from '@/components/nodeProperties/utils';
 import type { StaticConfigViewProps } from './types';
 import ReferenceEnvField from './shared/ReferenceEnvField';
+import { useSecretKeyOptions } from './shared/useSecretKeyOptions';
+import { useVariableKeyOptions } from './shared/useVariableKeyOptions';
 
 type VolumesFormState = {
   enabled: boolean;
@@ -27,6 +29,8 @@ export default function WorkspaceConfigView({ value, onChange, readOnly, disable
   const init = useMemo<Record<string, unknown>>(() => ({ ...(value || {}) }), [value]);
   const [image, setImage] = useState<string>((init.image as string) || '');
   const [env, setEnv] = useState<EnvVar[]>(() => readEnvList(init.env));
+  const secretKeys = useSecretKeyOptions();
+  const variableKeys = useVariableKeyOptions();
   const [initialScript, setInitialScript] = useState<string>((init.initialScript as string) || '');
   const [cpuLimit, setCpuLimit] = useState<string>(() => {
     const raw = init.cpu_limit as unknown;
@@ -97,7 +101,16 @@ export default function WorkspaceConfigView({ value, onChange, readOnly, disable
       </div>
       <div>
         <div className="text-xs mb-1">Environment</div>
-        <ReferenceEnvField value={env} onChange={(next) => setEnv(next)} readOnly={readOnly} disabled={disabled} addLabel="Add env" onValidate={onValidate} />
+        <ReferenceEnvField
+          value={env}
+          onChange={(next) => setEnv(next)}
+          readOnly={readOnly}
+          disabled={disabled}
+          addLabel="Add env"
+          onValidate={onValidate}
+          secretKeys={secretKeys}
+          variableKeys={variableKeys}
+        />
       </div>
       <div>
         <label htmlFor="initialScript" className="block text-xs mb-1">Initial script (optional)</label>

--- a/packages/platform-ui/src/components/configViews/shared/ReferenceField.tsx
+++ b/packages/platform-ui/src/components/configViews/shared/ReferenceField.tsx
@@ -1,65 +1,108 @@
-import { useEffect, useMemo, useState, type ChangeEvent } from 'react';
-import { Input } from '@/components/ui/input';
+import { useCallback, useEffect, useMemo, useState, type FocusEventHandler } from 'react';
+import { ReferenceInput } from '@/components/ReferenceInput';
 import { Label } from '@/components/ui/label';
-
-export type ReferenceValue = { value: string; source?: 'static' | 'vault' };
+import type { ReferenceConfigValue } from '@/components/nodeProperties/types';
+import {
+  encodeReferenceValue,
+  inferReferenceSource,
+  readReferenceValue,
+  type ReferenceSourceType,
+  writeReferenceValue,
+} from '@/components/nodeProperties/utils';
+import { normalizeReferenceValue, type LegacyReferenceValue } from './referenceUtils';
 
 export interface ReferenceFieldProps {
   label?: string;
-  value?: ReferenceValue | string;
-  onChange: (next: ReferenceValue) => void;
+  value?: ReferenceConfigValue | LegacyReferenceValue | string | null;
+  onChange: (next: ReferenceConfigValue) => void;
   readOnly?: boolean;
   disabled?: boolean;
   placeholder?: string;
   helpText?: string;
+  secretKeys?: string[];
+  variableKeys?: string[];
+  size?: 'sm' | 'default';
+  onFocus?: FocusEventHandler<HTMLInputElement>;
+  onBlur?: FocusEventHandler<HTMLInputElement>;
 }
 
-/**
- * ReferenceField allows choosing between static value and vault reference.
- * Emits normalized shape { value, source } with default source 'static'.
- */
-export default function ReferenceField({ label, value, onChange, readOnly, disabled, placeholder, helpText }: ReferenceFieldProps) {
-  const init = useMemo<ReferenceValue>(() => {
-    if (!value) return { value: '', source: 'static' };
-    if (typeof value === 'string') return { value, source: 'static' };
-    return { value: value.value || '', source: value.source || 'static' };
-  }, [value]);
-
-  const [val, setVal] = useState<string>(init.value);
-  const [source, setSource] = useState<'static' | 'vault'>(init.source || 'static');
-  // no masked/unmasked behavior
-
+export default function ReferenceField({
+  label,
+  value,
+  onChange,
+  readOnly,
+  disabled,
+  placeholder,
+  helpText,
+  secretKeys = [],
+  variableKeys = [],
+  size = 'sm',
+  onFocus,
+  onBlur,
+}: ReferenceFieldProps) {
+  const normalized = useMemo(() => normalizeReferenceValue(value), [value]);
+  const [rawValue, setRawValue] = useState<ReferenceConfigValue>(normalized);
+  const [sourceType, setSourceType] = useState<ReferenceSourceType>(() => inferReferenceSource(normalized));
+  const reference = useMemo(() => readReferenceValue(rawValue), [rawValue]);
   const isDisabled = !!readOnly || !!disabled;
 
   useEffect(() => {
-    onChange({ value: val, source });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [val, source]);
+    setRawValue(normalized);
+  }, [normalized]);
+
+  useEffect(() => {
+    setSourceType(inferReferenceSource(rawValue));
+  }, [rawValue]);
+
+  const handleValueChange = useCallback(
+    (next: string) => {
+      setRawValue((prev) => {
+        const nextRaw = writeReferenceValue(prev, next, sourceType);
+        onChange(nextRaw);
+        return nextRaw;
+      });
+    },
+    [onChange, sourceType],
+  );
+
+  const handleSourceTypeChange = useCallback(
+    (nextType: ReferenceSourceType) => {
+      setSourceType(nextType);
+      setRawValue((prev) => {
+        const nextRaw = encodeReferenceValue(nextType, '', prev);
+        onChange(nextRaw);
+        return nextRaw;
+      });
+    },
+    [onChange],
+  );
+
+  const computedPlaceholder = useMemo(() => {
+    if (placeholder) return placeholder;
+    if (sourceType === 'secret') return 'mount/path/key';
+    if (sourceType === 'variable') return 'VARIABLE_NAME';
+    return '';
+  }, [placeholder, sourceType]);
 
   return (
     <div className="space-y-1">
       {label ? <Label className="text-xs">{label}</Label> : null}
-      <div className="flex items-center gap-2">
-        <select
-          className="border rounded px-2 py-1 text-xs bg-background"
-          value={source}
-          onChange={(e: ChangeEvent<HTMLSelectElement>) => setSource((e.target.value as 'static' | 'vault') || 'static')}
-          disabled={isDisabled}
-          data-testid="ref-source"
-        >
-          <option value="static">static</option>
-          <option value="vault">vault</option>
-        </select>
-        <Input
-          className="text-xs flex-1"
-          value={val}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setVal(e.target.value)}
-          disabled={isDisabled}
-          placeholder={placeholder || (source === 'vault' ? 'mount/path/key' : '')}
-          data-testid="ref-value"
-        />
-      </div>
-      {helpText ? <div className="text-[10px] text-muted-foreground">{helpText}</div> : null}
+      <ReferenceInput
+        value={reference.value}
+        onChange={(event) => handleValueChange(event.target.value)}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        disabled={isDisabled}
+        readOnly={readOnly}
+        placeholder={computedPlaceholder}
+        sourceType={sourceType}
+        onSourceTypeChange={handleSourceTypeChange}
+        secretKeys={secretKeys}
+        variableKeys={variableKeys}
+        size={size}
+        className="text-xs"
+      />
+      {!helpText ? null : <div className="text-[10px] text-muted-foreground">{helpText}</div>}
     </div>
   );
 }

--- a/packages/platform-ui/src/components/configViews/shared/__tests__/ReferenceField.test.tsx
+++ b/packages/platform-ui/src/components/configViews/shared/__tests__/ReferenceField.test.tsx
@@ -1,21 +1,54 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ReferenceField from '../ReferenceField';
 
+const pointerProto = Element.prototype as unknown as {
+  hasPointerCapture?: (pointerId: number) => boolean;
+  setPointerCapture?: (pointerId: number) => void;
+  releasePointerCapture?: (pointerId: number) => void;
+};
+
+if (!pointerProto.hasPointerCapture) {
+  pointerProto.hasPointerCapture = () => false;
+}
+if (!pointerProto.setPointerCapture) {
+  pointerProto.setPointerCapture = () => {};
+}
+if (!pointerProto.releasePointerCapture) {
+  pointerProto.releasePointerCapture = () => {};
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
 describe('ReferenceField', () => {
-  it('emits normalized shape for string input', () => {
-    let last: any = null;
+  it('emits canonical vault structure when switching source', async () => {
+    const user = userEvent.setup();
+    let last: unknown = null;
     render(<ReferenceField value="abc" onChange={(v) => (last = v)} />);
-    // Change source to vault
-    fireEvent.change(screen.getByTestId('ref-source'), { target: { value: 'vault' } });
-    fireEvent.change(screen.getByTestId('ref-value'), { target: { value: 'secret/path/key' } });
-    expect(last).toEqual({ value: 'secret/path/key', source: 'vault' });
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    const listbox = await screen.findByRole('listbox');
+    const secretOption = within(listbox).getByRole('option', { name: /secret/i });
+    await user.click(secretOption);
+
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    fireEvent.change(input, { target: { value: 'secret/data/api' } });
+    expect(last).toMatchObject({ kind: 'vault', path: 'secret/data', key: 'api' });
   });
 
-  it('preserves provided object shape', () => {
-    let last: any = null;
+  it('preserves string output for static references', async () => {
+    const user = userEvent.setup();
+    let last: unknown = null;
     render(<ReferenceField value={{ value: 'xoxb-123', source: 'static' }} onChange={(v) => (last = v)} />);
-    fireEvent.change(screen.getByTestId('ref-value'), { target: { value: 'xoxb-456' } });
-    expect(last).toEqual({ value: 'xoxb-456', source: 'static' });
+
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    await user.type(input, 'xoxb-456');
+
+    expect(last).toBe('xoxb-456');
   });
 });

--- a/packages/platform-ui/src/components/configViews/shared/__tests__/ReferenceField.test.tsx
+++ b/packages/platform-ui/src/components/configViews/shared/__tests__/ReferenceField.test.tsx
@@ -37,7 +37,7 @@ describe('ReferenceField', () => {
     const input = screen.getByRole('textbox');
     await user.clear(input);
     fireEvent.change(input, { target: { value: 'secret/data/api' } });
-    expect(last).toMatchObject({ kind: 'vault', path: 'secret/data', key: 'api' });
+    expect(last).toMatchObject({ kind: 'vault', mount: 'secret', path: 'data', key: 'api' });
   });
 
   it('preserves string output for static references', async () => {

--- a/packages/platform-ui/src/components/configViews/shared/referenceUtils.ts
+++ b/packages/platform-ui/src/components/configViews/shared/referenceUtils.ts
@@ -1,0 +1,41 @@
+import type { ReferenceConfigValue } from '@/components/nodeProperties/types';
+import {
+  encodeReferenceValue,
+  inferReferenceSource,
+  isRecord,
+  readReferenceValue,
+  type ReferenceSourceType,
+} from '@/components/nodeProperties/utils';
+
+export type LegacyReferenceValue = { value?: string; source?: 'static' | 'vault' | 'variable' };
+
+export function normalizeReferenceValue(input: unknown): ReferenceConfigValue {
+  if (input == null) return '';
+  if (typeof input === 'string') return input;
+  if (!isRecord(input)) return '';
+
+  if (typeof input.kind === 'string') {
+    if (input.kind === 'vault' || input.kind === 'var') {
+      return input as ReferenceConfigValue;
+    }
+  }
+
+  const legacy = input as LegacyReferenceValue;
+  const value = typeof legacy.value === 'string' ? legacy.value : '';
+  const source: ReferenceSourceType =
+    legacy.source === 'vault' ? 'secret' : legacy.source === 'variable' ? 'variable' : 'text';
+  return encodeReferenceValue(source, value, input as ReferenceConfigValue);
+}
+
+export function readReferenceDetails(raw: unknown): {
+  value: string;
+  sourceType: ReferenceSourceType;
+  raw: ReferenceConfigValue;
+} {
+  const normalized = normalizeReferenceValue(raw);
+  return {
+    value: readReferenceValue(normalized).value,
+    sourceType: inferReferenceSource(normalized),
+    raw: normalized,
+  };
+}

--- a/packages/platform-ui/src/components/configViews/shared/useSecretKeyOptions.ts
+++ b/packages/platform-ui/src/components/configViews/shared/useSecretKeyOptions.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { listAllSecretPaths } from '@/features/secrets/utils/flatVault';
+
+const SECRET_SUGGESTION_TTL_MS = 5 * 60 * 1000;
+
+let cachedSecretKeys: string[] | null = null;
+let cachedAt = 0;
+let inflightPromise: Promise<string[]> | null = null;
+
+async function fetchSecretKeys(): Promise<string[]> {
+  const now = Date.now();
+  if (cachedSecretKeys && now - cachedAt < SECRET_SUGGESTION_TTL_MS) {
+    return cachedSecretKeys;
+  }
+
+  if (!inflightPromise) {
+    inflightPromise = listAllSecretPaths()
+      .then((keys) => {
+        cachedSecretKeys = Array.isArray(keys) ? keys : [];
+        cachedAt = Date.now();
+        return cachedSecretKeys;
+      })
+      .catch(() => {
+        cachedSecretKeys = [];
+        cachedAt = Date.now();
+        return cachedSecretKeys;
+      })
+      .finally(() => {
+        inflightPromise = null;
+      });
+  }
+
+  return inflightPromise;
+}
+
+export function useSecretKeyOptions(): string[] {
+  const [secretKeys, setSecretKeys] = useState<string[]>(() => cachedSecretKeys ?? []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchSecretKeys().then((keys) => {
+      if (cancelled) return;
+      setSecretKeys((current) => (current === keys ? current : keys));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return secretKeys;
+}

--- a/packages/platform-ui/src/components/configViews/shared/useVariableKeyOptions.ts
+++ b/packages/platform-ui/src/components/configViews/shared/useVariableKeyOptions.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { listVariables } from '@/features/variables/api';
+
+const VARIABLE_SUGGESTION_TTL_MS = 5 * 60 * 1000;
+
+let cachedVariableKeys: string[] | null = null;
+let variableCachedAt = 0;
+let variableInflightPromise: Promise<string[]> | null = null;
+
+async function fetchVariableKeys(): Promise<string[]> {
+  const now = Date.now();
+  if (cachedVariableKeys && now - variableCachedAt < VARIABLE_SUGGESTION_TTL_MS) {
+    return cachedVariableKeys;
+  }
+
+  if (!variableInflightPromise) {
+    variableInflightPromise = listVariables()
+      .then((items) => {
+        const keys = Array.isArray(items)
+          ? items
+              .map((item) => (typeof item?.key === 'string' ? item.key : ''))
+              .filter((key): key is string => key.length > 0)
+          : [];
+        cachedVariableKeys = keys;
+        variableCachedAt = Date.now();
+        return cachedVariableKeys;
+      })
+      .catch(() => {
+        cachedVariableKeys = [];
+        variableCachedAt = Date.now();
+        return cachedVariableKeys;
+      })
+      .finally(() => {
+        variableInflightPromise = null;
+      });
+  }
+
+  return variableInflightPromise;
+}
+
+export function useVariableKeyOptions(): string[] {
+  const [variableKeys, setVariableKeys] = useState<string[]>(() => cachedVariableKeys ?? []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchVariableKeys().then((keys) => {
+      if (cancelled) return;
+      setVariableKeys((current) => (current === keys ? current : keys));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return variableKeys;
+}

--- a/packages/platform-ui/src/components/nodeProperties/TriggerSection.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/TriggerSection.tsx
@@ -1,24 +1,35 @@
 import { FieldLabel } from './FieldLabel';
 import { ReferenceInput } from '../ReferenceInput';
+import type { ReferenceSourceType } from './utils';
 
 interface TriggerSectionProps {
   appToken: string;
+  appTokenSourceType: ReferenceSourceType;
   botToken: string;
+  botTokenSourceType: ReferenceSourceType;
   onAppTokenChange: (value: string) => void;
+  onAppTokenSourceTypeChange: (type: ReferenceSourceType) => void;
   onAppTokenFocus: () => void;
   onBotTokenChange: (value: string) => void;
+  onBotTokenSourceTypeChange: (type: ReferenceSourceType) => void;
   onBotTokenFocus: () => void;
   secretSuggestions: string[];
+  variableSuggestions: string[];
 }
 
 export function TriggerSection({
   appToken,
+  appTokenSourceType,
   botToken,
+  botTokenSourceType,
   onAppTokenChange,
+  onAppTokenSourceTypeChange,
   onAppTokenFocus,
   onBotTokenChange,
+  onBotTokenSourceTypeChange,
   onBotTokenFocus,
   secretSuggestions,
+  variableSuggestions,
 }: TriggerSectionProps) {
   return (
     <section>
@@ -30,8 +41,10 @@ export function TriggerSection({
             value={appToken}
             onChange={(event) => onAppTokenChange(event.target.value)}
             onFocus={onAppTokenFocus}
-            sourceType="secret"
+            sourceType={appTokenSourceType}
+            onSourceTypeChange={onAppTokenSourceTypeChange}
             secretKeys={secretSuggestions}
+            variableKeys={variableSuggestions}
             placeholder="Select or enter app token..."
             size="sm"
           />
@@ -42,8 +55,10 @@ export function TriggerSection({
             value={botToken}
             onChange={(event) => onBotTokenChange(event.target.value)}
             onFocus={onBotTokenFocus}
-            sourceType="secret"
+            sourceType={botTokenSourceType}
+            onSourceTypeChange={onBotTokenSourceTypeChange}
             secretKeys={secretSuggestions}
+            variableKeys={variableSuggestions}
             placeholder="Select or enter bot token..."
             size="sm"
           />

--- a/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.trigger.test.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.trigger.test.tsx
@@ -142,7 +142,8 @@ describe('NodePropertiesSidebar Slack trigger references', () => {
     await waitFor(() => {
       expect(latestUpdate(onConfigChange, 'bot_token')).toEqual({
         kind: 'vault',
-        path: 'secret/slack',
+        mount: 'secret',
+        path: 'slack',
         key: 'BOT_SECRET',
       });
     });

--- a/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.trigger.test.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.trigger.test.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import NodePropertiesSidebar from '../index';
+import type { NodeConfig, NodeState } from '../types';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+function renderTriggerSidebar(overrides?: Partial<NodeConfig>) {
+  const onConfigChange = vi.fn();
+  const config: NodeConfig = {
+    kind: 'Trigger',
+    title: 'Slack trigger',
+    template: 'slackTrigger',
+    app_token: { kind: 'vault', mount: 'secret', path: 'slack', key: 'APP_TOKEN' },
+    bot_token: { kind: 'var', name: 'SLACK_BOT_TOKEN' },
+    ...(overrides as Record<string, unknown>),
+  } as NodeConfig;
+
+  const state: NodeState = { status: 'ready' } as NodeState;
+
+  function Harness() {
+    const [currentConfig, setCurrentConfig] = useState<NodeConfig>(config);
+    const handleConfigChange = (patch: Partial<NodeConfig>) => {
+      setCurrentConfig((previous) => ({ ...previous, ...patch }));
+      onConfigChange(patch);
+    };
+
+    return (
+      <TooltipProvider delayDuration={0}>
+        <NodePropertiesSidebar
+          config={currentConfig}
+          state={state}
+          displayTitle={currentConfig.title}
+          onConfigChange={handleConfigChange}
+        />
+      </TooltipProvider>
+    );
+  }
+
+  render(<Harness />);
+
+  const appTokenInput = screen.getByPlaceholderText('Select or enter app token...') as HTMLInputElement;
+  const botTokenInput = screen.getByPlaceholderText('Select or enter bot token...') as HTMLInputElement;
+
+  return { onConfigChange, appTokenInput, botTokenInput };
+}
+
+function latestUpdate(mock: ReturnType<typeof vi.fn>, key: string) {
+  for (let i = mock.mock.calls.length - 1; i >= 0; i -= 1) {
+    const payload = mock.mock.calls[i]?.[0] as Record<string, unknown>;
+    if (payload && Object.prototype.hasOwnProperty.call(payload, key)) {
+      return payload[key];
+    }
+  }
+  return undefined;
+}
+
+describe('NodePropertiesSidebar Slack trigger references', () => {
+  it('loads canonical values, preserves round-trip, and supports mode switching', async () => {
+    const user = userEvent.setup();
+    const { onConfigChange, appTokenInput, botTokenInput } = renderTriggerSidebar();
+
+    expect(appTokenInput).toHaveValue('secret/slack/APP_TOKEN');
+    expect(botTokenInput).toHaveValue('SLACK_BOT_TOKEN');
+
+    onConfigChange.mockClear();
+    await user.clear(appTokenInput);
+    await waitFor(() => expect(appTokenInput).toHaveValue(''));
+    fireEvent.change(appTokenInput, { target: { value: 'secret/slack/NEW_APP_TOKEN' } });
+    await waitFor(() => expect(appTokenInput).toHaveValue('secret/slack/NEW_APP_TOKEN'));
+
+    await waitFor(() => {
+      expect(latestUpdate(onConfigChange, 'app_token')).toEqual({
+        kind: 'vault',
+        mount: 'secret',
+        path: 'slack',
+        key: 'NEW_APP_TOKEN',
+      });
+    });
+
+    onConfigChange.mockClear();
+    await user.clear(botTokenInput);
+    await waitFor(() => expect(botTokenInput).toHaveValue(''));
+    fireEvent.change(botTokenInput, { target: { value: 'SLACK_BOT_TOKEN_UPDATED' } });
+    await waitFor(() => expect(botTokenInput).toHaveValue('SLACK_BOT_TOKEN_UPDATED'));
+
+    await waitFor(() => {
+      expect(latestUpdate(onConfigChange, 'bot_token')).toEqual({
+        kind: 'var',
+        name: 'SLACK_BOT_TOKEN_UPDATED',
+      });
+    });
+
+    const [appSourceTrigger, botSourceTrigger] = screen.getAllByRole('combobox');
+
+    onConfigChange.mockClear();
+    await user.click(appSourceTrigger);
+    const variableOption = await screen.findByText('Variable');
+    await user.click(variableOption);
+
+    await waitFor(() => {
+      expect(appTokenInput).toHaveValue('');
+      expect(latestUpdate(onConfigChange, 'app_token')).toEqual({ kind: 'var', name: '' });
+    });
+
+    onConfigChange.mockClear();
+    fireEvent.change(appTokenInput, { target: { value: 'SLACK_APP_TOKEN_VAR' } });
+    await waitFor(() => expect(appTokenInput).toHaveValue('SLACK_APP_TOKEN_VAR'));
+
+    await waitFor(() => {
+      expect(latestUpdate(onConfigChange, 'app_token')).toEqual({ kind: 'var', name: 'SLACK_APP_TOKEN_VAR' });
+    });
+
+    onConfigChange.mockClear();
+    await user.click(botSourceTrigger);
+    const secretOption = await screen.findByText('Secret');
+    await user.click(secretOption);
+
+    await waitFor(() => {
+      expect(botTokenInput).toHaveValue('');
+      expect(latestUpdate(onConfigChange, 'bot_token')).toEqual({ kind: 'vault', path: '', key: '' });
+    });
+
+    onConfigChange.mockClear();
+    fireEvent.change(botTokenInput, { target: { value: 'secret/slack/BOT_SECRET' } });
+    await waitFor(() => expect(botTokenInput).toHaveValue('secret/slack/BOT_SECRET'));
+
+    await waitFor(() => {
+      expect(latestUpdate(onConfigChange, 'bot_token')).toEqual({
+        kind: 'vault',
+        path: 'secret/slack',
+        key: 'BOT_SECRET',
+      });
+    });
+  });
+});

--- a/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.workspace.env.test.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.workspace.env.test.tsx
@@ -1,0 +1,113 @@
+import React, { useCallback, useState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import NodePropertiesSidebar from '../index';
+import type { NodeConfig, NodePropertiesSidebarProps, NodeState } from '../types';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+const pointerProto = Element.prototype as unknown as {
+  setPointerCapture?: (pointerId: number) => void;
+  releasePointerCapture?: (pointerId: number) => void;
+};
+
+if (!pointerProto.setPointerCapture) {
+  pointerProto.setPointerCapture = () => {};
+}
+
+if (!pointerProto.releasePointerCapture) {
+  pointerProto.releasePointerCapture = () => {};
+}
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+function WorkspaceEnvHarness({
+  initialConfig,
+  onConfigChange,
+  extraProps,
+}: {
+  initialConfig?: Partial<NodeConfig>;
+  onConfigChange: (updates: Partial<NodeConfig>) => void;
+  extraProps?: Partial<NodePropertiesSidebarProps>;
+}) {
+  const [config, setConfig] = useState<NodeConfig>(
+    {
+      kind: 'Workspace',
+      title: 'Workspace Node',
+      env: [
+        {
+          id: 'env-1',
+          name: 'DB_SECRET',
+          value: 'kv/prod/app/TOKEN',
+          source: 'vault',
+        },
+      ],
+      ...(initialConfig as Record<string, unknown>),
+    } as NodeConfig,
+  );
+
+  const handleConfigChange = useCallback(
+    (updates: Partial<NodeConfig>) => {
+      setConfig((prev) => ({ ...prev, ...updates } as NodeConfig));
+      onConfigChange(updates);
+    },
+    [onConfigChange],
+  );
+
+  const state: NodeState = { status: 'ready' } as NodeState;
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <NodePropertiesSidebar
+        config={config}
+        state={state}
+        displayTitle={config.title}
+        onConfigChange={handleConfigChange}
+        tools={[]}
+        enabledTools={[]}
+        {...extraProps}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe('NodePropertiesSidebar workspace env suggestions', () => {
+  it('shows secret suggestions on focus and emits canonical values', async () => {
+    const user = userEvent.setup();
+    const onConfigChange = vi.fn();
+    const ensureSecretKeys = vi.fn().mockResolvedValue(['kv/prod/app/TOKEN', 'kv/prod/app/ALT']);
+
+    render(
+      <WorkspaceEnvHarness
+        onConfigChange={onConfigChange}
+        extraProps={{
+          secretKeys: ['kv/prod/app/TOKEN', 'kv/prod/app/ALT'],
+          ensureSecretKeys,
+        }}
+      />,
+    );
+
+    const valueInput = screen.getAllByPlaceholderText('Value or reference...')[0];
+    await user.click(valueInput);
+
+    await waitFor(() => expect(ensureSecretKeys).toHaveBeenCalled());
+    const suggestion = await screen.findByText('kv/prod/app/ALT');
+    await user.click(suggestion);
+
+    const envCalls = onConfigChange.mock.calls.filter((call) => Array.isArray(call[0]?.env));
+    const lastEnvCall = envCalls.at(-1)?.[0].env as Array<Record<string, unknown>> | undefined;
+    expect(lastEnvCall?.[0]).toMatchObject({
+      name: 'DB_SECRET',
+      source: 'vault',
+      value: {
+        kind: 'vault',
+        mount: 'kv',
+        path: 'prod/app',
+        key: 'ALT',
+      },
+    });
+  });
+});

--- a/packages/platform-ui/src/components/nodeProperties/__tests__/utils.test.ts
+++ b/packages/platform-ui/src/components/nodeProperties/__tests__/utils.test.ts
@@ -157,6 +157,22 @@ describe('nodeProperties utils', () => {
         { name: 'CONFIG', value: { value: 'v2', extra: true } },
       ]);
     });
+
+    it('writes variable references using canonical structure', () => {
+      const initial = readEnvList([
+        { name: 'FROM_VAR', value: { kind: 'var', name: 'SOURCE' }, source: 'variable' },
+      ]);
+      const updated = initial.map((item) =>
+        item.name === 'FROM_VAR'
+          ? { ...item, value: 'TARGET' }
+          : item,
+      );
+
+      const payload = serializeEnvVars(updated);
+      expect(payload).toEqual([
+        { name: 'FROM_VAR', source: 'variable', value: { kind: 'var', name: 'TARGET' } },
+      ]);
+    });
   });
 
   describe('Nix helpers', () => {

--- a/packages/platform-ui/src/components/nodeProperties/types.ts
+++ b/packages/platform-ui/src/components/nodeProperties/types.ts
@@ -81,7 +81,8 @@ export interface NodePropertiesSidebarProps {
     commitHash: string;
     attributePath: string;
   }>;
-  secretSuggestionProvider?: (query: string) => Promise<string[]>;
-  variableSuggestionProvider?: (query: string) => Promise<string[]>;
-  providerDebounceMs?: number;
+  secretKeys?: string[];
+  variableKeys?: string[];
+  ensureSecretKeys?: () => Promise<string[]>;
+  ensureVariableKeys?: () => Promise<string[]>;
 }

--- a/packages/platform-ui/src/components/nodeProperties/utils.inference.test.ts
+++ b/packages/platform-ui/src/components/nodeProperties/utils.inference.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { readEnvList, serializeEnvVars } from './utils';
+
+describe('nodeProperties env inference', () => {
+  it('infers vault and variable sources when source is omitted', () => {
+    const result = readEnvList([
+      { name: 'FROM_SECRET', value: { kind: 'vault', mount: 'kv', path: 'prod/app', key: 'TOKEN' } },
+      { name: 'FROM_VAR', value: { kind: 'var', name: 'GLOBAL_TOKEN' } },
+    ]);
+
+    expect(result[0]).toMatchObject({
+      name: 'FROM_SECRET',
+      source: 'vault',
+      value: 'kv/prod/app/TOKEN',
+    });
+    expect(result[0]?.meta.valueShape).toEqual({
+      kind: 'vault',
+      mount: 'kv',
+      path: 'prod/app',
+      key: 'TOKEN',
+    });
+
+    expect(result[1]).toMatchObject({
+      name: 'FROM_VAR',
+      source: 'variable',
+      value: 'GLOBAL_TOKEN',
+    });
+    expect(result[1]?.meta.valueShape).toEqual({ kind: 'var', name: 'GLOBAL_TOKEN' });
+  });
+
+  it('round trips inferred env entries through serializeEnvVars', () => {
+    const initial = readEnvList([
+      { name: 'DB_SECRET', value: { mount: 'kv', path: 'prod/db', key: 'PASSWORD' } },
+      { name: 'API_VAR', value: { name: 'API_TOKEN' } },
+    ]);
+
+    const payload = serializeEnvVars(initial);
+    expect(payload).toEqual([
+      { name: 'DB_SECRET', source: 'vault', value: { kind: 'vault', mount: 'kv', path: 'prod/db', key: 'PASSWORD' } },
+      { name: 'API_VAR', source: 'variable', value: { kind: 'var', name: 'API_TOKEN' } },
+    ]);
+  });
+});

--- a/packages/platform-ui/src/components/nodeProperties/utils.ts
+++ b/packages/platform-ui/src/components/nodeProperties/utils.ts
@@ -9,14 +9,18 @@ import type {
   WorkspaceNixPackage,
 } from './types';
 
+export type ReferenceSourceType = 'text' | 'secret' | 'variable';
+
 function formatVaultSegments(value: Record<string, unknown>): string {
   const segments: string[] = [];
   const mount = typeof value.mount === 'string' ? value.mount.trim() : undefined;
   const path = typeof value.path === 'string' ? value.path.trim() : undefined;
   const key = typeof value.key === 'string' ? value.key.trim() : undefined;
-  if (mount) segments.push(mount);
-  if (path) segments.push(path);
-  if (key) segments.push(key);
+  const hasPath = Boolean(path && path.length > 0);
+  const hasKey = Boolean(key && key.length > 0);
+  if (mount && (hasPath || hasKey)) segments.push(mount);
+  if (hasPath) segments.push(path as string);
+  if (hasKey) segments.push(key as string);
   if (segments.length === 0 && typeof value.value === 'string') return value.value;
   return segments.join('/');
 }
@@ -52,6 +56,20 @@ function parseVaultString(
 
 function parseVariable(input: string): { kind: 'var'; name: string } {
   return { kind: 'var', name: input.trim() };
+}
+
+function isVaultReferenceValue(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  if (value.kind === 'vault') return true;
+  if (typeof value.source === 'string' && value.source === 'vault') return true;
+  return typeof value.path === 'string' && typeof value.key === 'string';
+}
+
+function isVariableReferenceValue(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  if (value.kind === 'var') return true;
+  if (typeof value.source === 'string' && value.source === 'variable') return true;
+  return typeof value.name === 'string';
 }
 
 const hasStructuredClone = typeof structuredClone === 'function';
@@ -93,6 +111,7 @@ function cloneValueShape(value: unknown): ReferenceConfigValue | undefined {
 
 function buildVaultValue(input: string, previous?: ReferenceConfigValue): Record<string, unknown> {
   const prevMount = isRecord(previous) && typeof previous.mount === 'string' ? previous.mount : undefined;
+  const isEmptyInput = input.trim().length === 0;
   const parsed = parseVaultString(input, prevMount);
   const next = isRecord(previous) ? deepClone(previous) : {};
   const record = next as Record<string, unknown>;
@@ -101,10 +120,14 @@ function buildVaultValue(input: string, previous?: ReferenceConfigValue): Record
   record.key = parsed.key;
   if (parsed.mount) {
     record.mount = parsed.mount;
+  } else if (isEmptyInput && prevMount) {
+    record.mount = prevMount;
   } else {
     delete record.mount;
   }
   delete record.value;
+  delete (record as Record<string, unknown>).name;
+  delete (record as Record<string, unknown>).default;
   return record;
 }
 
@@ -190,6 +213,13 @@ export function mergeWithDefined(base: Record<string, unknown>, updates: Record<
 
 export function readReferenceValue(raw: unknown): { value: string; raw: ReferenceConfigValue } {
   if (typeof raw === 'string') return { value: raw, raw };
+  if (isVaultReferenceValue(raw)) {
+    return { value: formatVaultSegments(raw), raw: raw as Record<string, unknown> };
+  }
+  if (isVariableReferenceValue(raw)) {
+    const name = typeof raw.name === 'string' ? raw.name : typeof raw.value === 'string' ? raw.value : '';
+    return { value: name, raw: raw as Record<string, unknown> };
+  }
   if (isRecord(raw)) {
     const value = typeof raw.value === 'string' ? raw.value : '';
     return { value, raw: raw as Record<string, unknown> };
@@ -197,14 +227,42 @@ export function readReferenceValue(raw: unknown): { value: string; raw: Referenc
   return { value: '', raw: '' };
 }
 
-export function writeReferenceValue(prev: ReferenceConfigValue, nextValue: string): ReferenceConfigValue {
-  if (typeof prev === 'string') {
-    return nextValue;
+export function inferReferenceSource(raw: ReferenceConfigValue | undefined): ReferenceSourceType {
+  if (typeof raw === 'string') return 'text';
+  if (isVaultReferenceValue(raw)) return 'secret';
+  if (isVariableReferenceValue(raw)) return 'variable';
+  if (isRecord(raw) && typeof raw.source === 'string') {
+    if (raw.source === 'vault') return 'secret';
+    if (raw.source === 'variable') return 'variable';
   }
-  if (isRecord(prev)) {
-    return { ...prev, value: nextValue };
+  return 'text';
+}
+
+export function encodeReferenceValue(
+  sourceType: ReferenceSourceType,
+  value: string,
+  previous?: ReferenceConfigValue,
+): ReferenceConfigValue {
+  if (sourceType === 'secret') {
+    const record = buildVaultValue(value, previous);
+    delete record.source;
+    return record;
   }
-  return nextValue;
+  if (sourceType === 'variable') {
+    const record = buildVariableValue(value, previous);
+    delete record.source;
+    return record;
+  }
+  return value;
+}
+
+export function writeReferenceValue(
+  prev: ReferenceConfigValue | undefined,
+  nextValue: string,
+  sourceType?: ReferenceSourceType,
+): ReferenceConfigValue {
+  const inferred = sourceType ?? inferReferenceSource(prev);
+  return encodeReferenceValue(inferred, nextValue, prev);
 }
 
 export function readEnvList(raw: unknown): EnvVar[] {

--- a/packages/platform-ui/src/features/graph/__tests__/GraphLayout.workspace.env.integration.test.tsx
+++ b/packages/platform-ui/src/features/graph/__tests__/GraphLayout.workspace.env.integration.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GraphLayout, type GraphLayoutServices } from '@/components/agents/GraphLayout';
+import type { GraphNodeConfig, GraphPersistedEdge, GraphSaveState } from '@/features/graph/types';
+
+const sidebarProps: any[] = [];
+const canvasSpy = vi.hoisted(() => vi.fn());
+const listAllSecretPathsMock = vi
+  .hoisted(() => vi.fn<[], Promise<string[]>>().mockResolvedValue([]));
+
+type GraphLayoutServiceMocks = {
+  [K in keyof GraphLayoutServices]: vi.Mock<
+    Parameters<GraphLayoutServices[K]>,
+    ReturnType<GraphLayoutServices[K]>
+  >;
+};
+
+let services: GraphLayoutServiceMocks;
+
+const hookMocks = vi.hoisted(() => ({
+  useGraphData: vi.fn(),
+  useGraphSocket: vi.fn(),
+  useNodeStatus: vi.fn(),
+  useMcpNodeState: vi.fn(),
+  useNodeAction: vi.fn(),
+  useTemplates: vi.fn(),
+}));
+
+vi.mock('@/components/GraphCanvas', () => ({
+  GraphCanvas: (props: unknown) => {
+    canvasSpy(props);
+    return <div data-testid="graph-canvas-mock" />;
+  },
+}));
+
+vi.mock('@/components/NodePropertiesSidebar', () => ({
+  __esModule: true,
+  default: (props: unknown) => {
+    sidebarProps.push(props);
+    return <div data-testid="node-sidebar-mock" />;
+  },
+}));
+
+vi.mock('@/components/EmptySelectionSidebar', () => ({
+  __esModule: true,
+  default: () => <div data-testid="empty-sidebar-mock" />,
+}));
+
+vi.mock('@/features/graph/hooks/useGraphData', () => ({
+  useGraphData: hookMocks.useGraphData,
+}));
+
+vi.mock('@/features/graph/hooks/useGraphSocket', () => ({
+  useGraphSocket: hookMocks.useGraphSocket,
+}));
+
+vi.mock('@/features/graph/hooks/useNodeStatus', () => ({
+  useNodeStatus: hookMocks.useNodeStatus,
+}));
+
+vi.mock('@/lib/graph/hooks', () => ({
+  useMcpNodeState: hookMocks.useMcpNodeState,
+  useTemplates: hookMocks.useTemplates,
+}));
+
+vi.mock('@/features/graph/hooks/useNodeAction', () => ({
+  useNodeAction: hookMocks.useNodeAction,
+}));
+
+vi.mock('@/features/secrets/utils/flatVault', () => ({
+  listAllSecretPaths: listAllSecretPathsMock,
+}));
+
+const createServiceMocks = vi.hoisted((): (() => GraphLayoutServiceMocks) => () => {
+  const searchNixPackages = vi
+    .fn<Parameters<GraphLayoutServices['searchNixPackages']>, ReturnType<GraphLayoutServices['searchNixPackages']>>()
+    .mockResolvedValue([]);
+  const listNixPackageVersions = vi
+    .fn<Parameters<GraphLayoutServices['listNixPackageVersions']>, ReturnType<GraphLayoutServices['listNixPackageVersions']>>()
+    .mockResolvedValue([]);
+  const resolveNixSelection = vi
+    .fn<Parameters<GraphLayoutServices['resolveNixSelection']>, ReturnType<GraphLayoutServices['resolveNixSelection']>>()
+    .mockResolvedValue({ version: 'latest', commit: 'abc123', attr: 'pkg' });
+  const listVariableKeys = vi
+    .fn<Parameters<GraphLayoutServices['listVariableKeys']>, ReturnType<GraphLayoutServices['listVariableKeys']>>()
+    .mockResolvedValue([]);
+
+  return {
+    searchNixPackages,
+    listNixPackageVersions,
+    resolveNixSelection,
+    listVariableKeys,
+  } satisfies GraphLayoutServiceMocks;
+});
+
+type GraphDataMock = {
+  nodes: GraphNodeConfig[];
+  edges: GraphPersistedEdge[];
+  loading: boolean;
+  savingState: GraphSaveState;
+  savingErrorMessage: string | null;
+  updateNode: vi.Mock;
+  applyNodeStatus: vi.Mock;
+  applyNodeState: vi.Mock;
+  setEdges: vi.Mock;
+  removeNodes: vi.Mock;
+  addNode: vi.Mock;
+  scheduleSave: vi.Mock;
+  refresh: vi.Mock;
+};
+
+function mockGraphData(overrides: Partial<GraphDataMock> = {}): GraphDataMock {
+  const base: GraphDataMock = {
+    nodes: [],
+    edges: [],
+    loading: false,
+    savingState: { status: 'saved', error: null },
+    savingErrorMessage: null,
+    updateNode: vi.fn(),
+    applyNodeStatus: vi.fn(),
+    applyNodeState: vi.fn(),
+    setEdges: vi.fn(),
+    removeNodes: vi.fn(),
+    addNode: vi.fn(),
+    scheduleSave: vi.fn(),
+    refresh: vi.fn(),
+  } satisfies GraphDataMock;
+  const value: GraphDataMock = { ...base, ...overrides };
+  hookMocks.useGraphData.mockReturnValue(value);
+  return value;
+}
+
+describe('GraphLayout workspace env integration', () => {
+  beforeEach(() => {
+    sidebarProps.length = 0;
+    Object.values(hookMocks).forEach((mock) => mock.mockReset());
+    hookMocks.useMcpNodeState.mockReturnValue({
+      tools: [],
+      enabledTools: [],
+      setEnabledTools: vi.fn(),
+      isLoading: false,
+    });
+    hookMocks.useTemplates.mockReturnValue({ data: [], isLoading: false, isError: false });
+    hookMocks.useNodeAction.mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue(undefined), isPending: false });
+    canvasSpy.mockReset();
+    listAllSecretPathsMock.mockReset();
+    listAllSecretPathsMock.mockResolvedValue([]);
+    services = createServiceMocks();
+  });
+
+  it('fetches flat secret suggestions for workspace nodes and caches them', async () => {
+    const updateNode = vi.fn();
+
+    mockGraphData({
+      nodes: [
+        {
+          id: 'workspace-1',
+          template: 'workspace-template',
+          kind: 'Workspace',
+          title: 'Workspace Node',
+          x: 0,
+          y: 0,
+          status: 'not_ready',
+          config: {
+            title: 'Workspace Node',
+            env: [
+              {
+                name: 'DB_SECRET',
+                value: { mount: 'kv', path: 'prod/app', key: 'TOKEN' },
+              },
+            ],
+          },
+          ports: { inputs: [], outputs: [] },
+        },
+      ],
+      updateNode,
+    });
+
+    hookMocks.useGraphSocket.mockReturnValue(undefined);
+    hookMocks.useNodeStatus.mockReturnValue({ data: null, refetch: vi.fn() });
+
+    listAllSecretPathsMock.mockResolvedValue(['kv/prod/app/TOKEN', 'kv/prod/app/ALT']);
+
+    render(<GraphLayout services={services} />);
+
+    await waitFor(() => expect(canvasSpy).toHaveBeenCalled());
+    const canvasProps = canvasSpy.mock.calls.at(-1)?.[0] as {
+      onNodesChange?: (changes: any[]) => void;
+    };
+
+    act(() => {
+      canvasProps.onNodesChange?.([
+        {
+          id: 'workspace-1',
+          type: 'select',
+          selected: true,
+        },
+      ]);
+    });
+
+    await waitFor(() => expect(sidebarProps.length).toBeGreaterThan(0));
+    const sidebar = sidebarProps.at(-1) as {
+      secretKeys: string[];
+      ensureSecretKeys?: () => Promise<string[]>;
+    };
+
+    expect(sidebar.secretKeys).toEqual([]);
+
+    await expect(sidebar.ensureSecretKeys?.()).resolves.toEqual(['kv/prod/app/TOKEN', 'kv/prod/app/ALT']);
+    expect(listAllSecretPathsMock).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      const latest = sidebarProps.at(-1) as { secretKeys: string[] };
+      expect(latest.secretKeys).toEqual(['kv/prod/app/TOKEN', 'kv/prod/app/ALT']);
+    });
+
+    const afterFetch = sidebarProps.at(-1) as {
+      ensureSecretKeys?: () => Promise<string[]>;
+    };
+    await expect(afterFetch.ensureSecretKeys?.()).resolves.toEqual(['kv/prod/app/TOKEN', 'kv/prod/app/ALT']);
+    expect(listAllSecretPathsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/platform-ui/src/features/graph/containers/AgentsGraphContainer.tsx
+++ b/packages/platform-ui/src/features/graph/containers/AgentsGraphContainer.tsx
@@ -9,9 +9,6 @@ export function AgentsGraphContainer() {
     searchNixPackages: graphApiService.searchNixPackages,
     listNixPackageVersions: graphApiService.listNixPackageVersions,
     resolveNixSelection: graphApiService.resolveNixSelection,
-    listVaultMounts: graphApiService.listVaultMounts,
-    listVaultPaths: graphApiService.listVaultPaths,
-    listVaultKeys: graphApiService.listVaultKeys,
     listVariableKeys: async () => {
       try {
         const variables = await listVariables();

--- a/packages/platform-ui/src/features/secrets/utils/flatVault.ts
+++ b/packages/platform-ui/src/features/secrets/utils/flatVault.ts
@@ -1,0 +1,75 @@
+import type { SecretKey } from '@/api/modules/graph';
+import * as api from '@/api/modules/graph';
+
+async function listAllPathsForMount(mount: string, prefix = ''): Promise<string[]> {
+  const response = await api.graph.listVaultPaths(mount, prefix);
+  const items = Array.isArray(response.items) ? response.items : [];
+  const folders = items.filter((item) => typeof item === 'string' && item.endsWith('/')) as string[];
+  const leaves = items.filter((item) => typeof item === 'string' && !item.endsWith('/')) as string[];
+
+  if (folders.length === 0) {
+    return leaves;
+  }
+
+  const nestedLists = await Promise.all(
+    folders.map((folder) => listAllPathsForMount(mount, `${folder}`)),
+  );
+  return [...leaves, ...nestedLists.flat()];
+}
+
+export async function discoverVaultKeys(mounts: string[]): Promise<SecretKey[]> {
+  if (!Array.isArray(mounts) || mounts.length === 0) {
+    return [];
+  }
+
+  const keyLists = await Promise.all(
+    mounts.map(async (mount) => {
+      if (typeof mount !== 'string' || mount.length === 0) {
+        return [] as SecretKey[];
+      }
+
+      const paths = await listAllPathsForMount(mount, '');
+      const perPath = await Promise.all(
+        paths.map(async (path) => {
+          const response = await api.graph.listVaultKeys(mount, path, { maskErrors: false });
+          const keys = Array.isArray(response.items) ? response.items : [];
+          return keys
+            .filter((key): key is string => typeof key === 'string' && key.length > 0)
+            .map((key) => ({ mount, path, key } satisfies SecretKey));
+        }),
+      );
+
+      return perPath.flat();
+    }),
+  );
+
+  return keyLists.flat();
+}
+
+export async function listAllSecretPaths(): Promise<string[]> {
+  const mountsResponse = await api.graph.listVaultMounts();
+  const mounts = Array.isArray(mountsResponse.items)
+    ? mountsResponse.items.filter((item): item is string => typeof item === 'string' && item.length > 0)
+    : [];
+
+  if (mounts.length === 0) {
+    return [];
+  }
+
+  const keys = await discoverVaultKeys(mounts);
+  const normalized = keys.map(({ mount, path, key }) => {
+    const trimmedMount = (mount ?? '').trim();
+    const trimmedPath = (path ?? '').trim().replace(/^\/+|\/+$/g, '');
+    const trimmedKey = (key ?? '').trim();
+    const segments = [trimmedMount];
+    if (trimmedPath.length > 0) {
+      segments.push(trimmedPath);
+    }
+    if (trimmedKey.length > 0) {
+      segments.push(trimmedKey);
+    }
+    return segments.filter((segment) => segment.length > 0).join('/');
+  });
+
+  return Array.from(new Set(normalized.filter((entry) => entry.length > 0))).sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
## Summary
- align reference encoding/decoding with canonical vault and variable schema, preserving mount metadata during edits
- update ReferenceInput/TriggerSection wiring to support source switching and shared secret/variable autocomplete
- add focused unit and integration tests covering reference helpers, input behavior, and Slack trigger sidebar flows

Fixes #1142

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test -- --runInBand
