### PR TITLE
feat: surface provisioning error tooltips

### DIFF
--- a/packages/platform-ui/src/components/GraphCanvas.tsx
+++ b/packages/platform-ui/src/components/GraphCanvas.tsx
@@ -21,6 +21,7 @@ import '@xyflow/react/dist/style.css';
 
 import NodeComponent, { type NodeKind } from './Node';
 import { SavingStatusControl, type SavingStatus } from './SavingStatusControl';
+import type { GraphNodeStatus } from '@/features/graph/types';
 
 export type GraphNodeData = {
 	kind: NodeKind;
@@ -29,6 +30,8 @@ export type GraphNodeData = {
 	outputs?: { id: string; title: string }[];
 	avatar?: string;
 	avatarSeed?: string;
+	status?: GraphNodeStatus;
+	errorDetail?: string;
 };
 
 const DRAGGABLE_NODE_KINDS: NodeKind[] = ['Trigger', 'Agent', 'Tool', 'MCP', 'Workspace'];
@@ -103,6 +106,8 @@ export function GraphCanvas({
 					outputs={data.outputs}
 					avatar={data.avatar}
 					avatarSeed={data.avatarSeed}
+					status={data.status}
+					errorDetail={data.errorDetail}
 					selected={selected}
 				/>
 			),

--- a/packages/platform-ui/src/components/Node.tsx
+++ b/packages/platform-ui/src/components/Node.tsx
@@ -79,9 +79,8 @@ export default function GraphNode({
   const baseBoxShadow = selected
     ? '0 4px 12px rgba(0, 0, 0, 0.12)'
     : '0 2px 8px rgba(0, 0, 0, 0.08)';
-  const boxShadow = isProvisioningError
-    ? '0 0 0 2px var(--agyn-status-failed), 0 6px 18px rgba(220, 38, 38, 0.28)'
-    : baseBoxShadow;
+  const errorBoxShadow = '0 0 0 2px var(--agyn-status-failed), 0 4px 12px rgba(220, 38, 38, 0.15)';
+  const boxShadow = isProvisioningError ? errorBoxShadow : baseBoxShadow;
   const borderColor = isProvisioningError ? 'var(--agyn-status-failed)' : `${config.borderColor}40`;
   const selectionOutlineColor = isProvisioningError ? 'var(--agyn-status-failed)' : config.borderColor;
 
@@ -90,6 +89,7 @@ export default function GraphNode({
       {/* Node Container */}
       <div 
         className="relative bg-white rounded-[10px] w-[280px] transition-all cursor-pointer"
+        data-testid="graph-node-card"
         style={{ 
           border: `1px solid ${borderColor}`,
           boxShadow,
@@ -101,6 +101,7 @@ export default function GraphNode({
             className="pointer-events-none absolute inset-0 rounded-[10px]"
             style={{
               boxShadow: `0 0 0 2px ${selectionOutlineColor}`,
+              zIndex: 1,
             }}
           />
         )}

--- a/packages/platform-ui/src/components/Node.tsx
+++ b/packages/platform-ui/src/components/Node.tsx
@@ -73,7 +73,7 @@ export default function GraphNode({
     ? createAvatar(avataaars, { seed: avatarSeed }).toString()
     : undefined;
   const showAvatar = kind === 'Agent' && (avatar || avatarSvg);
-  const isProvisioningError = status === 'provisioning_error';
+  const isProvisioningError = status === 'provisioning_error' || status === 'error';
   const trimmedErrorDetail = typeof errorDetail === 'string' ? errorDetail.trim() : '';
   const errorMessage = trimmedErrorDetail.length > 0 ? trimmedErrorDetail : ERROR_FALLBACK_MESSAGE;
   const baseBoxShadow = selected
@@ -81,7 +81,7 @@ export default function GraphNode({
     : '0 2px 8px rgba(0, 0, 0, 0.08)';
   const errorBoxShadow = '0 0 0 2px var(--agyn-status-failed), 0 4px 12px rgba(220, 38, 38, 0.15)';
   const boxShadow = isProvisioningError ? errorBoxShadow : baseBoxShadow;
-  const borderColor = isProvisioningError ? 'var(--agyn-status-failed)' : `${config.borderColor}40`;
+  const borderColor = isProvisioningError ? 'var(--agyn-status-failed)' : config.borderColor;
   const selectionOutlineColor = isProvisioningError ? 'var(--agyn-status-failed)' : config.borderColor;
 
   return (
@@ -110,7 +110,7 @@ export default function GraphNode({
           className="px-4 py-3 rounded-t-[10px] overflow-hidden"
           style={{ 
             background: kind === 'Agent' ? (config.gradient || config.bgColor) : `${config.bgColor}`,
-            borderBottom: `1px solid ${config.borderColor}40`,
+            borderBottom: `1px solid ${config.borderColor}`,
           }}
         >
           <div className="flex items-center gap-3">

--- a/packages/platform-ui/src/components/Node.tsx
+++ b/packages/platform-ui/src/components/Node.tsx
@@ -73,7 +73,8 @@ export default function GraphNode({
     ? createAvatar(avataaars, { seed: avatarSeed }).toString()
     : undefined;
   const showAvatar = kind === 'Agent' && (avatar || avatarSvg);
-  const isProvisioningError = status === 'provisioning_error' || status === 'error';
+  const statusString = (status ?? '') as string;
+  const isProvisioningError = statusString === 'provisioning_error' || statusString === 'error';
   const trimmedErrorDetail = typeof errorDetail === 'string' ? errorDetail.trim() : '';
   const errorMessage = trimmedErrorDetail.length > 0 ? trimmedErrorDetail : ERROR_FALLBACK_MESSAGE;
   const baseBoxShadow = selected

--- a/packages/platform-ui/src/components/__tests__/Node.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/Node.test.tsx
@@ -23,6 +23,11 @@ describe('components/Node', () => {
       </ReactFlowProvider>,
     );
 
+    const card = screen.getByTestId('graph-node-card');
+    expect(card).toHaveStyle(
+      'box-shadow: 0 0 0 2px var(--agyn-status-failed), 0 4px 12px rgba(220, 38, 38, 0.15)',
+    );
+
     const errorButton = screen.getByRole('button', { name: /view node error details/i });
     await user.hover(errorButton);
 

--- a/packages/platform-ui/src/components/__tests__/Node.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/Node.test.tsx
@@ -8,6 +8,31 @@ import { ReactFlowProvider } from '@xyflow/react';
 import GraphNode from '../Node';
 
 describe('components/Node', () => {
+  it('renders healthy node border without invalid suffix', () => {
+    render(
+      <ReactFlowProvider>
+        <GraphNode
+          kind="Agent"
+          title="Agent Node"
+          inputs={[{ id: 'input', title: 'input' }]}
+          outputs={[{ id: 'output', title: 'output' }]}
+        />
+      </ReactFlowProvider>,
+    );
+
+    const card = screen.getByTestId('graph-node-card');
+    expect(card.style.border).toBe('1px solid var(--agyn-blue)');
+    expect(card.style.border).not.toContain(')40');
+
+    const header = screen.getByText('Agent Node').parentElement?.parentElement?.parentElement as HTMLElement;
+    expect(header).toBeTruthy();
+    if (!header) {
+      throw new Error('Header element not found');
+    }
+    expect(header.style.borderBottom).toBe('1px solid var(--agyn-blue)');
+    expect(header.style.borderBottom).not.toContain(')40');
+  });
+
   it('renders error icon and shows detail tooltip when provisioning fails', async () => {
     const user = userEvent.setup();
     render(
@@ -54,5 +79,32 @@ describe('components/Node', () => {
 
     const fallbackMessages = await screen.findAllByText(/No additional error details available/i);
     expect(fallbackMessages.length).toBeGreaterThan(0);
+  });
+
+  it('treats legacy error status as provisioning failure', async () => {
+    const user = userEvent.setup();
+    render(
+      <ReactFlowProvider>
+        <GraphNode
+          kind="Agent"
+          title="Agent Node"
+          status="error"
+          errorDetail="Legacy error state"
+          inputs={[{ id: 'input', title: 'input' }]}
+          outputs={[{ id: 'output', title: 'output' }]}
+        />
+      </ReactFlowProvider>,
+    );
+
+    const card = screen.getByTestId('graph-node-card');
+    expect(card).toHaveStyle(
+      'box-shadow: 0 0 0 2px var(--agyn-status-failed), 0 4px 12px rgba(220, 38, 38, 0.15)',
+    );
+
+    const errorButton = screen.getByRole('button', { name: /view node error details/i });
+    await user.hover(errorButton);
+
+    const legacyMessages = await screen.findAllByText('Legacy error state');
+    expect(legacyMessages.length).toBeGreaterThan(0);
   });
 });

--- a/packages/platform-ui/src/components/__tests__/Node.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/Node.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { ReactFlowProvider } from '@xyflow/react';
+
+import GraphNode from '../Node';
+
+describe('components/Node', () => {
+  it('renders error icon and shows detail tooltip when provisioning fails', async () => {
+    const user = userEvent.setup();
+    render(
+      <ReactFlowProvider>
+        <GraphNode
+          kind="Agent"
+          title="Agent Node"
+          status="provisioning_error"
+          errorDetail="Provisioning failed due to timeout"
+          inputs={[{ id: 'input', title: 'input' }]}
+          outputs={[{ id: 'output', title: 'output' }]}
+        />
+      </ReactFlowProvider>,
+    );
+
+    const errorButton = screen.getByRole('button', { name: /view node error details/i });
+    await user.hover(errorButton);
+
+    const messages = await screen.findAllByText('Provisioning failed due to timeout');
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to generic tooltip text when detail is missing', async () => {
+    const user = userEvent.setup();
+    render(
+      <ReactFlowProvider>
+        <GraphNode
+          kind="Agent"
+          title="Agent Node"
+          status="provisioning_error"
+          inputs={[{ id: 'input', title: 'input' }]}
+          outputs={[{ id: 'output', title: 'output' }]}
+        />
+      </ReactFlowProvider>,
+    );
+
+    const errorButton = screen.getByRole('button', { name: /view node error details/i });
+    await user.hover(errorButton);
+
+    const fallbackMessages = await screen.findAllByText(/No additional error details available/i);
+    expect(fallbackMessages.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/platform-ui/src/components/nodeProperties/__tests__/Header.test.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/__tests__/Header.test.tsx
@@ -62,4 +62,39 @@ describe('nodeProperties/Header', () => {
 
     expect(onDeprovision).not.toHaveBeenCalled();
   });
+
+  it('shows error detail tooltip when status is provisioning error', async () => {
+    const user = userEvent.setup();
+    render(
+      <Header
+        title="Agent Node"
+        status="provisioning_error"
+        errorDetail="Provisioning failed due to timeout"
+      />,
+    );
+
+    const trigger = screen.getByLabelText('View node error details');
+    await user.tab();
+    expect(trigger).toHaveFocus();
+
+    const messages = await screen.findAllByText('Provisioning failed due to timeout');
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
+  it('uses fallback tooltip text when error detail missing', async () => {
+    const user = userEvent.setup();
+    render(
+      <Header
+        title="Agent Node"
+        status="provisioning_error"
+      />,
+    );
+
+    const trigger = screen.getByLabelText('View node error details');
+    await user.tab();
+    expect(trigger).toHaveFocus();
+
+    const fallbackMessages = await screen.findAllByText(/No additional error details available/i);
+    expect(fallbackMessages.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/platform-ui/src/components/nodeProperties/index.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/index.tsx
@@ -81,6 +81,7 @@ function NodePropertiesSidebar({
   const { kind: nodeKind, title: nodeTitle, template } = config;
   const nodeTitleValue = typeof nodeTitle === 'string' ? nodeTitle : '';
   const { status } = state;
+  const errorDetail = typeof state.errorDetail === 'string' ? state.errorDetail : undefined;
   const configRecord = config as Record<string, unknown>;
   const configTemplate = typeof template === 'string' ? template : undefined;
   const recordTemplate =
@@ -810,6 +811,7 @@ function NodePropertiesSidebar({
       <Header
         title={headerTitle}
         status={status}
+        errorDetail={errorDetail}
         canProvision={canProvision}
         canDeprovision={canDeprovision}
         isActionPending={isActionPending}

--- a/packages/platform-ui/src/components/nodeProperties/types.ts
+++ b/packages/platform-ui/src/components/nodeProperties/types.ts
@@ -18,6 +18,7 @@ export interface NodeConfig extends Record<string, unknown> {
 
 export interface NodeState extends Record<string, unknown> {
   status: NodeStatus;
+  errorDetail?: string;
 }
 
 export type ReferenceConfigValue = string | Record<string, unknown>;


### PR DESCRIPTION
## Summary
- highlight provisioning error nodes and sidebar badges with error styling and icons
- propagate provisioning status details to node properties for consolidated messaging
- add tooltip accessibility coverage and unit tests for node and properties header

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test
