### PR TITLE
feat: show memory node titles

### DIFF
--- a/packages/platform-ui/src/features/graph/hooks/__tests__/useNodeTitleMap.test.tsx
+++ b/packages/platform-ui/src/features/graph/hooks/__tests__/useNodeTitleMap.test.tsx
@@ -1,0 +1,87 @@
+import React, { type ReactNode } from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import type { TemplateSchema } from '@/api/types/graph';
+import type { GraphPersisted } from '../../types';
+
+import { useNodeTitleMap } from '../useNodeTitleMap';
+
+const serviceMocks = vi.hoisted(() => ({
+  fetchGraph: vi.fn(),
+  fetchTemplates: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => ({
+  graphApiService: serviceMocks,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useNodeTitleMap', () => {
+  beforeEach(() => {
+    serviceMocks.fetchGraph.mockReset();
+    serviceMocks.fetchTemplates.mockReset();
+  });
+
+  it('builds a title map from graph nodes and templates', async () => {
+    const graphResponse: GraphPersisted = {
+      name: 'agents',
+      version: 3,
+      nodes: [
+        {
+          id: 'alpha-node',
+          template: 'tpl-agent',
+          config: { title: 'Agent Alpha' },
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: 'beta-node',
+          template: 'tpl-tool',
+          config: {},
+          position: { x: 10, y: 10 },
+        },
+      ],
+      edges: [],
+    } as GraphPersisted;
+
+    const templatesResponse: TemplateSchema[] = [
+      {
+        name: 'tpl-agent',
+        title: 'Agent Template',
+        kind: 'agent',
+        sourcePorts: {},
+        targetPorts: {},
+      },
+      {
+        name: 'tpl-tool',
+        title: 'Tool Template',
+        kind: 'tool',
+        sourcePorts: {},
+        targetPorts: {},
+      },
+    ];
+
+    serviceMocks.fetchGraph.mockResolvedValue(graphResponse);
+    serviceMocks.fetchTemplates.mockResolvedValue(templatesResponse);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useNodeTitleMap(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('success');
+    });
+
+    expect(serviceMocks.fetchGraph).toHaveBeenCalledTimes(1);
+    expect(serviceMocks.fetchTemplates).toHaveBeenCalledTimes(1);
+    expect(result.current.titleMap.get('alpha-node')).toBe('Agent Alpha');
+    expect(result.current.titleMap.get('beta-node')).toBe('Tool Template');
+  });
+});

--- a/packages/platform-ui/src/features/graph/hooks/__tests__/useNodeTitleMap.test.tsx
+++ b/packages/platform-ui/src/features/graph/hooks/__tests__/useNodeTitleMap.test.tsx
@@ -10,11 +10,18 @@ import { useNodeTitleMap } from '../useNodeTitleMap';
 
 const serviceMocks = vi.hoisted(() => ({
   fetchGraph: vi.fn(),
-  fetchTemplates: vi.fn(),
 }));
 
 vi.mock('../../services/api', () => ({
   graphApiService: serviceMocks,
+}));
+
+const templateHookMocks = vi.hoisted(() => ({
+  useTemplates: vi.fn(),
+}));
+
+vi.mock('@/lib/graph/hooks', () => ({
+  useTemplates: templateHookMocks.useTemplates,
 }));
 
 function createWrapper() {
@@ -28,7 +35,7 @@ function createWrapper() {
 describe('useNodeTitleMap', () => {
   beforeEach(() => {
     serviceMocks.fetchGraph.mockReset();
-    serviceMocks.fetchTemplates.mockReset();
+    templateHookMocks.useTemplates.mockReset();
   });
 
   it('builds a title map from graph nodes and templates', async () => {
@@ -68,9 +75,17 @@ describe('useNodeTitleMap', () => {
         targetPorts: {},
       },
     ];
+    const templatesQuery = {
+      data: templatesResponse,
+      status: 'success' as const,
+      error: null,
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    };
 
     serviceMocks.fetchGraph.mockResolvedValue(graphResponse);
-    serviceMocks.fetchTemplates.mockResolvedValue(templatesResponse);
+    templateHookMocks.useTemplates.mockReturnValue(templatesQuery);
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useNodeTitleMap(), { wrapper });
@@ -80,7 +95,7 @@ describe('useNodeTitleMap', () => {
     });
 
     expect(serviceMocks.fetchGraph).toHaveBeenCalledTimes(1);
-    expect(serviceMocks.fetchTemplates).toHaveBeenCalledTimes(1);
+    expect(templateHookMocks.useTemplates).toHaveBeenCalled();
     expect(result.current.titleMap.get('alpha-node')).toBe('Agent Alpha');
     expect(result.current.titleMap.get('beta-node')).toBe('Tool Template');
   });

--- a/packages/platform-ui/src/features/graph/hooks/useNodeTitleMap.ts
+++ b/packages/platform-ui/src/features/graph/hooks/useNodeTitleMap.ts
@@ -1,38 +1,58 @@
-import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { useQuery, type QueryStatus } from '@tanstack/react-query';
+
+import { useTemplates } from '@/lib/graph/hooks';
 
 import { graphApiService } from '../services/api';
 import { mapPersistedGraphToNodes } from '../mappers';
 
 type NodeTitleEntry = readonly [string, string];
 
-const QUERY_KEY = ['graph', 'node-title-map'] as const;
-
-async function fetchNodeTitleEntries(): Promise<NodeTitleEntry[]> {
-  const [graph, templates] = await Promise.all([
-    graphApiService.fetchGraph(),
-    graphApiService.fetchTemplates(),
-  ]);
-
-  const { nodes } = mapPersistedGraphToNodes(graph, templates);
-  return nodes.map((node) => [node.id, node.title] as const);
-}
+const GRAPH_QUERY_KEY = ['graph', 'persisted'] as const;
 
 export function useNodeTitleMap() {
-  const query = useQuery({
-    queryKey: QUERY_KEY,
-    queryFn: fetchNodeTitleEntries,
+  const templatesQuery = useTemplates();
+  const graphQuery = useQuery({
+    queryKey: GRAPH_QUERY_KEY,
+    queryFn: () => graphApiService.fetchGraph(),
     staleTime: 60_000,
   });
 
-  const titleMap = useMemo(() => new Map(query.data ?? []), [query.data]);
+  const entries = useMemo<NodeTitleEntry[]>(() => {
+    if (!graphQuery.data || !templatesQuery.data) {
+      return [];
+    }
+    const { nodes } = mapPersistedGraphToNodes(graphQuery.data, templatesQuery.data);
+    return nodes.map((node) => [node.id, node.title] as const);
+  }, [graphQuery.data, templatesQuery.data]);
+
+  const titleMap = useMemo(() => new Map(entries), [entries]);
+
+  const status: QueryStatus = useMemo(() => {
+    if (graphQuery.status === 'error' || templatesQuery.status === 'error') {
+      return 'error';
+    }
+    if (graphQuery.status === 'pending' || templatesQuery.status === 'pending') {
+      return 'pending';
+    }
+    return 'success';
+  }, [graphQuery.status, templatesQuery.status]);
+
+  const error = graphQuery.error ?? templatesQuery.error ?? null;
+  const isLoading = graphQuery.isLoading || templatesQuery.isLoading;
+  const isFetching = graphQuery.isFetching || templatesQuery.isFetching;
+
+  const refetch = useCallback(
+    () => Promise.all([graphQuery.refetch(), templatesQuery.refetch()]),
+    [graphQuery, templatesQuery],
+  );
 
   return {
     titleMap,
-    status: query.status,
-    isLoading: query.isLoading,
-    isFetching: query.isFetching,
-    error: query.error,
-    refetch: query.refetch,
+    status,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
   } as const;
 }

--- a/packages/platform-ui/src/features/graph/hooks/useNodeTitleMap.ts
+++ b/packages/platform-ui/src/features/graph/hooks/useNodeTitleMap.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { graphApiService } from '../services/api';
+import { mapPersistedGraphToNodes } from '../mappers';
+
+type NodeTitleEntry = readonly [string, string];
+
+const QUERY_KEY = ['graph', 'node-title-map'] as const;
+
+async function fetchNodeTitleEntries(): Promise<NodeTitleEntry[]> {
+  const [graph, templates] = await Promise.all([
+    graphApiService.fetchGraph(),
+    graphApiService.fetchTemplates(),
+  ]);
+
+  const { nodes } = mapPersistedGraphToNodes(graph, templates);
+  return nodes.map((node) => [node.id, node.title] as const);
+}
+
+export function useNodeTitleMap() {
+  const query = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: fetchNodeTitleEntries,
+    staleTime: 60_000,
+  });
+
+  const titleMap = useMemo(() => new Map(query.data ?? []), [query.data]);
+
+  return {
+    titleMap,
+    status: query.status,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error,
+    refetch: query.refetch,
+  } as const;
+}

--- a/packages/platform-ui/src/pages/MemoryNodeDetailPage.tsx
+++ b/packages/platform-ui/src/pages/MemoryNodeDetailPage.tsx
@@ -6,6 +6,7 @@ import { MemoryTree } from '@/components/memory/MemoryTree';
 import { MemoryEditor } from '@/components/memory/MemoryEditor';
 import { ThreadSelector } from '@/components/memory/ThreadSelector';
 import { normalizeMemoryPath } from '@/components/memory/path';
+import { useNodeTitleMap } from '@/features/graph/hooks/useNodeTitleMap';
 
 const THREAD_STORAGE_PREFIX = 'ui.memory.selectedThread.';
 
@@ -13,6 +14,8 @@ export function MemoryNodeDetailPage() {
   const params = useParams();
   const nodeIdParam = params.nodeId ?? '';
   const nodeId = decodeURIComponent(nodeIdParam);
+  const { titleMap } = useNodeTitleMap();
+  const displayName = titleMap.get(nodeId) ?? nodeId;
   const [searchParams, setSearchParams] = useSearchParams();
 
   const docsQuery = useQuery({
@@ -169,7 +172,12 @@ export function MemoryNodeDetailPage() {
             <Link to="/memory" className="text-xs text-primary hover:underline">
               &larr; Back to nodes
             </Link>
-            <h1 className="text-xl font-semibold break-all">{nodeId}</h1>
+            <div className="space-y-1">
+              <h1 className="text-xl font-semibold break-all">{displayName}</h1>
+              {displayName !== nodeId ? (
+                <p className="text-xs text-muted-foreground break-all">{nodeId}</p>
+              ) : null}
+            </div>
             <span className={`inline-block rounded px-2 py-0.5 text-xs uppercase ${scopeBadgeClass}`}>
               {scope}
             </span>


### PR DESCRIPTION
## Summary
- add useNodeTitleMap hook to derive display titles from graph data
- show memory node titles in memory manager selector with nodeId fallback
- surface titles in memory list/detail views while retaining node ids for reference

## Testing
- pnpm lint
- pnpm --filter @agyn/platform-ui test -- --reporter=basic
- pnpm --filter @agyn/platform-server exec -- vitest run --reporter=json --outputFile=packages/platform-server/server-tests.json

#1230
