### PR TITLE
feat: LiteLLM virtual key lifecycle

### DIFF
--- a/packages/platform-server/__tests__/litellm.provision.test.ts
+++ b/packages/platform-server/__tests__/litellm.provision.test.ts
@@ -1,2 +1,195 @@
-/* Issue #451: out-of-scope litellm provisioner tests skipped */
-describe.skip('skipped (Issue #451)', () => { it('noop', () => {}); });
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LiteLLMProvisioner } from '../src/llm/provisioners/litellm.provisioner';
+import type { ConfigService } from '../src/core/services/config.service';
+import type { LiteLLMKeyStore, PersistedLiteLLMKey } from '../src/llm/provisioners/litellm.key.store';
+import { HumanMessage } from '@agyn/llm';
+
+class InMemoryKeyStore implements LiteLLMKeyStore {
+  private snapshot: PersistedLiteLLMKey | null;
+
+  constructor(initial?: PersistedLiteLLMKey | null) {
+    this.snapshot = initial ?? null;
+  }
+
+  async load(alias: string): Promise<PersistedLiteLLMKey | null> {
+    return this.snapshot && this.snapshot.alias === alias ? { ...this.snapshot } : null;
+  }
+
+  async save(record: PersistedLiteLLMKey): Promise<void> {
+    this.snapshot = { ...record };
+  }
+
+  async delete(alias: string): Promise<void> {
+    if (this.snapshot?.alias === alias) {
+      this.snapshot = null;
+    }
+  }
+
+  get current(): PersistedLiteLLMKey | null {
+    return this.snapshot ? { ...this.snapshot } : null;
+  }
+}
+
+const respondJson = (payload: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(payload), {
+    status: init?.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(init?.headers || {}) },
+  });
+
+const respondStatus = (status: number, body = '') => new Response(body, { status });
+
+const baseConfig = (): ConfigService =>
+  ({
+    openaiApiKey: undefined,
+    openaiBaseUrl: undefined,
+    litellmBaseUrl: 'http://litellm.local:4000',
+    litellmMasterKey: 'sk-master',
+    llmProvider: 'litellm',
+  } as unknown as ConfigService);
+
+const getUrl = (input: RequestInfo | URL): string => {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return (input as Request).url;
+};
+
+describe('LiteLLMProvisioner', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    process.env.LITELLM_KEY_ALIAS = 'agents/unit-test';
+  });
+
+  afterEach(() => {
+    delete process.env.LITELLM_KEY_ALIAS;
+  });
+
+  it('revokes persisted key on startup and stores newly issued key', async () => {
+    const store = new InMemoryKeyStore({ alias: 'agents/unit-test', key: 'sk-old', expiresAt: null });
+    const expires = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = getUrl(input);
+      if (url.endsWith('/key/delete')) {
+        return respondJson({ deleted_keys: ['sk-old'] });
+      }
+      if (url.endsWith('/key/generate')) {
+        return respondJson({ key: 'sk-new', expires });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+
+    const provisioner = new LiteLLMProvisioner(baseConfig(), store, fetchMock as unknown as typeof fetch);
+    await provisioner.init();
+
+    const deleteCall = fetchMock.mock.calls.find(([arg]) => getUrl(arg as RequestInfo | URL).endsWith('/key/delete'));
+    expect(deleteCall?.[1]).toMatchObject({ body: JSON.stringify({ keys: ['sk-old'] }) });
+
+    const generateCalls = fetchMock.mock.calls.filter(([arg]) =>
+      getUrl(arg as RequestInfo | URL).endsWith('/key/generate'),
+    );
+    expect(generateCalls.length).toBeGreaterThanOrEqual(1);
+    expect(store.current?.key).toBe('sk-new');
+    await provisioner.teardown();
+  });
+
+  it('refreshes the virtual key before expiry and revokes the previous key', async () => {
+    vi.useFakeTimers();
+    const now = new Date('2025-01-01T00:00:00.000Z');
+    vi.setSystemTime(now);
+    const store = new InMemoryKeyStore();
+    const generateResponses = [
+      respondJson({ key: 'sk-one', expires: new Date(now.getTime() + 10 * 60 * 1000).toISOString() }),
+      respondJson({ key: 'sk-two', expires: new Date(now.getTime() + 20 * 60 * 1000).toISOString() }),
+    ];
+    const deleteResponses = [respondJson({ deleted_keys: ['sk-one'] })];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = getUrl(input);
+      if (url.endsWith('/key/generate')) {
+        const next = generateResponses.shift();
+        if (!next) throw new Error('Missing generate response');
+        return next;
+      }
+      if (url.endsWith('/key/delete')) {
+        const next = deleteResponses.shift();
+        if (!next) throw new Error('Missing delete response');
+        return next;
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+
+    const provisioner = new LiteLLMProvisioner(baseConfig(), store, fetchMock as unknown as typeof fetch);
+    await provisioner.init();
+
+    // Advance past the 5 minute refresh lead time.
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000);
+
+    const generateCalls = fetchMock.mock.calls.filter(([arg]) =>
+      getUrl(arg as RequestInfo | URL).endsWith('/key/generate'),
+    );
+    expect(generateCalls.length).toBe(2);
+
+    const deleteCall = fetchMock.mock.calls.find(([arg]) => getUrl(arg as RequestInfo | URL).endsWith('/key/delete'));
+    expect(deleteCall?.[1]).toMatchObject({ body: JSON.stringify({ keys: ['sk-one'] }) });
+    expect(store.current?.key).toBe('sk-two');
+
+    await provisioner.teardown();
+  });
+
+  it('reprovisions once on 401 and retries the original OpenAI call', async () => {
+    const store = new InMemoryKeyStore();
+    const messages = [HumanMessage.fromText('hello world')];
+    const responsePayload = {
+      id: 'resp-1',
+      object: 'response',
+      created: 0,
+      model: 'gpt-test',
+      output: [
+        {
+          id: 'msg-1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'all good' }],
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    };
+
+    const generateResponses = [
+      respondJson({ key: 'sk-initial', expires: new Date(Date.now() + 30 * 60 * 1000).toISOString() }),
+      respondJson({ key: 'sk-refreshed', expires: new Date(Date.now() + 60 * 60 * 1000).toISOString() }),
+    ];
+    const deleteResponses = [respondJson({ deleted_keys: ['sk-initial'] })];
+    let llmRequestCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = getUrl(input);
+      if (url.endsWith('/key/generate')) {
+        const next = generateResponses.shift();
+        if (!next) throw new Error('Missing generate response');
+        return next;
+      }
+      if (url.endsWith('/key/delete')) {
+        const next = deleteResponses.shift();
+        if (!next) throw new Error('Missing delete response');
+        return next;
+      }
+      if (url.endsWith('/v1/responses')) {
+        llmRequestCount += 1;
+        if (llmRequestCount === 1) {
+          return respondStatus(401, 'expired');
+        }
+        return respondJson(responsePayload);
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+
+    const provisioner = new LiteLLMProvisioner(baseConfig(), store, fetchMock as unknown as typeof fetch);
+    await provisioner.init();
+
+    const llm = await provisioner.getLLM();
+    const response = await llm.call({ model: 'gpt-test', input: messages });
+
+    expect(response.text).toBe('all good');
+    expect(llmRequestCount).toBe(2);
+    expect(store.current?.key).toBe('sk-refreshed');
+    await provisioner.teardown();
+  });
+});

--- a/packages/platform-server/prisma/migrations/20251214000652_add_litellm_virtual_keys/migration.sql
+++ b/packages/platform-server/prisma/migrations/20251214000652_add_litellm_virtual_keys/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "litellm_virtual_keys" (
+    "id" SERIAL NOT NULL,
+    "alias" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "litellm_virtual_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "litellm_virtual_keys_alias_key" ON "litellm_virtual_keys"("alias");

--- a/packages/platform-server/prisma/schema.prisma
+++ b/packages/platform-server/prisma/schema.prisma
@@ -30,6 +30,17 @@ model VariableLocal {
   updatedAt DateTime @updatedAt
 }
 
+model LiteLLMVirtualKey {
+  id        Int      @id @default(autoincrement())
+  alias     String   @unique
+  key       String
+  expiresAt DateTime?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("litellm_virtual_keys")
+}
+
 enum MemoryScope {
   global
   perThread

--- a/packages/platform-server/src/llm/provisioners/litellm.key.store.ts
+++ b/packages/platform-server/src/llm/provisioners/litellm.key.store.ts
@@ -1,0 +1,41 @@
+import { PrismaService } from '../../core/services/prisma.service';
+
+export type PersistedLiteLLMKey = {
+  alias: string;
+  key: string;
+  expiresAt: Date | null;
+};
+
+export class LiteLLMKeyStore {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async load(alias: string): Promise<PersistedLiteLLMKey | null> {
+    const record = await this.prismaService.getClient().liteLLMVirtualKey.findUnique({ where: { alias } });
+    if (!record) return null;
+    return {
+      alias: record.alias,
+      key: record.key,
+      expiresAt: record.expiresAt,
+    };
+  }
+
+  async save(record: PersistedLiteLLMKey): Promise<void> {
+    await this.prismaService.getClient().liteLLMVirtualKey.upsert({
+      where: { alias: record.alias },
+      update: { key: record.key, expiresAt: record.expiresAt },
+      create: { alias: record.alias, key: record.key, expiresAt: record.expiresAt },
+    });
+  }
+
+  async delete(alias: string): Promise<void> {
+    try {
+      await this.prismaService.getClient().liteLLMVirtualKey.delete({ where: { alias } });
+    } catch (error) {
+      if (!this.isRecordMissingError(error)) throw error;
+    }
+  }
+
+  private isRecordMissingError(error: unknown): boolean {
+    return Boolean(error && typeof error === 'object' && 'code' in error && (error as { code?: string }).code === 'P2025');
+  }
+}

--- a/packages/platform-server/src/llm/provisioners/litellm.provisioner.ts
+++ b/packages/platform-server/src/llm/provisioners/litellm.provisioner.ts
@@ -1,110 +1,259 @@
 import { LLM } from '@agyn/llm';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import OpenAI from 'openai';
+import os from 'node:os';
 import { ConfigService } from '../../core/services/config.service';
 import { LLMProvisioner } from './llm.provisioner';
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { LiteLLMKeyStore } from './litellm.key.store';
 
-type ProvisionResult = { apiKey?: string; baseUrl?: string };
+type ProvisionContext = 'startup' | 'refresh' | 'auth_error';
+type VirtualKeyState = { key: string; expiresAt: Date | null };
+
+const MIN_REFRESH_DELAY_MS = 60_000;
+const REFRESH_GRACE_MS = 5 * 60_000;
 
 @Injectable()
 export class LiteLLMProvisioner extends LLMProvisioner {
   private readonly logger = new Logger(LiteLLMProvisioner.name);
-  private llm?: LLM;
+  private readonly fetchImpl: typeof fetch;
+  private readonly keyAlias: string;
 
-  constructor(@Inject(ConfigService) private cfg: ConfigService) {
+  private llm?: LLM;
+  private readyPromise?: Promise<void>;
+  private refreshPromise?: Promise<void>;
+  private refreshTimer?: NodeJS.Timeout;
+  private currentKey?: VirtualKeyState;
+  private readonly shutdownHandlers: Array<{ signal: NodeJS.Signals; handler: () => void }> = [];
+  private baseUrl?: string;
+
+  constructor(
+    @Inject(ConfigService) private readonly cfg: ConfigService,
+    private readonly keyStore: LiteLLMKeyStore,
+    fetchImpl?: typeof fetch,
+  ) {
     super();
+    this.fetchImpl = fetchImpl ?? globalThis.fetch.bind(globalThis);
+    this.keyAlias = this.resolveAlias();
+  }
+
+  init(): Promise<void> {
+    if (!this.readyPromise) {
+      this.readyPromise = this.initialize();
+    }
+    return this.readyPromise;
   }
 
   async getLLM(): Promise<LLM> {
-    if (this.llm) return this.llm;
-
-    const { apiKey, baseUrl } = await this.fetchOrCreateKeysInternal();
-    const client = new OpenAI({ apiKey, baseURL: baseUrl });
-    this.llm = new LLM(client);
+    await this.init();
+    if (!this.llm) throw new Error('litellm_llm_uninitialized');
     return this.llm;
   }
 
-  private async fetchOrCreateKeysInternal(): Promise<{ apiKey: string; baseUrl?: string }> {
-    // Prefer direct OpenAI if available
+  async teardown(): Promise<void> {
+    if (this.refreshTimer) clearTimeout(this.refreshTimer);
+    this.removeShutdownHooks();
+  }
+
+  private async initialize(): Promise<void> {
     if (this.cfg.openaiApiKey) {
-      return { apiKey: this.cfg.openaiApiKey, baseUrl: this.cfg.openaiBaseUrl };
+      this.initializeDirectOpenAI();
+      return;
     }
 
-    // Otherwise require LiteLLM config to be present for provisioning
+    this.ensureLiteLLMConfig();
+    await this.bootstrapVirtualKey();
+    this.registerShutdownHooks();
+  }
+
+  private initializeDirectOpenAI(): void {
+    const apiKey = this.cfg.openaiApiKey;
+    if (!apiKey) throw new Error('openai_provider_missing_key');
+    const client = new OpenAI({ apiKey, baseURL: this.cfg.openaiBaseUrl });
+    this.llm = new LLM(client);
+  }
+
+  private ensureLiteLLMConfig(): void {
+    if (!this.cfg.litellmBaseUrl || !this.cfg.litellmMasterKey) {
+      throw new Error('litellm_missing_config');
+    }
+    this.baseUrl = (this.cfg.openaiBaseUrl || `${this.cfg.litellmBaseUrl.replace(/\/$/, '')}/v1`).replace(/\/$/, '');
+  }
+
+  private async bootstrapVirtualKey(): Promise<void> {
+    const persisted = await this.keyStore.load(this.keyAlias);
+    if (persisted?.key) {
+      await this.revokeKey(persisted.key, 'startup');
+    }
+
+    const state = await this.generateAndPersistKey('startup');
+    this.applyKeyState(state);
+    this.ensureOpenAIClient();
+  }
+
+  private ensureOpenAIClient(): void {
+    if (this.llm) return;
+    if (!this.baseUrl) throw new Error('litellm_missing_base_url');
+    const client = new OpenAI({
+      apiKey: 'virtual-key-managed-by-agents',
+      baseURL: this.baseUrl,
+      fetch: this.buildOpenAIFetch(),
+    });
+    this.llm = new LLM(client);
+  }
+
+  private buildOpenAIFetch(): typeof fetch {
+    return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const sourceRequest = new Request(input as RequestInfo, init);
+      const firstAttempt = this.cloneWithAuthorization(sourceRequest.clone(), this.requireActiveKey());
+      let response = await this.fetchImpl(firstAttempt);
+
+      if (this.shouldRetry(response.status)) {
+        const reProvisioned = await this.handleAuthFailure(response.status);
+        if (reProvisioned) {
+          const retryRequest = this.cloneWithAuthorization(sourceRequest.clone(), this.requireActiveKey());
+          response = await this.fetchImpl(retryRequest);
+        }
+      }
+
+      return response;
+    };
+  }
+
+  private cloneWithAuthorization(request: Request, key: string): Request {
+    const headers = new Headers(request.headers);
+    headers.set('authorization', `Bearer ${key}`);
+    return new Request(request, { headers });
+  }
+
+  private shouldRetry(status: number): boolean {
+    return status === 401 || status === 403;
+  }
+
+  private async handleAuthFailure(status: number): Promise<boolean> {
+    try {
+      this.logger.warn(`LiteLLM auth failure detected, reprovisioning ${JSON.stringify({ status })}`);
+      await this.refreshKey('auth_error');
+      return true;
+    } catch (error) {
+      this.logger.error('LiteLLM reprovisioning after auth failure failed', error);
+      return false;
+    }
+  }
+
+  private requireActiveKey(): string {
+    if (!this.currentKey?.key) {
+      throw new Error('litellm_active_key_missing');
+    }
+    return this.currentKey.key;
+  }
+
+  private async refreshKey(trigger: ProvisionContext): Promise<void> {
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+    this.refreshPromise = this.performRefresh(trigger).finally(() => {
+      this.refreshPromise = undefined;
+    });
+    await this.refreshPromise;
+  }
+
+  private async performRefresh(trigger: ProvisionContext): Promise<void> {
+    const previousKey = this.currentKey?.key;
+    const state = await this.generateAndPersistKey(trigger);
+    this.applyKeyState(state);
+    if (previousKey) {
+      await this.revokeKey(previousKey, `rotation:${trigger}`);
+    }
+  }
+
+  private applyKeyState(state: VirtualKeyState): void {
+    this.currentKey = state;
+    this.scheduleRefresh(state.expiresAt);
+    this.ensureOpenAIClient();
+  }
+
+  private scheduleRefresh(expiresAt: Date | null): void {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = undefined;
+    }
+    if (!expiresAt) return;
+
+    const msUntilExpiry = expiresAt.getTime() - Date.now();
+    const delay = Math.max(MIN_REFRESH_DELAY_MS, msUntilExpiry - REFRESH_GRACE_MS);
+    this.refreshTimer = setTimeout(() => {
+      void this.refreshKey('refresh');
+    }, delay);
+  }
+
+  private async generateAndPersistKey(context: ProvisionContext): Promise<VirtualKeyState> {
+    const generated = await this.generateVirtualKey();
+    await this.keyStore.save({ alias: this.keyAlias, key: generated.key, expiresAt: generated.expiresAt });
+    this.logger.debug(`LiteLLM virtual key issued ${JSON.stringify({ alias: this.keyAlias, context })}`);
+    return generated;
+  }
+
+  private async generateVirtualKey(): Promise<VirtualKeyState> {
     if (!this.cfg.litellmBaseUrl || !this.cfg.litellmMasterKey) {
       throw new Error('litellm_missing_config');
     }
 
-    const { apiKey: provKey, baseUrl } = await this.provisionWithRetry();
-    if (provKey) return { apiKey: provKey, baseUrl };
-
-    // Fallback to configured envs
-    const fallbackKey = this.cfg.litellmMasterKey as string; // ensureKeys guarantees presence
-    const base =
-      this.cfg.openaiBaseUrl ||
-      (this.cfg.litellmBaseUrl ? `${this.cfg.litellmBaseUrl.replace(/\/$/, '')}/v1` : undefined);
-    return { apiKey: fallbackKey, baseUrl: base };
-  }
-
-  private async provisionWithRetry(): Promise<ProvisionResult> {
-    const base = this.cfg.litellmBaseUrl;
-    const master = this.cfg.litellmMasterKey;
-    if (!base || !master) return {};
-
-    const models = this.toList(process.env.LITELLM_MODELS, ['all-team-models']);
-    const duration = process.env.LITELLM_KEY_DURATION || '30d';
-    const keyAlias = process.env.LITELLM_KEY_ALIAS || `agents-${process.pid}`;
-    const maxBudget = process.env.LITELLM_MAX_BUDGET;
-    const rpm = process.env.LITELLM_RPM_LIMIT;
-    const tpm = process.env.LITELLM_TPM_LIMIT;
-    const teamId = process.env.LITELLM_TEAM_ID;
-
-    const url = `${base.replace(/\/$/, '')}/key/generate`;
+    const base = this.cfg.litellmBaseUrl.replace(/\/$/, '');
+    const url = `${base}/key/generate`;
     const headers: Record<string, string> = {
       'content-type': 'application/json',
-      authorization: `Bearer ${master}`,
+      authorization: `Bearer ${this.cfg.litellmMasterKey}`,
     };
-    const body: Record<string, unknown> = { models, duration, key_alias: keyAlias };
-    const num = (s?: string) => {
-      if (!s) return undefined;
-      const n = Number(s);
-      return Number.isFinite(n) && n >= 0 ? n : undefined;
+    const body: Record<string, unknown> = {
+      key_alias: this.keyAlias,
+      models: this.toList(process.env.LITELLM_MODELS, ['all-team-models']),
+      duration: process.env.LITELLM_KEY_DURATION || '30d',
     };
-    const mb = num(maxBudget);
-    const r = num(rpm);
-    const t = num(tpm);
-    if (mb !== undefined) body.max_budget = mb;
-    if (r !== undefined) body.rpm_limit = r;
-    if (t !== undefined) body.tpm_limit = t;
-    if (typeof teamId === 'string' && teamId.length > 0) body.team_id = teamId;
+
+    const setNumeric = (value: string | undefined, key: string) => {
+      if (!value) return;
+      const parsed = Number(value);
+      if (Number.isFinite(parsed) && parsed >= 0) {
+        body[key] = parsed;
+      }
+    };
+
+    setNumeric(process.env.LITELLM_MAX_BUDGET, 'max_budget');
+    setNumeric(process.env.LITELLM_RPM_LIMIT, 'rpm_limit');
+    setNumeric(process.env.LITELLM_TPM_LIMIT, 'tpm_limit');
+
+    if (process.env.LITELLM_TEAM_ID) {
+      body.team_id = process.env.LITELLM_TEAM_ID;
+    }
 
     const maxAttempts = 3;
     const baseDelayMs = 300;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       try {
-        const resp = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
-        if (!resp.ok && (await this.handleProvisionNonOk(resp, attempt, maxAttempts, baseDelayMs))) continue;
-        const data = (await this.safeReadJson(resp)) as { key?: string } | undefined;
-        const key = data?.key;
-        if (!key || typeof key !== 'string') throw new Error('litellm_provision_invalid_response');
-        const baseUrl = this.cfg.openaiBaseUrl || `${base.replace(/\/$/, '')}/v1`;
-        return { apiKey: key, baseUrl };
-      } catch (e: unknown) {
-        const msg = e && typeof e === 'object' && 'message' in e ? (e as { message?: string }).message : String(e);
-        if (attempt < maxAttempts) {
-          this.logger.debug(
-            `LiteLLM provisioning attempt failed ${JSON.stringify({ attempt, error: msg || String(e) })}`,
-          );
-          await this.delay(baseDelayMs * Math.pow(2, attempt - 1));
+        const response = await this.fetchImpl(url, { method: 'POST', headers, body: JSON.stringify(body) });
+        if (!response.ok) {
+          await this.handleProvisionNonOk(response, attempt, maxAttempts, baseDelayMs);
           continue;
         }
-        this.logger.error(
-          `LiteLLM provisioning failed after retries ${JSON.stringify({ attempts: maxAttempts })}`,
+
+        const data = (await this.safeReadJson(response)) as { key?: string; expires?: string } | undefined;
+        if (!data?.key || typeof data.key !== 'string') {
+          throw new Error('litellm_provision_invalid_response');
+        }
+        const expiresAt = this.parseExpiry(data.expires);
+        return { key: data.key, expiresAt };
+      } catch (error) {
+        if (attempt >= maxAttempts) {
+          this.logger.error('LiteLLM provisioning failed after retries', error);
+          throw error;
+        }
+        this.logger.debug(
+          `LiteLLM provisioning attempt failed ${JSON.stringify({ attempt, error: this.describeError(error) })}`,
         );
-        return {};
+        await this.delay(baseDelayMs * Math.pow(2, attempt - 1));
       }
     }
-    return {};
+    throw new Error('litellm_provision_failed');
   }
 
   private async handleProvisionNonOk(
@@ -112,26 +261,80 @@ export class LiteLLMProvisioner extends LLMProvisioner {
     attempt: number,
     maxAttempts: number,
     baseDelayMs: number,
-  ): Promise<boolean> {
+  ): Promise<void> {
     const text = await this.safeReadText(resp);
     this.logger.error(
       `LiteLLM provisioning failed ${JSON.stringify({ status: String(resp.status), body: this.redact(text) })}`,
     );
-    const shouldRetry = resp.status >= 500 && attempt < maxAttempts;
-    if (shouldRetry) {
+    if (resp.status >= 500 && attempt < maxAttempts) {
       await this.delay(baseDelayMs * Math.pow(2, attempt - 1));
-      return true;
+      return;
     }
     throw new Error(`litellm_provision_failed_${resp.status}`);
   }
 
-  private toList(v: string | undefined, dflt: string[]): string[] {
+  private parseExpiry(candidate: string | undefined): Date | null {
+    if (!candidate) return null;
+    const ts = Date.parse(candidate);
+    return Number.isFinite(ts) ? new Date(ts) : null;
+  }
+
+  private async revokeKey(key: string, context: string): Promise<void> {
+    if (!this.cfg.litellmBaseUrl || !this.cfg.litellmMasterKey) return;
+    const base = this.cfg.litellmBaseUrl.replace(/\/$/, '');
+    const url = `${base}/key/delete`;
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      authorization: `Bearer ${this.cfg.litellmMasterKey}`,
+    };
+
+    try {
+      const resp = await this.fetchImpl(url, { method: 'POST', headers, body: JSON.stringify({ keys: [key] }) });
+      if (resp.status === 404) {
+        this.logger.debug(`LiteLLM key already revoked ${JSON.stringify({ context })}`);
+        return;
+      }
+      if (!resp.ok) {
+        const text = await this.safeReadText(resp);
+        this.logger.warn(
+          `LiteLLM key revoke failed ${JSON.stringify({ context, status: resp.status, body: this.redact(text) })}`,
+        );
+      }
+    } catch (error) {
+      this.logger.warn(`LiteLLM key revoke error ${JSON.stringify({ context, error: this.describeError(error) })}`);
+    }
+  }
+
+  private registerShutdownHooks(): void {
+    const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+    for (const signal of signals) {
+      const handler = () => {
+        void this.revokeCurrentKey('shutdown');
+      };
+      process.once(signal, handler);
+      this.shutdownHandlers.push({ signal, handler });
+    }
+  }
+
+  private async revokeCurrentKey(context: string): Promise<void> {
+    if (!this.currentKey?.key) return;
+    await this.revokeKey(this.currentKey.key, context);
+  }
+
+  private removeShutdownHooks(): void {
+    for (const { signal, handler } of this.shutdownHandlers.splice(0)) {
+      process.off(signal, handler);
+    }
+  }
+
+  private toList(v: string | undefined, fallback: string[]): string[] {
     const parts = (v || '')
       .split(',')
       .map((x) => x.trim())
       .filter(Boolean);
-    return parts.length ? parts : dflt;
+    return parts.length ? parts : fallback;
   }
+
   private async safeReadText(resp: Response): Promise<string> {
     try {
       return await resp.text();
@@ -139,6 +342,7 @@ export class LiteLLMProvisioner extends LLMProvisioner {
       return '';
     }
   }
+
   private async safeReadJson(resp: Response): Promise<unknown> {
     try {
       return await resp.json();
@@ -146,11 +350,36 @@ export class LiteLLMProvisioner extends LLMProvisioner {
       return undefined;
     }
   }
-  private redact(s: string): string {
-    if (!s) return s;
-    return s.replace(/(sk-[A-Za-z0-9_-]{6,})/g, '[REDACTED]');
+
+  private redact(value: string): string {
+    return value?.replace(/(sk-[A-Za-z0-9_-]{6,})/g, '[REDACTED]') ?? value;
   }
-  private async delay(ms: number) {
-    await new Promise((res) => setTimeout(res, ms));
+
+  private resolveAlias(): string {
+    const explicit = (process.env.LITELLM_KEY_ALIAS ?? '').trim();
+    if (explicit) return explicit;
+
+    const envName = (process.env.AGENTS_ENV ?? process.env.NODE_ENV ?? 'local').replace(/\s+/g, '-');
+    const deployment =
+      process.env.AGENTS_DEPLOYMENT ||
+      process.env.DEPLOYMENT_ID ||
+      process.env.HOSTNAME ||
+      os.hostname() ||
+      'unknown';
+    const normalizedDeployment = deployment.replace(/\s+/g, '-');
+    return `agents/${envName}/${normalizedDeployment}`;
+  }
+
+  private describeError(error: unknown): string {
+    if (!error) return 'unknown';
+    if (typeof error === 'string') return error;
+    if (typeof error === 'object' && 'message' in error) {
+      return String((error as { message?: unknown }).message);
+    }
+    return String(error);
+  }
+
+  private async delay(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
   }
 }


### PR DESCRIPTION
## Summary
- add a persistent LiteLLMVirtualKey model + store for durable key lifecycle
- re-implement the LiteLLM provisioner to persist, refresh, and revoke virtual keys with auth retry hooks
- document the lifecycle expectations and add regression coverage for provisioning, refresh, and auth retry

## Testing
- pnpm lint
- LOG_LEVEL=error AGENTS_DATABASE_URL='postgresql://postgres:postgres@localhost:5432/agents_test' LITELLM_BASE_URL='http://localhost:4000' LITELLM_MASTER_KEY='test-master-key' pnpm --filter @agyn/platform-server test
