### PR TITLE
Fix ordered list numbering in conversation markdown

### DIFF
--- a/packages/platform-ui/src/components/MarkdownContent.tsx
+++ b/packages/platform-ui/src/components/MarkdownContent.tsx
@@ -4,6 +4,7 @@ import { Children, cloneElement, isValidElement, type ComponentPropsWithoutRef, 
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { MARKDOWN_REMARK_PLUGINS, MARKDOWN_REHYPE_PLUGINS } from '@/lib/markdown/config';
+import { cn } from '@/lib/utils';
 
 interface MarkdownContentProps {
   content: string;
@@ -18,6 +19,10 @@ type MarkdownCodeProps = ComponentPropsWithoutRef<'code'> & {
 type MarkdownPreProps = ComponentPropsWithoutRef<'pre'> & {
   node?: unknown;
 };
+
+type MarkdownOrderedListProps = ComponentPropsWithoutRef<'ol'>;
+type MarkdownUnorderedListProps = ComponentPropsWithoutRef<'ul'>;
+type MarkdownListItemProps = ComponentPropsWithoutRef<'li'>;
 
 export function MarkdownContent({ content, className = '' }: MarkdownContentProps) {
   const markdownComponents: Components = {
@@ -61,18 +66,24 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
     ),
 
     // Lists
-    ul: ({ children }) => (
-      <ul className="list-disc list-outside ml-5 mb-4 space-y-1 text-[var(--agyn-dark)]">
+    ul: ({ children, className, ...props }: MarkdownUnorderedListProps) => (
+      <ul
+        className={cn('list-disc list-outside ml-5 mb-4 space-y-1 text-[var(--agyn-dark)]', className)}
+        {...props}
+      >
         {children}
       </ul>
     ),
-    ol: ({ children }) => (
-      <ol className="list-decimal list-outside ml-5 mb-4 space-y-1 text-[var(--agyn-dark)]">
+    ol: ({ children, className, ...props }: MarkdownOrderedListProps) => (
+      <ol
+        className={cn('list-decimal list-outside ml-5 mb-4 space-y-1 text-[var(--agyn-dark)]', className)}
+        {...props}
+      >
         {children}
       </ol>
     ),
-    li: ({ children }) => (
-      <li className="text-[var(--agyn-dark)] leading-relaxed">
+    li: ({ children, className, ...props }: MarkdownListItemProps) => (
+      <li className={cn('text-[var(--agyn-dark)] leading-relaxed', className)} {...props}>
         {children}
       </li>
     ),

--- a/packages/platform-ui/src/components/MarkdownContent.tsx
+++ b/packages/platform-ui/src/components/MarkdownContent.tsx
@@ -20,9 +20,17 @@ type MarkdownPreProps = ComponentPropsWithoutRef<'pre'> & {
   node?: unknown;
 };
 
-type MarkdownOrderedListProps = ComponentPropsWithoutRef<'ol'>;
-type MarkdownUnorderedListProps = ComponentPropsWithoutRef<'ul'>;
-type MarkdownListItemProps = ComponentPropsWithoutRef<'li'>;
+type ReactMarkdownListInternals = {
+  node?: unknown;
+  ordered?: boolean;
+  depth?: number;
+  index?: number;
+  checked?: boolean | null;
+};
+
+type MarkdownOrderedListProps = ComponentPropsWithoutRef<'ol'> & ReactMarkdownListInternals;
+type MarkdownUnorderedListProps = ComponentPropsWithoutRef<'ul'> & ReactMarkdownListInternals;
+type MarkdownListItemProps = ComponentPropsWithoutRef<'li'> & ReactMarkdownListInternals;
 
 export function MarkdownContent({ content, className = '' }: MarkdownContentProps) {
   const markdownComponents: Components = {
@@ -66,24 +74,24 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
     ),
 
     // Lists
-    ul: ({ children, className, ...props }: MarkdownUnorderedListProps) => (
+    ul: ({ children, className, node: _node, depth: _depth, ordered: _ordered, ...domProps }: MarkdownUnorderedListProps) => (
       <ul
         className={cn('list-disc list-outside ml-5 mb-4 space-y-1 text-[var(--agyn-dark)]', className)}
-        {...props}
+        {...domProps}
       >
         {children}
       </ul>
     ),
-    ol: ({ children, className, ...props }: MarkdownOrderedListProps) => (
+    ol: ({ children, className, node: _node, depth: _depth, ordered: _ordered, index: _index, ...domProps }: MarkdownOrderedListProps) => (
       <ol
         className={cn('list-decimal list-outside ml-5 mb-4 space-y-1 text-[var(--agyn-dark)]', className)}
-        {...props}
+        {...domProps}
       >
         {children}
       </ol>
     ),
-    li: ({ children, className, ...props }: MarkdownListItemProps) => (
-      <li className={cn('text-[var(--agyn-dark)] leading-relaxed', className)} {...props}>
+    li: ({ children, className, node: _node, ordered: _ordered, index: _index, checked: _checked, depth: _depth, ...domProps }: MarkdownListItemProps) => (
+      <li className={cn('text-[var(--agyn-dark)] leading-relaxed', className)} {...domProps}>
         {children}
       </li>
     ),

--- a/packages/platform-ui/src/components/__tests__/MarkdownContent.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/MarkdownContent.test.tsx
@@ -37,6 +37,7 @@ const codeBlockNoLanguage = ['```', 'line one', 'line two', '```'].join('\n');
 const newlineSeparatedText = ['First line', 'Second line', 'Third line'].join('\n');
 
 const listMarkdown = ['- First item', '- Second item'].join('\n');
+const orderedListWithParagraph = ['1. First item', '', 'Extra context between items.', '', '2. Second item'].join('\n');
 
 const sanitizedHtmlCodeBlock = '<pre><code>alpha\nbeta\ngamma</code></pre>';
 const wrappingMarkdown = 'Discuss removing break-all without forced breaks.';
@@ -170,5 +171,19 @@ describe('MarkdownContent rendering', () => {
     expect(items).toHaveLength(2);
     expect(items[0]).toHaveTextContent('First item');
     expect(items[1]).toHaveTextContent('Second item');
+  });
+
+  it('maintains ordered list numbering across separated segments', () => {
+    const { container } = render(<MarkdownContent content={orderedListWithParagraph} />);
+
+    const orderedLists = container.querySelectorAll('ol');
+    expect(orderedLists).toHaveLength(2);
+
+    const [firstList, secondList] = Array.from(orderedLists);
+    expect(firstList.querySelectorAll('li')).toHaveLength(1);
+    expect(secondList.querySelectorAll('li')).toHaveLength(1);
+
+    expect(secondList).toHaveAttribute('start', '2');
+    expect(screen.getByText('Extra context between items.').tagName).toBe('P');
   });
 });

--- a/packages/platform-ui/src/lib/markdown/sanitize.ts
+++ b/packages/platform-ui/src/lib/markdown/sanitize.ts
@@ -43,6 +43,14 @@ export const markdownSanitizeSchema: Schema = {
     code: [
       ['className', /^language-[\w-]+$/],
     ],
+    ol: [
+      ['start', /^-?\d+$/],
+      ['type', '1', 'a', 'A', 'i', 'I'],
+      'reversed',
+    ],
+    li: [
+      ['value', /^-?\d+$/],
+    ],
     th: ['align'],
     td: ['align'],
   },


### PR DESCRIPTION
## Summary
- add a regression test that captures how ordered lists split across paragraphs currently render more than one `<ol>` tag
- allow `ReactMarkdown` to forward ordered list metadata to the DOM (and permit it through the sanitizer) so numbering no longer resets
- reuse the same helper-based class merging for list elements to ensure we preserve any attributes `react-markdown` provides in the future

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui exec vitest run --reporter=dot
