### PR TITLE
Fix manage tool termination waiters

### DIFF
--- a/packages/platform-server/__tests__/agent.node.termination.autosend.test.ts
+++ b/packages/platform-server/__tests__/agent.node.termination.autosend.test.ts
@@ -1,0 +1,91 @@
+import 'reflect-metadata';
+
+import { describe, expect, it, vi } from 'vitest';
+import { Test } from '@nestjs/testing';
+
+import { AgentNode } from '../src/nodes/agent/agent.node';
+import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
+import { RunSignalsRegistry } from '../src/agents/run-signals.service';
+import { ConfigService, configSchema } from '../src/core/services/config.service';
+import { LLMProvisioner } from '../src/llm/provisioners/llm.provisioner';
+import { ThreadTransportService } from '../src/messaging/threadTransport.service';
+
+import { HumanMessage, Loop, Reducer, ResponseMessage } from '@agyn/llm';
+import type { LLMContext, LLMState } from '../src/llm/types';
+
+class DelayReducer extends Reducer<LLMState, LLMContext> {
+  override async invoke(state: LLMState): Promise<LLMState> {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return state;
+  }
+}
+
+class TerminationAutoSendAgent extends AgentNode {
+  protected override async prepareLoop(): Promise<Loop<LLMState, LLMContext>> {
+    return new Loop<LLMState, LLMContext>({ load: new DelayReducer() });
+  }
+}
+
+describe('AgentNode termination auto-send', () => {
+  it('auto-sends a termination message when run ends via terminate signal', async () => {
+    const beginRunThread = vi.fn(async () => ({ runId: 'run-terminate' }));
+    const completeRun = vi.fn(async () => undefined);
+    const ensureThreadModel = vi.fn(async (_threadId: string, model: string) => model);
+    const recordInjected = vi.fn(async () => ({ messageIds: [] }));
+    const sendTextToThread = vi
+      .fn()
+      .mockResolvedValue({ ok: true, threadId: 'thread-terminate', error: undefined });
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: new ConfigService().init(
+            configSchema.parse({ llmProvider: 'openai', agentsDatabaseUrl: 'postgres://user:pass@host/db' }),
+          ),
+        },
+        {
+          provide: LLMProvisioner,
+          useValue: { getLLM: vi.fn(async () => ({ call: vi.fn(async () => ({ text: 'ok', output: [] })) })) },
+        },
+        {
+          provide: AgentsPersistenceService,
+          useValue: {
+            beginRunThread,
+            completeRun,
+            ensureThreadModel,
+            recordInjected,
+          },
+        },
+        { provide: ThreadTransportService, useValue: { sendTextToThread } },
+        RunSignalsRegistry,
+        TerminationAutoSendAgent,
+        { provide: AgentNode, useExisting: TerminationAutoSendAgent },
+      ],
+    }).compile();
+
+    try {
+      const agent = await moduleRef.resolve(TerminationAutoSendAgent);
+      agent.init({ nodeId: 'agent-termination-auto' });
+      await agent.setConfig({});
+
+      const registry = moduleRef.get(RunSignalsRegistry);
+
+      const invokePromise = agent.invoke('thread-terminate', [HumanMessage.fromText('start work')]);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      registry.activateTerminate('run-terminate');
+      const result = await invokePromise;
+
+      expect(result).toBeInstanceOf(ResponseMessage);
+      expect(result.text).toBe('terminated');
+      expect(sendTextToThread).toHaveBeenCalledWith(
+        'thread-terminate',
+        'terminated',
+        expect.objectContaining({ runId: 'run-terminate', source: 'auto_response' }),
+      );
+      expect(completeRun).toHaveBeenCalledWith('run-terminate', 'terminated', []);
+    } finally {
+      await moduleRef.close();
+    }
+  });
+});

