### PR TITLE
fix(docker): compile platform server for runtime

### DIFF
--- a/packages/platform-server/Dockerfile
+++ b/packages/platform-server/Dockerfile
@@ -27,6 +27,8 @@ RUN pnpm install --filter @agyn/platform-server... --offline --frozen-lockfile
 
 RUN pnpm --filter @agyn/platform-server run prisma:generate
 
+RUN pnpm --filter @agyn/platform-server run build
+
 RUN pnpm deploy --filter @agyn/platform-server --prod --legacy /opt/app
 
 FROM node:20-slim AS runtime
@@ -38,12 +40,12 @@ WORKDIR /opt/app/packages/platform-server
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends openssl \
- && npm install --global tsx@4.20.5 \
  && npm install --global prisma@^6.18.0 \
  && npm cache clean --force \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build --chown=node:node /opt/app /opt/app
+COPY --from=build --chown=node:node /workspace/packages/platform-server/dist /opt/app/packages/platform-server/dist
 COPY --from=build --chown=node:node /workspace/packages/platform-server/src /opt/app/packages/platform-server/src
 COPY --from=build --chown=node:node /workspace/packages/platform-server/package.json /opt/app/packages/platform-server/package.json
 COPY --from=build --chown=node:node /workspace/packages/platform-server/prisma /opt/app/packages/platform-server/prisma
@@ -54,4 +56,4 @@ USER node
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 CMD node -e "const net = require('node:net'); const port = Number(process.env.PORT) || 3010; const host = process.env.HEALTHCHECK_HOST || '127.0.0.1'; const socket = net.connect({ port, host }, () => { socket.end(); process.exit(0); }); socket.on('error', () => process.exit(1)); setTimeout(() => { socket.destroy(); process.exit(1); }, 2000);"
 
-CMD ["tsx", "src/index.ts"]
+CMD ["node", "dist/index.js"]

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc -p packages/platform-server/tsconfig.json",
+    "build": "tsc -p tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "pnpm run prisma:generate && eslint .",

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
+    "build": "tsc -p packages/platform-server/tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "pnpm run prisma:generate && eslint .",


### PR DESCRIPTION
## Summary
- add a build script for @agyn/platform-server to compile TypeScript via project tsconfig
- run the build during docker image construction so dist/ assets are produced
- switch runtime command to node dist/index.js while keeping prisma CLI and healthcheck

## Testing
- ~/.nix-profile/bin/pnpm lint
