### PR TITLE
feat: derive LiteLLM provider from credentials

### DIFF
--- a/packages/platform-server/__tests__/llm.settings.service.test.ts
+++ b/packages/platform-server/__tests__/llm.settings.service.test.ts
@@ -135,7 +135,6 @@ describe.sequential('LLMSettingsService', () => {
           credential_name: 'openai-dev',
           credential_info: {
             litellm_provider: 'openai',
-            tags: ['default'],
           },
           credential_values: {
             api_key: 'sk-test',
@@ -151,7 +150,6 @@ describe.sequential('LLMSettingsService', () => {
     const res = await service.createCredential({
       name: 'openai-dev',
       provider: 'openai',
-      tags: ['default', ''],
       values: { api_key: ' sk-test ', api_base: 'https://api.openai.com/v1' },
     });
     expect(res).toMatchObject({ success: true });
@@ -164,7 +162,7 @@ describe.sequential('LLMSettingsService', () => {
         expect(body).toMatchObject({
           credential_name: 'openai-dev',
           credential_info: {
-            tags: ['primary'],
+            environment: 'primary',
           },
         });
         expect(body).not.toHaveProperty('credential_values');
@@ -174,7 +172,7 @@ describe.sequential('LLMSettingsService', () => {
       .reply(200, { success: true });
 
     const service = new LLMSettingsService(createConfig());
-    const res = await service.updateCredential({ name: 'openai-dev', tags: ['primary'] });
+    const res = await service.updateCredential({ name: 'openai-dev', metadata: { environment: 'primary' } });
     expect(res).toMatchObject({ success: true });
     scope.done();
   });
@@ -336,7 +334,6 @@ describe.sequential('LLMSettingsService', () => {
       service.createCredential({
         name: 'openai-dev',
         provider: 'openai',
-        tags: [],
         values: { api_key: 'sk-test' },
       }),
     ).rejects.toMatchObject({
@@ -365,7 +362,6 @@ describe.sequential('LLMSettingsService', () => {
       service.createCredential({
         name: 'openai-dev',
         provider: 'openai',
-        tags: [],
         values: { api_key: 'sk-test' },
       }),
     ).rejects.toMatchObject({

--- a/packages/platform-server/src/settings/llm/dto/create-credential.dto.ts
+++ b/packages/platform-server/src/settings/llm/dto/create-credential.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
 
 export class CreateCredentialDto {
   @IsString()
@@ -8,11 +8,6 @@ export class CreateCredentialDto {
   @IsString()
   @IsNotEmpty()
   provider!: string;
-
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  tags?: string[];
 
   @IsOptional()
   @IsObject()

--- a/packages/platform-server/src/settings/llm/dto/update-credential.dto.ts
+++ b/packages/platform-server/src/settings/llm/dto/update-credential.dto.ts
@@ -1,14 +1,9 @@
-import { IsArray, IsObject, IsOptional, IsString } from 'class-validator';
+import { IsObject, IsOptional, IsString } from 'class-validator';
 
 export class UpdateCredentialDto {
   @IsOptional()
   @IsString()
   provider?: string;
-
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  tags?: string[];
 
   @IsOptional()
   @IsObject()

--- a/packages/platform-server/src/settings/llm/llmSettings.controller.ts
+++ b/packages/platform-server/src/settings/llm/llmSettings.controller.ts
@@ -39,7 +39,6 @@ export class LLMSettingsController {
     return this.llmSettings.createCredential({
       name: dto.name,
       provider: dto.provider,
-      tags: dto.tags,
       metadata: dto.metadata,
       values: dto.values,
     });
@@ -50,7 +49,6 @@ export class LLMSettingsController {
     return this.llmSettings.updateCredential({
       name,
       provider: dto.provider,
-      tags: dto.tags,
       metadata: dto.metadata,
       values: dto.values,
     });

--- a/packages/platform-server/src/settings/llm/llmSettings.service.ts
+++ b/packages/platform-server/src/settings/llm/llmSettings.service.ts
@@ -15,7 +15,6 @@ type LiteLLMAdminErrorCode = 'litellm_admin_request_failed' | 'litellm_admin_una
 type CreateCredentialInput = {
   name: string;
   provider: string;
-  tags?: string[];
   metadata?: Record<string, unknown>;
   values?: Record<string, unknown>;
 };
@@ -23,7 +22,6 @@ type CreateCredentialInput = {
 type UpdateCredentialInput = {
   name: string;
   provider?: string;
-  tags?: string[];
   metadata?: Record<string, unknown>;
   values?: Record<string, unknown>;
 };
@@ -131,18 +129,6 @@ function sanitizeRecord(input?: Record<string, unknown>): Record<string, unknown
   return Object.keys(out).length ? out : {};
 }
 
-function sanitizeTags(tags?: string[]): string[] | undefined {
-  if (!Array.isArray(tags)) return undefined;
-  const cleaned = Array.from(
-    new Set(
-      tags
-        .map((tag) => (typeof tag === 'string' ? tag.trim() : ''))
-        .filter((tag) => tag.length > 0),
-    ),
-  );
-  return cleaned.length ? cleaned : undefined;
-}
-
 function ensureNoSecretKeys(params?: Record<string, unknown>): void {
   if (!params) return;
   for (const key of Object.keys(params)) {
@@ -197,8 +183,6 @@ export class LLMSettingsService {
       litellm_provider: input.provider,
       ...(input.metadata || {}),
     };
-    const tags = sanitizeTags(input.tags);
-    if (tags) info.tags = tags;
     const payload = {
       credential_name: input.name,
       credential_info: info,
@@ -211,8 +195,6 @@ export class LLMSettingsService {
     const info: Record<string, unknown> = {};
     if (input.provider) info.litellm_provider = input.provider;
     if (input.metadata) Object.assign(info, input.metadata);
-    const tags = sanitizeTags(input.tags);
-    if (tags) info.tags = tags;
     const sanitizedValues = sanitizeRecord(input.values);
     const payload = {
       credential_name: input.name,

--- a/packages/platform-server/src/settings/llm/llmSettings.service.ts
+++ b/packages/platform-server/src/settings/llm/llmSettings.service.ts
@@ -162,6 +162,19 @@ function redactBaseUrl(value?: string): string | undefined {
   }
 }
 
+function extractCredentialProvider(info?: Record<string, unknown>): string | undefined {
+  if (!info) return undefined;
+  const litellm = info['litellm_provider'];
+  if (typeof litellm === 'string' && litellm.trim().length > 0) {
+    return litellm.trim();
+  }
+  const legacy = info['custom_llm_provider'];
+  if (typeof legacy === 'string' && legacy.trim().length > 0) {
+    return legacy.trim();
+  }
+  return undefined;
+}
+
 @Injectable()
 export class LLMSettingsService {
   private readonly logger = new Logger(LLMSettingsService.name);
@@ -235,9 +248,7 @@ export class LLMSettingsService {
       throw new BadRequestException('model is required to test credential');
     }
     const detail = await this.getCredentialDetail(input.name);
-    const provider = typeof (detail?.credential_info as Record<string, unknown> | undefined)?.litellm_provider === 'string'
-      ? ((detail.credential_info as Record<string, unknown>).litellm_provider as string)
-      : undefined;
+    const provider = extractCredentialProvider(detail?.credential_info as Record<string, unknown> | undefined);
     if (!provider) {
       throw new BadRequestException('credential is missing provider metadata');
     }

--- a/packages/platform-ui/src/api/modules/llmSettings.ts
+++ b/packages/platform-ui/src/api/modules/llmSettings.ts
@@ -90,7 +90,6 @@ export async function listCredentials(): Promise<LiteLLMCredential[]> {
 export async function createCredential(body: {
   name: string;
   provider: string;
-  tags?: string[];
   metadata?: Record<string, unknown>;
   values?: Record<string, unknown>;
 }): Promise<LiteLLMGenericResponse> {
@@ -99,7 +98,6 @@ export async function createCredential(body: {
 
 export async function updateCredential(name: string, body: {
   provider?: string;
-  tags?: string[];
   metadata?: Record<string, unknown>;
   values?: Record<string, unknown>;
 }): Promise<LiteLLMGenericResponse> {

--- a/packages/platform-ui/src/features/llmSettings/SettingsLlmContainer.tsx
+++ b/packages/platform-ui/src/features/llmSettings/SettingsLlmContainer.tsx
@@ -246,7 +246,6 @@ export function SettingsLlmContainer(): ReactElement {
       await createCredential({
         name: payload.name,
         provider: payload.providerKey,
-        tags: payload.tags,
         metadata: payload.metadata,
         values: payload.values,
       });
@@ -263,7 +262,6 @@ export function SettingsLlmContainer(): ReactElement {
     mutationFn: async ({ name, ...payload }: CredentialFormPayload) => {
       await updateCredential(name, {
         provider: payload.providerKey,
-        tags: payload.tags,
         metadata: payload.metadata,
         values: payload.values,
       });

--- a/packages/platform-ui/src/features/llmSettings/components/CredentialsTab.tsx
+++ b/packages/platform-ui/src/features/llmSettings/components/CredentialsTab.tsx
@@ -79,12 +79,6 @@ export function CredentialsTab({
                   </th>
                   <th
                     scope="col"
-                    className="bg-white px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide"
-                  >
-                    Tags
-                  </th>
-                  <th
-                    scope="col"
                     className="bg-white px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide"
                   >
                     Actions
@@ -94,13 +88,13 @@ export function CredentialsTab({
               <tbody>
                 {loading ? (
                   <tr>
-                    <td colSpan={4} className="px-6 py-6 text-center text-[var(--agyn-text-subtle)]">
+                    <td colSpan={3} className="px-6 py-6 text-center text-[var(--agyn-text-subtle)]">
                       Loading credentials…
                     </td>
                   </tr>
                 ) : credentials.length === 0 ? (
                   <tr>
-                    <td colSpan={4} className="px-6 py-10 text-center text-[var(--agyn-text-subtle)]">
+                    <td colSpan={3} className="px-6 py-10 text-center text-[var(--agyn-text-subtle)]">
                       No credentials configured yet.
                     </td>
                   </tr>
@@ -130,19 +124,6 @@ export function CredentialsTab({
                           </Badge>
                         ) : (
                           <span className="text-[var(--agyn-text-subtle)]">—</span>
-                        )}
-                      </td>
-                      <td className="px-6 py-4 align-top">
-                        {credential.tags.length === 0 ? (
-                          <span className="text-[var(--agyn-text-subtle)]">—</span>
-                        ) : (
-                          <div className="flex flex-wrap gap-2">
-                            {credential.tags.map((tag) => (
-                              <Badge key={tag} variant="outline" size="sm" className="text-[11px] uppercase tracking-tight">
-                                {tag}
-                              </Badge>
-                            ))}
-                          </div>
                         )}
                       </td>
                       <td className="px-4 py-3">

--- a/packages/platform-ui/src/features/llmSettings/components/CredentialsTab.tsx
+++ b/packages/platform-ui/src/features/llmSettings/components/CredentialsTab.tsx
@@ -57,7 +57,6 @@ export function CredentialsTab({
               <colgroup>
                 <col className="w-[32%]" />
                 <col className="w-[24%]" />
-                <col />
                 <col className="w-[140px]" />
               </colgroup>
               <thead

--- a/packages/platform-ui/src/features/llmSettings/components/ModelFormDialog.tsx
+++ b/packages/platform-ui/src/features/llmSettings/components/ModelFormDialog.tsx
@@ -202,140 +202,150 @@ export function ModelFormDialog({
 
   return (
     <ScreenDialog open={open} onOpenChange={onOpenChange}>
-      <ScreenDialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
-        <ScreenDialogHeader>
-          <ScreenDialogTitle>{mode === 'create' ? 'Create Model' : `Edit Model — ${model?.id}`}</ScreenDialogTitle>
-          <ScreenDialogDescription>
-            Define LiteLLM model routing and guardrails for agent usage.
-          </ScreenDialogDescription>
-        </ScreenDialogHeader>
-        <Form {...form}>
-          <form id="llm-model-form" onSubmit={handleSubmit} className="grid gap-4">
-            <FormField
-              control={form.control}
-              name="name"
-              rules={{ required: 'Name is required' }}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Model Name</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="assistant-prod" />
-                  </FormControl>
-                  <FormDescription>Unique identifier referenced by agents.</FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="model"
-              rules={{ required: 'Model identifier is required' }}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Provider Model Identifier</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder={providerPlaceholder} />
-                  </FormControl>
-                  <FormDescription>Exact model slug as recognized by the provider.</FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+      <ScreenDialogContent className="max-h-[90vh] p-0 sm:max-w-2xl">
+        <div className="flex max-h-[inherit] flex-col">
+          <div className="border-b border-[var(--agyn-border-subtle)] px-6 pb-4 pt-6">
+            <ScreenDialogHeader>
+              <ScreenDialogTitle>{mode === 'create' ? 'Create Model' : `Edit Model — ${model?.id}`}</ScreenDialogTitle>
+              <ScreenDialogDescription>
+                Define LiteLLM model routing and guardrails for agent usage.
+              </ScreenDialogDescription>
+            </ScreenDialogHeader>
+          </div>
 
-            <FormField
-              control={form.control}
-              name="credentialName"
-              rules={{ required: 'Credential is required' }}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Credential</FormLabel>
-                  <FormControl>
-                    <SelectInput
-                      value={field.value ?? ''}
-                      onChange={(event) => field.onChange(event.target.value)}
-                      placeholder="Select credential"
-                      options={credentials.map((credentialOption) => ({
-                        value: credentialOption.name,
-                        label: credentialOption.name,
-                      }))}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    {selectedProvider
-                      ? `Provider derived from credential: ${selectedProvider.label}.`
-                      : 'Select a credential to derive provider.'}
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <Form {...form}>
+            <div className="flex-1 overflow-y-auto px-6 py-4">
+              <form id="llm-model-form" onSubmit={handleSubmit} className="grid gap-4">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  rules={{ required: 'Name is required' }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Model Name</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="assistant-prod" />
+                      </FormControl>
+                      <FormDescription>Unique identifier referenced by agents.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="model"
+                  rules={{ required: 'Model identifier is required' }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Provider Model Identifier</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder={providerPlaceholder} />
+                      </FormControl>
+                      <FormDescription>Exact model slug as recognized by the provider.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            <FormField
-              control={form.control}
-              name="mode"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Mode</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="chat" />
-                  </FormControl>
-                  <FormDescription>LiteLLM mode (chat, completion, embedding, etc.).</FormDescription>
-                </FormItem>
-              )}
-            />
+                <FormField
+                  control={form.control}
+                  name="credentialName"
+                  rules={{ required: 'Credential is required' }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Credential</FormLabel>
+                      <FormControl>
+                        <SelectInput
+                          value={field.value ?? ''}
+                          onChange={(event) => field.onChange(event.target.value)}
+                          placeholder="Select credential"
+                          options={credentials.map((credentialOption) => ({
+                            value: credentialOption.name,
+                            label: credentialOption.name,
+                          }))}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        {selectedProvider
+                          ? `Provider derived from credential: ${selectedProvider.label}.`
+                          : 'Select a credential to derive provider.'}
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            <div className="grid gap-4 md:grid-cols-2">
-              <NumericField label="Temperature" name="temperature" control={form.control} placeholder="0.7" />
-              <NumericField label="Top P" name="topP" control={form.control} placeholder="0.95" />
-              <NumericField label="Frequency Penalty" name="frequencyPenalty" control={form.control} placeholder="0" />
-              <NumericField label="Presence Penalty" name="presencePenalty" control={form.control} placeholder="0" />
-              <NumericField label="Max Tokens" name="maxTokens" control={form.control} placeholder="4096" />
-              <NumericField label="Requests per Minute" name="rpm" control={form.control} placeholder="600" />
-              <NumericField label="Tokens per Minute" name="tpm" control={form.control} placeholder="90000" />
+                <FormField
+                  control={form.control}
+                  name="mode"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Mode</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="chat" />
+                      </FormControl>
+                      <FormDescription>LiteLLM mode (chat, completion, embedding, etc.).</FormDescription>
+                    </FormItem>
+                  )}
+                />
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <NumericField label="Temperature" name="temperature" control={form.control} placeholder="0.7" />
+                  <NumericField label="Top P" name="topP" control={form.control} placeholder="0.95" />
+                  <NumericField label="Frequency Penalty" name="frequencyPenalty" control={form.control} placeholder="0" />
+                  <NumericField label="Presence Penalty" name="presencePenalty" control={form.control} placeholder="0" />
+                  <NumericField label="Max Tokens" name="maxTokens" control={form.control} placeholder="4096" />
+                  <NumericField label="Requests per Minute" name="rpm" control={form.control} placeholder="600" />
+                  <NumericField label="Tokens per Minute" name="tpm" control={form.control} placeholder="90000" />
+                </div>
+
+                <FormField
+                  control={form.control}
+                  name="stream"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-center justify-between rounded-md border p-3">
+                      <div className="space-y-0.5">
+                        <FormLabel>Enable streaming</FormLabel>
+                        <FormDescription>Allow streaming responses when agents use this model.</FormDescription>
+                      </div>
+                      <FormControl>
+                        <SwitchControl checked={field.value} onCheckedChange={field.onChange} />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="paramsJson"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Advanced Params (JSON)</FormLabel>
+                      <FormControl>
+                        <Textarea {...field} placeholder='{ "timeout": 30 }' className="min-h-[160px] font-mono text-sm" />
+                      </FormControl>
+                      <FormDescription>
+                        Additional LiteLLM parameters encoded as JSON. Leave empty for defaults.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </form>
             </div>
+          </Form>
 
-            <FormField
-              control={form.control}
-              name="stream"
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-center justify-between rounded-md border p-3">
-                  <div className="space-y-0.5">
-                    <FormLabel>Enable streaming</FormLabel>
-                    <FormDescription>Allow streaming responses when agents use this model.</FormDescription>
-                  </div>
-                  <FormControl>
-                    <SwitchControl checked={field.value} onCheckedChange={field.onChange} />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="paramsJson"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Advanced Params (JSON)</FormLabel>
-                  <FormControl>
-                    <Textarea {...field} placeholder='{ "timeout": 30 }' className="min-h-[160px] font-mono text-sm" />
-                  </FormControl>
-                  <FormDescription>
-                    Additional LiteLLM parameters encoded as JSON. Leave empty for defaults.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </form>
-        </Form>
-        <ScreenDialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
-            Cancel
-          </Button>
-          <Button type="submit" form="llm-model-form" disabled={submitting}>
-            {submitting ? 'Saving…' : mode === 'create' ? 'Create Model' : 'Save Changes'}
-          </Button>
-        </ScreenDialogFooter>
+          <div className="border-t border-[var(--agyn-border-subtle)] px-6 pb-6 pt-4">
+            <ScreenDialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button type="submit" form="llm-model-form" disabled={submitting}>
+                {submitting ? 'Saving…' : mode === 'create' ? 'Create Model' : 'Save Changes'}
+              </Button>
+            </ScreenDialogFooter>
+          </div>
+        </div>
       </ScreenDialogContent>
     </ScreenDialog>
   );

--- a/packages/platform-ui/src/features/llmSettings/types.ts
+++ b/packages/platform-ui/src/features/llmSettings/types.ts
@@ -29,7 +29,6 @@ export type CredentialRecord = {
   name: string;
   providerKey: string;
   providerLabel: string;
-  tags: string[];
   values: Record<string, string>;
   maskedFields: Set<string>;
   metadata: Record<string, unknown>;
@@ -106,10 +105,6 @@ export function mapCredentials(
   if (!Array.isArray(items)) return [];
   return items.map((item) => {
     const info = (item.credential_info ?? {}) as Record<string, unknown>;
-    const tagsRaw = info?.tags;
-    const tags = Array.isArray(tagsRaw)
-      ? tagsRaw.map((t) => (typeof t === 'string' ? t : String(t))).filter((t) => t.length > 0)
-      : [];
     const providerKey = resolveCredentialProvider(info);
     const provider = providers.get(providerKey);
     const providerLabel = provider?.label ?? (providerKey || 'Unknown');
@@ -137,7 +132,6 @@ export function mapCredentials(
       name: item.credential_name,
       providerKey,
       providerLabel,
-      tags,
       values,
       maskedFields,
       metadata,

--- a/packages/platform-ui/src/features/llmSettings/types.ts
+++ b/packages/platform-ui/src/features/llmSettings/types.ts
@@ -61,6 +61,19 @@ const FIELD_TYPE_MAP: Record<string, ProviderFieldType> = {
   upload: 'textarea',
 };
 
+function resolveCredentialProvider(info?: Record<string, unknown>): string {
+  if (!info) return '';
+  const litellm = info['litellm_provider'];
+  if (typeof litellm === 'string' && litellm.trim().length > 0) {
+    return litellm.trim();
+  }
+  const legacy = info['custom_llm_provider'];
+  if (typeof legacy === 'string' && legacy.trim().length > 0) {
+    return legacy.trim();
+  }
+  return '';
+}
+
 export function mapProviders(items: LiteLLMProviderInfo[] | undefined): ProviderOption[] {
   if (!Array.isArray(items)) return [];
   return items.map((item) => {
@@ -97,7 +110,7 @@ export function mapCredentials(
     const tags = Array.isArray(tagsRaw)
       ? tagsRaw.map((t) => (typeof t === 'string' ? t : String(t))).filter((t) => t.length > 0)
       : [];
-    const providerKey = typeof info?.litellm_provider === 'string' ? (info.litellm_provider as string) : '';
+    const providerKey = resolveCredentialProvider(info);
     const provider = providers.get(providerKey);
     const providerLabel = provider?.label ?? (providerKey || 'Unknown');
 
@@ -116,7 +129,7 @@ export function mapCredentials(
 
     const metadata: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(info)) {
-      if (key === 'litellm_provider' || key === 'tags') continue;
+      if (key === 'litellm_provider' || key === 'custom_llm_provider' || key === 'tags') continue;
       metadata[key] = value;
     }
 

--- a/packages/platform-ui/src/pages/__tests__/settings-llm.test.tsx
+++ b/packages/platform-ui/src/pages/__tests__/settings-llm.test.tsx
@@ -93,7 +93,7 @@ describe('Settings/LLM page', () => {
     const credentialRecords = [
       {
         credential_name: 'openai-prod',
-        credential_info: { litellm_provider: 'openai', tags: ['prod'] },
+        credential_info: { litellm_provider: 'openai' },
         credential_values: { api_key: 'sk****prod' },
       },
     ];
@@ -143,7 +143,7 @@ describe('Settings/LLM page', () => {
     expect(credentialHeader.className).toContain('top-0');
     const credentialRow = screen.getByTestId('llm-credential-row-openai-prod');
     expect(within(credentialRow).getByText('OpenAI')).toBeInTheDocument();
-    expect(within(credentialRow).getByText('prod')).toBeInTheDocument();
+    expect(within(credentialRow).queryByText('prod')).not.toBeInTheDocument();
 
     const modelsTab = screen.getByRole('tab', { name: 'Models' });
     await user.click(modelsTab);
@@ -174,7 +174,7 @@ describe('Settings/LLM page', () => {
     const credentialRecords = [
       {
         credential_name: 'openai-prod',
-        credential_info: { litellm_provider: 'openai', tags: ['prod'] },
+        credential_info: { litellm_provider: 'openai' },
         credential_values: { api_key: 'sk****prod' },
       },
     ];
@@ -321,7 +321,7 @@ describe('Settings/LLM page', () => {
     const credentialRecords = [
       {
         credential_name: 'openai-prod',
-        credential_info: { litellm_provider: 'openai', tags: [] },
+        credential_info: { litellm_provider: 'openai' },
         credential_values: { api_key: 'sk****prod' },
       },
     ];
@@ -390,12 +390,11 @@ describe('Settings/LLM page', () => {
         const body = (await request.json()) as {
           name: string;
           provider: string;
-          tags?: string[];
           values?: Record<string, string>;
         };
         credentialRecords.push({
           credential_name: body.name,
-          credential_info: { litellm_provider: body.provider, tags: body.tags ?? [] },
+          credential_info: { litellm_provider: body.provider },
           credential_values: { api_key: 'sk****new' },
         });
         return HttpResponse.json({ success: true });
@@ -445,7 +444,7 @@ describe('Settings/LLM page', () => {
     const credentialRecords = [
       {
         credential_name: 'openai-prod',
-        credential_info: { litellm_provider: 'openai', tags: ['prod'] },
+        credential_info: { litellm_provider: 'openai' },
         credential_values: { api_key: 'sk****prod' },
       },
     ];
@@ -465,10 +464,10 @@ describe('Settings/LLM page', () => {
       http.get(abs('/api/settings/llm/models'), () => HttpResponse.json({ models: [] })),
       http.get(abs('/api/settings/llm/health-check-modes'), () => HttpResponse.json({ modes: DEFAULT_HEALTH_CHECK_MODES })),
       http.patch(abs('/api/settings/llm/credentials/openai-prod'), async ({ request }) => {
-        const body = (await request.json()) as { tags?: string[]; values?: Record<string, string> };
-        expect(body).toMatchObject({ tags: ['prod', 'beta'] });
-        expect(Object.keys(body.values ?? {})).toHaveLength(0);
-        credentialRecords[0].credential_info.tags = body.tags ?? [];
+        const body = (await request.json()) as { values?: Record<string, string> };
+        expect(body).not.toHaveProperty('tags');
+        expect(body).toMatchObject({ values: { api_key: 'sk-updated-secret' } });
+        credentialRecords[0].credential_values.api_key = 'sk****updated';
         return HttpResponse.json({ success: true });
       }),
     );
@@ -487,15 +486,14 @@ describe('Settings/LLM page', () => {
     await user.click(editButton);
 
     const dialog = await screen.findByRole('dialog', { name: /Edit Credential/i });
-    const tagsInput = within(dialog).getByLabelText('Tags');
-    await user.clear(tagsInput);
-    await user.type(tagsInput, 'prod, beta');
+    const apiKeyInput = within(dialog).getByLabelText('OpenAI API Key');
+    await user.type(apiKeyInput, 'sk-updated-secret');
 
     const saveButton = within(dialog).getByRole('button', { name: 'Save Changes' });
     await user.click(saveButton);
 
     await waitFor(() => expect(notifyMocks.success).toHaveBeenCalledWith('Credential updated'));
-    await screen.findByText('beta');
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /Edit Credential/i })).not.toBeInTheDocument());
   });
 
   it('deletes a credential via the confirmation dialog', async () => {
@@ -514,7 +512,7 @@ describe('Settings/LLM page', () => {
     const credentialRecords = [
       {
         credential_name: 'openai-prod',
-        credential_info: { litellm_provider: 'openai', tags: ['prod'] },
+        credential_info: { litellm_provider: 'openai' },
         credential_values: { api_key: 'sk****prod' },
       },
     ];
@@ -585,12 +583,12 @@ describe('Settings/LLM page', () => {
     const credentialRecords = [
       {
         credential_name: 'openai-default',
-        credential_info: { litellm_provider: 'openai', tags: [] },
+        credential_info: { litellm_provider: 'openai' },
         credential_values: { api_key: 'sk****openai' },
       },
       {
         credential_name: 'zz-anthropic-legacy',
-        credential_info: { custom_llm_provider: 'anthropic', tags: [] },
+        credential_info: { custom_llm_provider: 'anthropic' },
         credential_values: { api_key: 'sk****anthropic' },
       },
     ];
@@ -709,7 +707,7 @@ describe('Settings/LLM page', () => {
     const credentialRecords = [
       {
         credential_name: 'openai-prod',
-        credential_info: { litellm_provider: 'openai', tags: ['prod'] },
+        credential_info: { litellm_provider: 'openai' },
         credential_values: { api_key: 'sk****prod' },
       },
     ];


### PR DESCRIPTION
## Summary
- prefer credential_info.litellm_provider with fallback to credential_info.custom_llm_provider when testing credentials
- derive model provider metadata from the selected credential in the UI and drop the manual provider selector
- add regression coverage for legacy provider fallback across server and client flows

## Testing
- pnpm lint
- pnpm test

No database migrations required.

Resolves #1236.