--- a/packages/platform-server/__tests__/linking.child.termination.test.ts
+++ b/packages/platform-server/__tests__/linking.child.termination.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CallAgentLinkingService } from '../src/agents/call-agent-linking.service';
+import type { PrismaService } from '../src/core/services/prisma.service';
+import type { RunEventsService } from '../src/events/run-events.service';
+import type { EventsBusService } from '../src/events/events-bus.service';
+
+describe('CallAgentLinkingService child termination metadata', () => {
+  it('persists terminated status in parent tool metadata', async () => {
+    const storedEvent = {
+      id: 'evt-manage',
+      metadata: {
+        tool: 'manage',
+        parentThreadId: 'parent-thread',
+        childThreadId: 'child-thread',
+        childRun: { id: 'run-child', status: 'running', linkEnabled: true, latestMessageId: 'msg-1' },
+        childRunId: 'run-child',
+        childRunStatus: 'running',
+        childRunLinkEnabled: true,
+        childMessageId: 'msg-1',
+      } as Record<string, unknown>,
+    };
+
+    const prismaClient = {
+      runEvent: {
+        findFirst: vi.fn(async () => storedEvent),
+        update: vi.fn(async ({ where, data }: { where: { id: string }; data: { metadata: Record<string, unknown> } }) => {
+          if (where.id !== storedEvent.id) throw new Error('unexpected event id');
+          storedEvent.metadata = data.metadata;
+          return { id: storedEvent.id, metadata: storedEvent.metadata };
+        }),
+      },
+    };
+
+    const prismaService = { getClient: () => prismaClient } as unknown as PrismaService;
+    const runEvents = {} as RunEventsService;
+    const eventsBus = { publishEvent: vi.fn() } as unknown as EventsBusService;
+
+    const linking = new CallAgentLinkingService(prismaService, runEvents, eventsBus);
+
+    const result = await linking.onChildRunCompleted({ runId: 'run-child', status: 'terminated' });
+
+    expect(result).toBe('evt-manage');
+    expect(prismaClient.runEvent.update).toHaveBeenCalledTimes(1);
+
+    const metadata = storedEvent.metadata as Record<string, unknown>;
+    expect(metadata.childRunStatus).toBe('terminated');
+    const childRun = metadata.childRun as Record<string, unknown> | undefined;
+    expect(childRun).toBeDefined();
+    expect(childRun?.status).toBe('terminated');
+    expect(childRun?.id).toBe('run-child');
+  });
+});

