### PR TITLE
feat(docker): bundle Prisma CLI in platform-server image

### DIFF
--- a/packages/platform-server/Dockerfile
+++ b/packages/platform-server/Dockerfile
@@ -39,6 +39,7 @@ WORKDIR /opt/app/packages/platform-server
 RUN apt-get update \
  && apt-get install -y --no-install-recommends openssl \
  && npm install --global tsx@4.20.5 \
+ && npm install --global prisma@^6.18.0 \
  && npm cache clean --force \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
feat(docker): bundle Prisma CLI in platform-server runtime for migrations

Summary
- Adds `prisma@^6.18.0` to the platform-server Docker image runtime layer, alongside `tsx`, enabling `prisma migrate deploy` to run before app start.

Why
- Our client-facing isolated bootstrap compose (agynio/bootstrap) needs to apply Prisma migrations automatically at startup. Bundling Prisma CLI in the server image allows the compose to run:
  `prisma migrate deploy && tsx src/index.ts`

Notes
- No functional app changes; image size impact minimal (Prisma CLI only).
- Server continues to run as non-root with a TCP healthcheck.

Related
- Original task: build/push images for platform-server/ui (Issue #1145).
- Bootstrap compose PR: https://github.com/agynio/bootstrap/pull/2
