### PR TITLE
feat: add MCP env reference resolution

### DIFF
--- a/packages/platform-server/__tests__/env.service.test.ts
+++ b/packages/platform-server/__tests__/env.service.test.ts
@@ -1,18 +1,84 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EnvService, type EnvItem } from '../src/env/env.service';
+import type { ReferenceResolverService } from '../src/utils/reference-resolver.service';
+import { ResolveError } from '../src/utils/references';
+
+const emptyReport = () => ({
+  events: [],
+  counts: { total: 0, resolved: 0, unresolved: 0, cacheHits: 0, errors: 0 },
+});
+
+const secretKey = (ref: { mount?: string | null; path: string; key: string }) => `${ref.mount ?? ''}:${ref.path}:${ref.key}`;
+
+const createResolver = (overrides?: {
+  secrets?: Record<string, string>;
+  variables?: Record<string, string>;
+}): { service: ReferenceResolverService; mock: ReturnType<typeof vi.fn> } => {
+  const secrets = overrides?.secrets ?? {};
+  const variables = overrides?.variables ?? {};
+  const resolve = vi.fn(async (input: string | EnvItem['value'], opts?: { basePath?: string }) => {
+    if (typeof input === 'string') {
+      return { output: input, report: emptyReport() };
+    }
+    if (input.kind === 'vault') {
+      const key = secretKey(input);
+      if (!(key in secrets)) {
+        throw new ResolveError('unresolved_reference', 'secret missing', {
+          path: opts?.basePath ?? '/env',
+          source: 'secret',
+        });
+      }
+      return { output: secrets[key], report: emptyReport() };
+    }
+    if (input.kind === 'var') {
+      if (!(input.name in variables)) {
+        throw new ResolveError('unresolved_reference', 'variable missing', {
+          path: opts?.basePath ?? '/env',
+          source: 'variable',
+        });
+      }
+      return { output: variables[input.name], report: emptyReport() };
+    }
+    throw new ResolveError('invalid_reference', 'unsupported reference', {
+      path: opts?.basePath ?? '/env',
+      source: 'variable',
+    });
+  });
+  const service = { resolve } as unknown as ReferenceResolverService;
+  return { service, mock: resolve };
+};
 
 describe('EnvService', () => {
   it('resolveEnvItems: static only', async () => {
-    const svc = new EnvService();
-    const res = await svc.resolveEnvItems([
-      { name: 'A', value: '1' },
-      { name: 'B', value: '2' },
-    ] satisfies EnvItem[]);
+    const { service: resolver } = createResolver();
+    const svc = new EnvService(resolver);
+    const res = await svc.resolveEnvItems(
+      [
+        { name: 'A', value: '1' },
+        { name: 'B', value: '2' },
+      ] satisfies EnvItem[],
+    );
     expect(res).toEqual({ A: '1', B: '2' });
   });
 
+  it('resolveEnvItems: resolves secret and variable references', async () => {
+    const { service: resolver } = createResolver({
+        secrets: { [secretKey({ path: 'secret/app/db', key: 'PASSWORD' })]: 'postgres' },
+        variables: { API_TOKEN: 'token-123' },
+      });
+    const svc = new EnvService(resolver);
+    const res = await svc.resolveEnvItems(
+      [
+        { name: 'DB_PASSWORD', value: { kind: 'vault', path: 'secret/app/db', key: 'PASSWORD' } },
+        { name: 'API_TOKEN', value: { kind: 'var', name: 'API_TOKEN' } },
+      ] satisfies EnvItem[],
+    );
+    expect(res).toEqual({ DB_PASSWORD: 'postgres', API_TOKEN: 'token-123' });
+  });
+
   it('resolveEnvItems: duplicate name error', async () => {
-    const svc = new EnvService();
+    const { service: resolver } = createResolver();
+    const svc = new EnvService(resolver);
     await expect(
       svc.resolveEnvItems([
         { name: 'A', value: '1' },
@@ -21,13 +87,24 @@ describe('EnvService', () => {
     ).rejects.toMatchObject({ code: 'env_name_duplicate' });
   });
 
-  it('resolveEnvItems: rejects non-string values', async () => {
+  it('resolveEnvItems: throws when resolver unavailable for reference', async () => {
     const svc = new EnvService();
     await expect(
       svc.resolveEnvItems([
-        { name: 'A', value: { kind: 'vault', path: 'secret/app/db', key: 'PASSWORD' } as unknown as string },
+        { name: 'A', value: { kind: 'vault', path: 'secret/app/db', key: 'PASSWORD' } },
       ] satisfies EnvItem[]),
-    ).rejects.toMatchObject({ code: 'env_value_invalid' });
+    ).rejects.toMatchObject({ code: 'env_reference_resolver_missing' });
+  });
+
+  it('resolveEnvItems: wraps unresolved references with EnvError', async () => {
+    const { service: resolver, mock } = createResolver();
+    const svc = new EnvService(resolver);
+    await expect(
+      svc.resolveEnvItems([
+        { name: 'A', value: { kind: 'vault', path: 'secret/app/db', key: 'PASSWORD' } },
+      ] satisfies EnvItem[]),
+    ).rejects.toMatchObject({ code: 'env_reference_unresolved', details: expect.objectContaining({ path: '/env/A/value' }) });
+    expect(mock.mock.calls[0][1]).toMatchObject({ basePath: '/env/A/value' });
   });
 
   it('mergeEnv: overlay precedence and empty preservation', () => {
@@ -40,8 +117,8 @@ describe('EnvService', () => {
   });
 
   it('resolveProviderEnv: supports array items with base overlay', async () => {
-    const svc = new EnvService();
-    const spy = vi.spyOn(svc, 'resolveEnvItems').mockResolvedValue({ A: '1', B: '2' });
+    const { service: resolver } = createResolver();
+    const svc = new EnvService(resolver);
     const base = { BASE: 'x' };
     const merged = await svc.resolveProviderEnv(
       [
@@ -52,15 +129,20 @@ describe('EnvService', () => {
       base,
     );
     expect(merged).toEqual({ BASE: 'x', A: '1', B: '2' });
-    expect(spy).toHaveBeenCalledTimes(1);
-    spy.mockRestore();
   });
 
   it('resolveProviderEnv: supports map input', async () => {
-    const svc = new EnvService();
+    const { service: resolver } = createResolver({
+        secrets: { [secretKey({ path: 'secret/app/db', key: 'PASSWORD' })]: 'postgres' },
+      });
+    const svc = new EnvService(resolver);
     const base = { BASE: 'x' };
-    const merged = await svc.resolveProviderEnv({ A: '1', B: '2' }, undefined, base);
-    expect(merged).toEqual({ BASE: 'x', A: '1', B: '2' });
+    const merged = await svc.resolveProviderEnv(
+      { A: '1', PASSWORD: { kind: 'vault', path: 'secret/app/db', key: 'PASSWORD' } },
+      undefined,
+      base,
+    );
+    expect(merged).toEqual({ BASE: 'x', A: '1', PASSWORD: 'postgres' });
   });
 
   it('resolveProviderEnv: undefined or empty returns base or undefined', async () => {

--- a/packages/platform-ui/src/vite-env.d.ts
+++ b/packages/platform-ui/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_TRACING_SERVER_URL?: string;
+  readonly VITE_UI_MOCK_SIDEBAR?: string;
 }
 interface ImportMeta {
   readonly env: ImportMetaEnv;

--- a/packages/platform-ui/src/vite-env.d.ts
+++ b/packages/platform-ui/src/vite-env.d.ts
@@ -2,7 +2,6 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
-  readonly VITE_TRACING_SERVER_URL?: string;
   readonly VITE_UI_MOCK_SIDEBAR?: string;
 }
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- resolve MCP env arrays and maps through ReferenceResolverService with strict error reporting
- ensure local MCP node accepts reference values, forwards resolved env to docker discovery and tool exec, and update frontend typings/docs
- expand backend coverage for EnvService and MCP env propagation, including reference happy/edge paths

## Testing
- AGENTS_DATABASE_URL=postgresql://user:pass@localhost:5432/db VITE_API_BASE_URL=http://localhost LLM_PROVIDER=openai LOG_LEVEL=error pnpm --filter @agyn/platform-server test
- pnpm --filter @agyn/platform-server exec eslint src/env/env.service.ts src/nodes/mcp/localMcpServer.node.ts __tests__/env.service.test.ts __tests__/localMcpServer.test.ts
- pnpm --filter @agyn/platform-ui typecheck

Fixes #1155