--- a/packages/platform-server/__tests__/manage.tool.termination.test.ts
+++ b/packages/platform-server/__tests__/manage.tool.termination.test.ts
@@ -1,0 +1,71 @@
+import 'reflect-metadata';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ManageToolNode } from '../src/nodes/tools/manage/manage.node';
+import { ManageFunctionTool } from '../src/nodes/tools/manage/manage.tool';
+import type { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
+import type { CallAgentLinkingService } from '../src/agents/call-agent-linking.service';
+import { ResponseMessage, HumanMessage } from '@agyn/llm';
+import type { AgentNode } from '../src/nodes/agent/agent.node';
+import type { LLMContext } from '../src/llm/types';
+import { Signal } from '../src/signal';
+
+const createManageTool = async (options?: { timeoutMs?: number }) => {
+  const persistence = {
+    getOrCreateSubthreadByAlias: vi.fn().mockResolvedValue('child-thread-terminate'),
+    setThreadChannelNode: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AgentsPersistenceService;
+  const linking = {
+    registerParentToolExecution: vi.fn().mockResolvedValue('evt-manage'),
+  } as unknown as CallAgentLinkingService;
+
+  const node = new ManageToolNode(persistence, linking);
+  node.init({ nodeId: 'manage-node-termination' });
+  await node.setConfig({ mode: 'sync', timeoutMs: options?.timeoutMs ?? 0 });
+  const tool = node.getTool() as ManageFunctionTool;
+
+  return { node, tool, persistence, linking };
+};
+
+const buildContext = (overrides?: Partial<LLMContext>): LLMContext =>
+  ({
+    threadId: 'parent-thread',
+    runId: 'parent-run',
+    finishSignal: new Signal(),
+    terminateSignal: new Signal(),
+    callerAgent: { invoke: vi.fn().mockResolvedValue(undefined) },
+    ...overrides,
+  }) as LLMContext;
+
+describe('Manage tool termination handling', () => {
+  it('resolves sync waiter when termination message arrives', async () => {
+    const { node, tool } = await createManageTool();
+
+    const workerAgent = {
+      config: { name: 'Worker One', sendFinalResponseToThread: true },
+      invoke: vi.fn().mockResolvedValue(ResponseMessage.fromText('child completed')), // child reply unused in sync path
+    } as unknown as AgentNode;
+
+    node.addWorker(workerAgent);
+
+    const ctx = buildContext();
+
+    const executionPromise = tool.execute(
+      { command: 'send_message', worker: 'Worker One', message: 'handle task' },
+      ctx,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await node.sendToChannel('child-thread-terminate', 'terminated');
+    const rendered = await executionPromise;
+
+    expect(workerAgent.invoke).toHaveBeenCalledTimes(1);
+    expect(workerAgent.invoke).toHaveBeenCalledWith(
+      'child-thread-terminate',
+      expect.arrayContaining([expect.any(HumanMessage)]),
+    );
+    expect(rendered).toBe('Response from: Worker One\nterminated');
+  });
+});

--- a/packages/platform-server/__tests__/manage.tool.timeout.test.ts
+++ b/packages/platform-server/__tests__/manage.tool.timeout.test.ts
@@ -1,0 +1,70 @@
+import 'reflect-metadata';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ManageToolNode } from '../src/nodes/tools/manage/manage.node';
+import type { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
+import type { CallAgentLinkingService } from '../src/agents/call-agent-linking.service';
+import { ResponseMessage, HumanMessage } from '@agyn/llm';
+import type { AgentNode } from '../src/nodes/agent/agent.node';
+import type { LLMContext } from '../src/llm/types';
+import { Signal } from '../src/signal';
+
+const createSyncManageTool = async (timeoutMs: number) => {
+  const persistence = {
+    getOrCreateSubthreadByAlias: vi.fn().mockResolvedValue('child-thread-timeout'),
+    setThreadChannelNode: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AgentsPersistenceService;
+  const linking = {
+    registerParentToolExecution: vi.fn().mockResolvedValue('evt-timeout'),
+  } as unknown as CallAgentLinkingService;
+
+  const node = new ManageToolNode(persistence, linking);
+  node.init({ nodeId: 'manage-node-timeout' });
+  await node.setConfig({ mode: 'sync', timeoutMs });
+  const tool = node.getTool();
+
+  const workerAgent = {
+    config: { name: 'Timeout Worker', sendFinalResponseToThread: true },
+    invoke: vi.fn().mockResolvedValue(ResponseMessage.fromText('placeholder')),
+  } as unknown as AgentNode;
+
+  node.addWorker(workerAgent);
+
+  const context = {
+    threadId: 'parent-thread',
+    runId: 'parent-run',
+    finishSignal: new Signal(),
+    terminateSignal: new Signal(),
+    callerAgent: { invoke: vi.fn().mockResolvedValue(undefined) },
+  } as LLMContext;
+
+  return { node, tool, workerAgent, context };
+};
+
+describe('Manage tool timeout behaviour', () => {
+  it('rejects sync invocation when child response does not arrive within timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const { tool, workerAgent, context } = await createSyncManageTool(25);
+
+      const executionPromise = tool.execute(
+        { command: 'send_message', worker: 'Timeout Worker', message: 'do work' },
+        context,
+      );
+
+      const expectation = expect(executionPromise).rejects.toThrow('manage_timeout');
+
+      await vi.advanceTimersByTimeAsync(30);
+      await expectation;
+
+      expect(workerAgent.invoke).toHaveBeenCalledTimes(1);
+      expect(workerAgent.invoke).toHaveBeenCalledWith(
+        'child-thread-timeout',
+        expect.arrayContaining([expect.any(HumanMessage)]),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/platform-server/src/nodes/tools/manage/manage.node.ts
+++ b/packages/platform-server/src/nodes/tools/manage/manage.node.ts
@@ -26,7 +26,7 @@ export const ManageToolStaticConfigSchema = z
       .number()
       .int()
       .min(0)
-      .default(0)
+      .default(15000)
       .describe('Timeout in milliseconds when waiting for child responses in sync mode. 0 disables timeout.'),
   })
   .strict();


### PR DESCRIPTION
## Summary
- auto-send a termination message from `AgentNode` to unblock manage waiter
- set manage tool sync timeout default to 15s for resiliency
- add regression tests for termination auto-send, manage sync handling, timeout, and linking metadata

## Testing
- pnpm lint
- LOG_LEVEL=error pnpm --filter @agyn/platform-server exec vitest run --reporter=json --outputFile vitest-report.json

Resolves #1172
