### PR TITLE
fix(docker): include prisma schema in runtime

### DIFF
--- a/packages/platform-server/Dockerfile
+++ b/packages/platform-server/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build --chown=node:node /opt/app /opt/app
+COPY --from=build --chown=node:node /workspace/packages/platform-server/prisma /opt/app/packages/platform-server/prisma
 
 EXPOSE 3010
 


### PR DESCRIPTION
## Summary
- copy the platform-server prisma directory into the runtime image so CLI can locate schema during migrations

## Testing
- pnpm lint
