### PR TITLE
Refactor onboarding gating modal

### DIFF
--- a/packages/platform-ui/src/features/onboarding/components/OnboardingContent.tsx
+++ b/packages/platform-ui/src/features/onboarding/components/OnboardingContent.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo } from 'react';
+import { CheckCircle2, Loader2 } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/components/ui/utils';
+
+import type { OnboardingStatusResponse } from '../api';
+import { EMPTY_PROFILE, type ProfileFormValues } from '../lib/profile';
+
+const PROFILE_STEP_ID = 'profile.basic_v1';
+
+const STEP_COPY: Record<string, { title: string; description: string }> = {
+  [PROFILE_STEP_ID]: {
+    title: 'Tell us about yourself',
+    description: 'Add your first name, last name, and a contact email so agents know who you are.',
+  },
+};
+
+export type OnboardingContentProps = {
+  status: OnboardingStatusResponse;
+  onSubmitProfile: (values: ProfileFormValues) => Promise<void>;
+  isSubmitting: boolean;
+};
+
+export function OnboardingContent({ status, onSubmitProfile, isSubmitting }: OnboardingContentProps) {
+  const orderedSteps = useMemo(() => deriveOrderedSteps(status), [status]);
+  const currentStepId = status.requiredSteps[0] ?? null;
+
+  return (
+    <div className="space-y-8">
+      <WizardProgress status={status} orderedSteps={orderedSteps} />
+      <div className="grid gap-8 lg:grid-cols-2">
+        <StepList orderedSteps={orderedSteps} status={status} currentStepId={currentStepId} />
+        <div className="rounded-2xl border border-[var(--agyn-border-light)] bg-white p-6 shadow-sm">
+          {currentStepId === PROFILE_STEP_ID ? (
+            <ProfileStepForm
+              initialValues={status.data.profile ?? EMPTY_PROFILE}
+              onSubmit={onSubmitProfile}
+              isSubmitting={isSubmitting}
+            />
+          ) : (
+            <UnknownStep stepId={currentStepId} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function deriveOrderedSteps(status: OnboardingStatusResponse): string[] {
+  const ordered: string[] = [];
+  for (const id of status.completedSteps) {
+    if (!ordered.includes(id)) ordered.push(id);
+  }
+  for (const id of status.requiredSteps) {
+    if (!ordered.includes(id)) ordered.push(id);
+  }
+  return ordered.length > 0 ? ordered : [PROFILE_STEP_ID];
+}
+
+function WizardProgress({
+  status,
+  orderedSteps,
+}: {
+  status: OnboardingStatusResponse;
+  orderedSteps: string[];
+}) {
+  const totalSteps = Math.max(orderedSteps.length, 1);
+  const completed = Math.min(status.completedSteps.length, totalSteps);
+  const currentNumber = Math.min(completed + 1, totalSteps);
+  const progressPercent = (completed / totalSteps) * 100;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>
+          Step {currentNumber} of {totalSteps}
+        </span>
+        <span>{Math.round(progressPercent)}% complete</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-[var(--agyn-border-light)]">
+        <div
+          className="h-full bg-[var(--agyn-blue)] transition-all duration-300"
+          style={{ width: `${progressPercent}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StepList({
+  orderedSteps,
+  status,
+  currentStepId,
+}: {
+  orderedSteps: string[];
+  status: OnboardingStatusResponse;
+  currentStepId: string | null;
+}) {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">Required steps</p>
+      <ul className="space-y-3">
+        {orderedSteps.map((stepId) => {
+          const copy = STEP_COPY[stepId] ?? {
+            title: stepId,
+            description: 'Complete this step to continue.',
+          };
+          const isComplete = status.completedSteps.includes(stepId);
+          const isActive = stepId === currentStepId;
+          return (
+            <li key={stepId} className="flex items-start gap-3">
+              {isComplete ? (
+                <CheckCircle2 className="mt-0.5 h-5 w-5 text-green-500" />
+              ) : (
+                <span
+                  className={cn(
+                    'mt-0.5 h-5 w-5 rounded-full border border-[var(--agyn-border-light)]',
+                    isActive && 'border-[var(--agyn-blue)] bg-[rgba(67,97,238,0.08)]',
+                  )}
+                />
+              )}
+              <div>
+                <p className="text-sm font-medium">{copy.title}</p>
+                <p className="text-xs leading-snug text-muted-foreground">{copy.description}</p>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function ProfileStepForm({
+  initialValues,
+  onSubmit,
+  isSubmitting,
+}: {
+  initialValues: ProfileFormValues;
+  onSubmit: (values: ProfileFormValues) => Promise<void>;
+  isSubmitting: boolean;
+}) {
+  const form = useForm<ProfileFormValues>({
+    defaultValues: initialValues ?? EMPTY_PROFILE,
+  });
+
+  useEffect(() => {
+    form.reset(initialValues ?? EMPTY_PROFILE);
+  }, [initialValues, form]);
+
+  return (
+    <Form {...form}>
+      <form
+        className="space-y-4"
+        onSubmit={form.handleSubmit(async (values) => {
+          await onSubmit(values);
+        })}
+      >
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Profile basics</h3>
+          <p className="text-sm text-muted-foreground">
+            We use this information to personalize agent assignments and notifications.
+          </p>
+        </div>
+
+        <FormField
+          control={form.control}
+          name="firstName"
+          rules={{
+            required: 'First name is required',
+            validate: (value) => value.trim().length > 0 || 'First name is required',
+          }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>First name</FormLabel>
+              <FormControl>
+                <Input {...field} autoComplete="given-name" placeholder="Jane" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="lastName"
+          rules={{
+            required: 'Last name is required',
+            validate: (value) => value.trim().length > 0 || 'Last name is required',
+          }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Last name</FormLabel>
+              <FormControl>
+                <Input {...field} autoComplete="family-name" placeholder="Doe" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="email"
+          rules={{
+            required: 'Email is required',
+            validate: (value) => /.+@.+\..+/.test(value.trim()) || 'Enter a valid email',
+          }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input {...field} type="email" autoComplete="email" placeholder="you@example.com" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
+          {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Save and continue
+        </Button>
+      </form>
+    </Form>
+  );
+}
+
+function UnknownStep({ stepId }: { stepId: string | null }) {
+  if (!stepId) {
+    return <p className="text-sm text-muted-foreground">No additional steps are required right now.</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="font-medium">{stepId}</p>
+      <p className="text-sm text-muted-foreground">
+        This onboarding step is not yet supported in the UI. Please check back after updating the application.
+      </p>
+    </div>
+  );
+}

--- a/packages/platform-ui/src/features/onboarding/components/OnboardingGate.tsx
+++ b/packages/platform-ui/src/features/onboarding/components/OnboardingGate.tsx
@@ -8,34 +8,25 @@ import { OnboardingModal } from './OnboardingModal';
 
 export function OnboardingGate() {
   const statusQuery = useOnboardingStatus();
-  const hasData = Boolean(statusQuery.data);
-  const loadingWithoutData = statusQuery.isFetching && !hasData;
-  const errorWithoutData = statusQuery.isError && !hasData;
-  const initialLoading = !hasData && statusQuery.isLoading;
-  const initialError = !hasData && statusQuery.isError;
+  const status = statusQuery.data ?? null;
 
-  if (initialLoading) {
+  if (!status) {
+    if (statusQuery.isError) {
+      return <GateMessage variant="error" onRetry={() => statusQuery.refetch()} />;
+    }
     return <GateMessage variant="loading" />;
   }
 
-  if (initialError) {
-    return <GateMessage variant="error" onRetry={() => statusQuery.refetch()} />;
-  }
-
-  if (!statusQuery.data) {
-    return null;
-  }
-
-  const shouldShowModal = !statusQuery.data.isComplete;
+  const shouldShowModal = !status.isComplete;
 
   return (
     <>
       <Outlet />
       <OnboardingModal
         open={shouldShowModal}
-        status={statusQuery.data}
-        isLoading={loadingWithoutData}
-        isError={errorWithoutData}
+        status={status}
+        isLoading={statusQuery.isFetching && !statusQuery.isSuccess}
+        isError={statusQuery.isError && !statusQuery.isSuccess}
         onRetry={() => statusQuery.refetch()}
       />
     </>

--- a/packages/platform-ui/src/features/onboarding/components/OnboardingModal.tsx
+++ b/packages/platform-ui/src/features/onboarding/components/OnboardingModal.tsx
@@ -1,0 +1,102 @@
+import { AlertTriangle, Loader2 } from 'lucide-react';
+
+import {
+  ScreenDialog,
+  ScreenDialogContent,
+  ScreenDialogDescription,
+  ScreenDialogHeader,
+  ScreenDialogTitle,
+} from '@/components/Dialog';
+import { Button } from '@/components/ui/button';
+
+import type { OnboardingStatusResponse } from '../api';
+import { useSaveOnboardingProfile } from '../hooks';
+
+import { OnboardingContent } from './OnboardingContent';
+import { buildProfilePayload } from '../lib/profile';
+
+type OnboardingModalProps = {
+  open: boolean;
+  status: OnboardingStatusResponse | null;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => unknown;
+};
+
+export function OnboardingModal({ open, status, isLoading, isError, onRetry }: OnboardingModalProps) {
+  const saveProfile = useSaveOnboardingProfile();
+
+  if (!open) {
+    return null;
+  }
+
+  const showLoading = isLoading && !status;
+  const showError = isError && !status;
+
+  return (
+    <ScreenDialog open={open} modal data-testid="onboarding-modal" onOpenChange={() => {}}>
+      <ScreenDialogContent
+        hideCloseButton
+        className="w-full max-w-4xl space-y-6"
+        onEscapeKeyDown={(event) => event.preventDefault()}
+        onPointerDownOutside={(event) => event.preventDefault()}
+      >
+        <ScreenDialogHeader className="space-y-1">
+          <ScreenDialogTitle>Complete onboarding</ScreenDialogTitle>
+          <ScreenDialogDescription>
+            Finish the required steps to unlock the rest of your workspace.
+          </ScreenDialogDescription>
+        </ScreenDialogHeader>
+
+        {showLoading ? (
+          <ModalState variant="loading" />
+        ) : showError ? (
+          <ModalState variant="error" onRetry={onRetry} />
+        ) : status ? (
+          <OnboardingContent
+            status={status}
+            onSubmitProfile={async (values) => {
+              await saveProfile.mutateAsync(buildProfilePayload(values));
+            }}
+            isSubmitting={saveProfile.isPending}
+          />
+        ) : null}
+      </ScreenDialogContent>
+    </ScreenDialog>
+  );
+}
+
+type ModalStateProps = {
+  variant: 'loading' | 'error';
+  onRetry?: () => unknown;
+};
+
+function ModalState({ variant, onRetry }: ModalStateProps) {
+  const copy: Record<ModalStateProps['variant'], { title: string; body: string }> = {
+    loading: {
+      title: 'Preparing onboarding…',
+      body: 'Fetching the latest onboarding requirements.',
+    },
+    error: {
+      title: 'Unable to load onboarding data',
+      body: 'Please retry. If the issue continues, verify the server logs.',
+    },
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-8 text-center">
+      {variant === 'error' ? (
+        <AlertTriangle className="h-10 w-10 text-destructive" />
+      ) : (
+        <Loader2 className="h-10 w-10 animate-spin text-[var(--agyn-blue)]" />
+      )}
+      <div className="space-y-1">
+        <p className="text-lg font-semibold">{copy[variant].title}</p>
+        <p className="text-sm text-muted-foreground">{copy[variant].body}</p>
+      </div>
+      {variant === 'error' && onRetry ? (
+        <Button onClick={() => void onRetry()}>Retry</Button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/platform-ui/src/features/onboarding/lib/profile.ts
+++ b/packages/platform-ui/src/features/onboarding/lib/profile.ts
@@ -1,0 +1,21 @@
+import type { OnboardingProfilePayload } from '../api';
+
+export type ProfileFormValues = {
+  firstName: string;
+  lastName: string;
+  email: string;
+};
+
+export const EMPTY_PROFILE: ProfileFormValues = {
+  firstName: '',
+  lastName: '',
+  email: '',
+};
+
+export function buildProfilePayload(values: ProfileFormValues): OnboardingProfilePayload {
+  return {
+    firstName: values.firstName.trim(),
+    lastName: values.lastName.trim(),
+    email: values.email.trim(),
+  };
+}

--- a/packages/platform-ui/src/pages/OnboardingPage.tsx
+++ b/packages/platform-ui/src/pages/OnboardingPage.tsx
@@ -1,30 +1,11 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { CheckCircle2, Loader2, AlertTriangle } from 'lucide-react';
-import { useForm } from 'react-hook-form';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { cn } from '@/components/ui/utils';
+import { OnboardingContent } from '@/features/onboarding/components/OnboardingContent';
+import { buildProfilePayload } from '@/features/onboarding/lib/profile';
 import { useOnboardingStatus, useSaveOnboardingProfile } from '@/features/onboarding/hooks';
-import type { OnboardingStatusResponse } from '@/features/onboarding/api';
-
-const PROFILE_STEP_ID = 'profile.basic_v1';
-const STEP_COPY: Record<string, { title: string; description: string }> = {
-  [PROFILE_STEP_ID]: {
-    title: 'Tell us about yourself',
-    description: 'Add your first name, last name, and a contact email so agents know who you are.',
-  },
-};
-
-type ProfileFormValues = {
-  firstName: string;
-  lastName: string;
-  email: string;
-};
-
-const EMPTY_PROFILE: ProfileFormValues = { firstName: '', lastName: '', email: '' };
 
 export function OnboardingPage() {
   const statusQuery = useOnboardingStatus();
@@ -36,31 +17,15 @@ export function OnboardingPage() {
     return state?.from ?? '/agents/graph';
   }, [location.state]);
 
-  const status = statusQuery.data ?? null;
-  const orderedSteps = useMemo(() => (status ? deriveOrderedSteps(status) : [PROFILE_STEP_ID]), [status]);
-  const currentStepId = status?.requiredSteps[0] ?? null;
-
-  const handleProfileSubmit = useCallback(
-    async (values: ProfileFormValues) => {
-      const payload = {
-        firstName: values.firstName.trim(),
-        lastName: values.lastName.trim(),
-        email: values.email.trim(),
-      };
-      await saveProfile.mutateAsync(payload);
-    },
-    [saveProfile],
-  );
-
   if (statusQuery.isLoading) {
     return <FullScreenState variant="loading" onRetry={() => statusQuery.refetch()} />;
   }
 
-  if (statusQuery.isError || !status) {
+  if (statusQuery.isError || !statusQuery.data) {
     return <FullScreenState variant="error" onRetry={() => statusQuery.refetch()} />;
   }
 
-  if (status.isComplete) {
+  if (statusQuery.data.isComplete) {
     return (
       <FullScreenState
         variant="success"
@@ -71,229 +36,21 @@ export function OnboardingPage() {
 
   return (
     <div className="min-h-screen bg-[var(--agyn-bg-light)] flex items-center justify-center px-4 py-10">
-      <Card className="w-full max-w-3xl border border-[var(--agyn-border-light)] shadow-xl">
-        <CardHeader>
-          <CardTitle className="text-2xl font-semibold">Complete onboarding</CardTitle>
-          <CardDescription>
-            Finish the required steps below to unlock the rest of the workspace.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-8">
-          <WizardProgress status={status} orderedSteps={orderedSteps} />
-          <div className="grid gap-8 lg:grid-cols-2">
-            <StepList orderedSteps={orderedSteps} status={status} currentStepId={currentStepId} />
-            <div className="rounded-xl border border-[var(--agyn-border-light)] p-6 bg-white shadow-sm">
-              {currentStepId === PROFILE_STEP_ID ? (
-                <ProfileStepForm
-                  initialValues={status.data.profile ?? EMPTY_PROFILE}
-                  onSubmit={handleProfileSubmit}
-                  isSubmitting={saveProfile.isPending}
-                />
-              ) : (
-                <UnknownStep stepId={currentStepId} />
-              )}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function deriveOrderedSteps(status: OnboardingStatusResponse): string[] {
-  const ordered: string[] = [];
-  for (const id of status.completedSteps) {
-    if (!ordered.includes(id)) ordered.push(id);
-  }
-  for (const id of status.requiredSteps) {
-    if (!ordered.includes(id)) ordered.push(id);
-  }
-  return ordered.length > 0 ? ordered : [PROFILE_STEP_ID];
-}
-
-function WizardProgress({
-  status,
-  orderedSteps,
-}: {
-  status: OnboardingStatusResponse;
-  orderedSteps: string[];
-}) {
-  const totalSteps = Math.max(orderedSteps.length, 1);
-  const completed = Math.min(status.completedSteps.length, totalSteps);
-  const currentNumber = Math.min(completed + 1, totalSteps);
-  const progressPercent = (completed / totalSteps) * 100;
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-sm text-muted-foreground">
-        <span>
-          Step {currentNumber} of {totalSteps}
-        </span>
-        <span>{Math.round(progressPercent)}% complete</span>
-      </div>
-      <div className="h-2 rounded-full bg-[var(--agyn-border-light)] overflow-hidden">
-        <div
-          className="h-full bg-[var(--agyn-blue)] transition-all duration-300"
-          style={{ width: `${progressPercent}%` }}
-        />
-      </div>
-    </div>
-  );
-}
-
-function StepList({
-  orderedSteps,
-  status,
-  currentStepId,
-}: {
-  orderedSteps: string[];
-  status: OnboardingStatusResponse;
-  currentStepId: string | null;
-}) {
-  return (
-    <div className="space-y-4">
-      <p className="text-sm text-muted-foreground">Required steps</p>
-      <ul className="space-y-3">
-        {orderedSteps.map((stepId) => {
-          const copy = STEP_COPY[stepId] ?? {
-            title: stepId,
-            description: 'Complete this step to continue.',
-          };
-          const isComplete = status.completedSteps.includes(stepId);
-          const isActive = stepId === currentStepId;
-          return (
-            <li key={stepId} className="flex items-start gap-3">
-              {isComplete ? (
-                <CheckCircle2 className="h-5 w-5 text-green-500" />
-              ) : (
-                <span
-                  className={cn(
-                    'h-5 w-5 rounded-full border border-[var(--agyn-border-light)] mt-0.5',
-                    isActive && 'border-[var(--agyn-blue)] bg-[rgba(67,97,238,0.08)]',
-                  )}
-                />
-              )}
-              <div>
-                <p className="font-medium text-sm">{copy.title}</p>
-                <p className="text-xs text-muted-foreground leading-snug">{copy.description}</p>
-              </div>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
-}
-
-function ProfileStepForm({
-  initialValues,
-  onSubmit,
-  isSubmitting,
-}: {
-  initialValues: ProfileFormValues;
-  onSubmit: (values: ProfileFormValues) => Promise<void>;
-  isSubmitting: boolean;
-}) {
-  const form = useForm<ProfileFormValues>({
-    defaultValues: initialValues ?? EMPTY_PROFILE,
-  });
-
-  useEffect(() => {
-    form.reset(initialValues ?? EMPTY_PROFILE);
-  }, [initialValues, form]);
-
-  return (
-    <Form {...form}>
-      <form
-        className="space-y-4"
-        onSubmit={form.handleSubmit(async (values) => {
-          await onSubmit(values);
-        })}
-      >
-        <div className="space-y-2">
-          <h3 className="text-lg font-semibold">Profile basics</h3>
+      <div className="w-full max-w-4xl rounded-[18px] border border-[var(--agyn-border-subtle)] bg-white p-8 shadow-[0px_32px_72px_-24px_rgba(15,23,42,0.35)]">
+        <div className="mb-8 space-y-2 text-center">
+          <h1 className="text-2xl font-semibold">Complete onboarding</h1>
           <p className="text-sm text-muted-foreground">
-            We use this information to personalize agent assignments and notifications.
+            Finish the required steps below to unlock the rest of the workspace.
           </p>
         </div>
-
-        <FormField
-          control={form.control}
-          name="firstName"
-          rules={{
-            required: 'First name is required',
-            validate: (value) => value.trim().length > 0 || 'First name is required',
+        <OnboardingContent
+          status={statusQuery.data}
+          onSubmitProfile={async (values) => {
+            await saveProfile.mutateAsync(buildProfilePayload(values));
           }}
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>First name</FormLabel>
-              <FormControl>
-                <Input {...field} autoComplete="given-name" placeholder="Jane" />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          isSubmitting={saveProfile.isPending}
         />
-
-        <FormField
-          control={form.control}
-          name="lastName"
-          rules={{
-            required: 'Last name is required',
-            validate: (value) => value.trim().length > 0 || 'Last name is required',
-          }}
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Last name</FormLabel>
-              <FormControl>
-                <Input {...field} autoComplete="family-name" placeholder="Doe" />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="email"
-          rules={{
-            required: 'Email is required',
-            validate: (value) => /.+@.+\..+/.test(value.trim()) || 'Enter a valid email',
-          }}
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Email</FormLabel>
-              <FormControl>
-                <Input {...field} type="email" autoComplete="email" placeholder="you@example.com" />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <Button type="submit" className="w-full" disabled={isSubmitting}>
-          {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Save and continue
-        </Button>
-      </form>
-    </Form>
-  );
-}
-
-function UnknownStep({ stepId }: { stepId: string | null }) {
-  if (!stepId) {
-    return (
-      <div className="text-sm text-muted-foreground">
-        No additional steps are required right now.
       </div>
-    );
-  }
-
-  return (
-    <div className="space-y-2">
-      <p className="font-medium">{stepId}</p>
-      <p className="text-sm text-muted-foreground">
-        This onboarding step is not yet supported in the UI. Please check back after updating the application.
-      </p>
     </div>
   );
 }
@@ -327,7 +84,7 @@ function FullScreenState({
   return (
     <div className="min-h-screen bg-[var(--agyn-bg-light)] flex flex-col items-center justify-center gap-4 text-center px-6">
       {variant === 'error' && <AlertTriangle className="h-12 w-12 text-destructive" />}
-      {variant === 'loading' && <Loader2 className="h-12 w-12 text-[var(--agyn-blue)] animate-spin" />}
+      {variant === 'loading' && <Loader2 className="h-12 w-12 animate-spin text-[var(--agyn-blue)]" />}
       {variant === 'success' && <CheckCircle2 className="h-12 w-12 text-green-500" />}
       <div className="space-y-2">
         <p className="text-xl font-semibold">{copy[variant].title}</p>


### PR DESCRIPTION
## Summary
- replace the redirect-based onboarding gate with a ScreenDialog modal overlay that blocks interaction until steps are complete
- extract the onboarding card UI into reusable `OnboardingContent` plus a dedicated `OnboardingModal`, and share payload helpers via a new profile utility module
- convert the `/onboarding` route into a compatibility wrapper that reuses the shared content while still allowing success/loader states

Closes #1207.

## Testing
- `PATH=/nix/store/7brhmf1z6sygq1ag0d0y802m2la9fv6w-nodejs-20.19.6/bin:$PATH pnpm --filter @agyn/platform-ui lint`
- `PATH=/nix/store/7brhmf1z6sygq1ag0d0y802m2la9fv6w-nodejs-20.19.6/bin:$PATH pnpm --filter @agyn/platform-ui test -- --runInBand`
