### PR TITLE
Fix sync manage waiter ordering

### DIFF
--- a/packages/platform-server/__tests__/agent.auto-send.test.ts
+++ b/packages/platform-server/__tests__/agent.auto-send.test.ts
@@ -173,4 +173,22 @@ describe('AgentNode auto-send final response', () => {
 
     await moduleRef.close();
   });
+
+  it('auto-sends terminal error messages when invocation fails', async () => {
+    const { moduleRef, agent, transport } = await createAgentFixture();
+    await agent.setConfig({});
+
+    agent.setResponseFactory(() => {
+      throw new Error('loop failure');
+    });
+
+    await expect(agent.invoke('thread-err', [HumanMessage.fromText('boom')])).rejects.toThrow('loop failure');
+    expect(transport.sendTextToThread).toHaveBeenCalledWith(
+      'thread-err',
+      expect.stringContaining('loop failure'),
+      expect.objectContaining({ runId: 'run-1', source: 'auto_response' }),
+    );
+
+    await moduleRef.close();
+  });
 });

--- a/packages/platform-server/__tests__/manage.tool.test.ts
+++ b/packages/platform-server/__tests__/manage.tool.test.ts
@@ -398,9 +398,15 @@ describe('ManageTool unit', () => {
 
     const tool = node.getTool();
     const ctx = buildCtx({ threadId: 'p' });
+    const waiterSpy = vi
+      .spyOn(node, 'awaitChildResponse')
+      .mockResolvedValue('Agent run failed: child failure');
+
     await expect(
       tool.execute({ command: 'send_message', worker: 'W', message: 'go', threadAlias: 'alias-W' }, ctx),
-    ).rejects.toThrow('child failure');
+    ).resolves.toBe('Response from: W\nAgent run failed: child failure');
+
+    expect(waiterSpy).toHaveBeenCalledWith('child-t', expect.any(Number));
   });
 });
 


### PR DESCRIPTION
## Summary
- align Manage sync flow to register the invocation before calling workers and wait only on the waiter while logging sync invoke failures
- tighten ManageToolNode sync safeguards by warning on pre-existing queue data, logging missing waiters, and flushing queued messages deterministically
- auto-send normalized error responses from AgentNode when runs fail so Manage sync threads receive fallback content
- expand Manage/agent test coverage for fast waiter responses, sync error handling, and channel warnings

Fixes #1149.

## Testing
- pnpm lint
- pnpm test
