### PR TITLE
feat(ui): align llm dialogs with dropdown

### DIFF
--- a/packages/platform-ui/src/components/Dropdown.tsx
+++ b/packages/platform-ui/src/components/Dropdown.tsx
@@ -1,3 +1,4 @@
+import type { ComponentPropsWithoutRef } from 'react';
 import {
   Select,
   SelectContent,
@@ -7,6 +8,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from './ui/select';
+
+type SelectTriggerProps = ComponentPropsWithoutRef<typeof SelectTrigger>;
 
 interface DropdownOption {
   value: string;
@@ -18,7 +21,7 @@ interface DropdownGroup {
   options: DropdownOption[];
 }
 
-interface DropdownProps {
+interface DropdownProps extends Omit<SelectTriggerProps, 'children' | 'className' | 'size' | 'disabled'> {
   label?: string;
   placeholder?: string;
   value?: string;
@@ -32,6 +35,7 @@ interface DropdownProps {
   variant?: 'default' | 'flat';
   disabled?: boolean;
   className?: string;
+  triggerClassName?: string;
 }
 
 export function Dropdown({
@@ -48,6 +52,8 @@ export function Dropdown({
   variant = 'default',
   disabled = false,
   className = '',
+  triggerClassName = '',
+  ...triggerProps
 }: DropdownProps) {
   return (
     <div className={`w-full ${className}`}>
@@ -65,6 +71,7 @@ export function Dropdown({
       >
         <SelectTrigger
           size={size}
+          disabled={disabled}
           className={`
             w-full
             ${variant === 'flat' 
@@ -80,7 +87,9 @@ export function Dropdown({
                 ${size === 'sm' ? 'px-3 !h-10' : 'px-4 py-3'}
               `
             }
+          ${triggerClassName}
           `}
+          {...triggerProps}
         >
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>

--- a/packages/platform-ui/src/features/llmSettings/SettingsLlmContainer.tsx
+++ b/packages/platform-ui/src/features/llmSettings/SettingsLlmContainer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type ReactElement } from 'react';
 import axios from 'axios';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { X } from 'lucide-react';
 import {
   ScreenDialog,
   ScreenDialogContent,
@@ -10,6 +11,7 @@ import {
   ScreenDialogTitle,
 } from '@/components/Dialog';
 import { Button } from '@/components/Button';
+import { IconButton } from '@/components/IconButton';
 import { notifyError, notifySuccess } from '@/lib/notify';
 import {
   createCredential,
@@ -538,20 +540,35 @@ export function SettingsLlmContainer(): ReactElement {
       ) : null}
 
       <ScreenDialog open={deleteState !== null} onOpenChange={(open) => !open && setDeleteState(null)}>
-        <ScreenDialogContent className="sm:max-w-md">
-          <ScreenDialogHeader>
-            <ScreenDialogTitle>Delete {deleteState?.type === 'credential' ? 'Credential' : 'Model'}?</ScreenDialogTitle>
-            <ScreenDialogDescription>
-              This action cannot be undone. References to the {deleteState?.type ?? 'item'} will fail once removed.
-            </ScreenDialogDescription>
-          </ScreenDialogHeader>
-          <ScreenDialogFooter>
-            <Button type="button" variant="outline" onClick={() => setDeleteState(null)} disabled={deleteSubmitting}>
+        <ScreenDialogContent className="sm:max-w-md" hideCloseButton>
+          <div className="flex items-start justify-between gap-4">
+            <ScreenDialogHeader className="flex-1 gap-2">
+              <ScreenDialogTitle>
+                Delete {deleteState?.type === 'credential' ? 'Credential' : 'Model'}?
+              </ScreenDialogTitle>
+              <ScreenDialogDescription>
+                This action cannot be undone. References to the {deleteState?.type ?? 'item'} will fail once removed.
+              </ScreenDialogDescription>
+            </ScreenDialogHeader>
+            <IconButton
+              icon={<X className="h-4 w-4" />}
+              variant="ghost"
+              size="sm"
+              rounded={false}
+              aria-label="Close dialog"
+              title="Close"
+              className="shrink-0"
+              onClick={() => setDeleteState(null)}
+            />
+          </div>
+          <ScreenDialogFooter className="mt-6">
+            <Button type="button" variant="ghost" size="md" onClick={() => setDeleteState(null)} disabled={deleteSubmitting}>
               Cancel
             </Button>
             <Button
               type="button"
               variant="danger"
+              size="md"
               disabled={deleteSubmitting}
               onClick={() => {
                 if (!ensureWritable()) return;

--- a/packages/platform-ui/src/features/llmSettings/components/CredentialFormDialog.tsx
+++ b/packages/platform-ui/src/features/llmSettings/components/CredentialFormDialog.tsx
@@ -200,6 +200,7 @@ export function CredentialFormDialog({
                           {...field}
                           placeholder="openai-prod"
                           disabled={mode === 'edit'}
+                          size="sm"
                         />
                       </FormControl>
                       <FormDescription>Unique identifier used when referencing this credential.</FormDescription>
@@ -225,6 +226,7 @@ export function CredentialFormDialog({
                             value: provider.litellmProvider,
                             label: provider.label,
                           }))}
+                          size="sm"
                         />
                       </FormControl>
                       <FormMessage />
@@ -288,7 +290,16 @@ type FieldChangeHandler = (value: string) => void;
 function renderFieldInput(field: ProviderField, value: string, onChange: FieldChangeHandler, isMasked: boolean) {
   const placeholder = isMasked ? '••••••' : field.placeholder ?? undefined;
   if (field.type === 'password') {
-    return <Input type="password" value={value} onChange={(event) => onChange(event.target.value)} placeholder={placeholder} autoComplete="new-password" />;
+    return (
+      <Input
+        type="password"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        autoComplete="new-password"
+        size="sm"
+      />
+    );
   }
 
   if (field.type === 'select' && field.options) {
@@ -298,13 +309,29 @@ function renderFieldInput(field: ProviderField, value: string, onChange: FieldCh
         onValueChange={onChange}
         placeholder="Select option"
         options={field.options.map((option) => ({ value: option, label: option }))}
+        size="sm"
       />
     );
   }
 
   if (field.type === 'textarea') {
-    return <Textarea value={value} onChange={(event) => onChange(event.target.value)} placeholder={placeholder} className="min-h-[120px]" />;
+    return (
+      <Textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="min-h-[120px]"
+        size="sm"
+      />
+    );
   }
 
-  return <Input value={value} onChange={(event) => onChange(event.target.value)} placeholder={placeholder} />;
+  return (
+    <Input
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={placeholder}
+      size="sm"
+    />
+  );
 }

--- a/packages/platform-ui/src/features/llmSettings/components/CredentialFormDialog.tsx
+++ b/packages/platform-ui/src/features/llmSettings/components/CredentialFormDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, type ReactElement } from 'react';
+import { X } from 'lucide-react';
 import { useForm, useWatch, type FieldValues } from 'react-hook-form';
 import {
   ScreenDialog,
@@ -9,9 +10,10 @@ import {
   ScreenDialogTitle,
 } from '@/components/Dialog';
 import { Button } from '@/components/Button';
+import { IconButton } from '@/components/IconButton';
 import { Input } from '@/components/Input';
 import { Textarea } from '@/components/Textarea';
-import { SelectInput } from '@/components/SelectInput';
+import { Dropdown } from '@/components/Dropdown';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/forms/Form';
 import type { CredentialRecord, ProviderField, ProviderOption } from '../types';
 
@@ -158,15 +160,29 @@ export function CredentialFormDialog({
 
   return (
     <ScreenDialog open={open} onOpenChange={onOpenChange}>
-      <ScreenDialogContent className="max-h-[90vh] p-0 sm:max-w-2xl">
+      <ScreenDialogContent className="max-h-[90vh] p-0 sm:max-w-2xl" hideCloseButton>
         <div className="flex max-h-[inherit] flex-col">
           <div className="border-b border-[var(--agyn-border-subtle)] px-6 pb-4 pt-6">
-            <ScreenDialogHeader>
-              <ScreenDialogTitle>{mode === 'create' ? 'Create Credential' : `Edit Credential — ${credential?.name}`}</ScreenDialogTitle>
-              <ScreenDialogDescription>
-                Provide LiteLLM credential details. All values are stored securely on the server.
-              </ScreenDialogDescription>
-            </ScreenDialogHeader>
+            <div className="flex items-start justify-between gap-4">
+              <ScreenDialogHeader className="flex-1 gap-2">
+                <ScreenDialogTitle>
+                  {mode === 'create' ? 'Create Credential' : `Edit Credential — ${credential?.name}`}
+                </ScreenDialogTitle>
+                <ScreenDialogDescription>
+                  Provide LiteLLM credential details. All values are stored securely on the server.
+                </ScreenDialogDescription>
+              </ScreenDialogHeader>
+              <IconButton
+                icon={<X className="h-4 w-4" />}
+                variant="ghost"
+                size="sm"
+                rounded={false}
+                aria-label="Close dialog"
+                title="Close"
+                className="shrink-0"
+                onClick={() => onOpenChange(false)}
+              />
+            </div>
           </div>
 
           <Form {...form}>
@@ -200,9 +216,9 @@ export function CredentialFormDialog({
                     <FormItem>
                       <FormLabel>Provider</FormLabel>
                       <FormControl>
-                        <SelectInput
-                          value={field.value ?? ''}
-                          onChange={(event) => field.onChange(event.target.value)}
+                        <Dropdown
+                          value={field.value || undefined}
+                          onValueChange={(value) => field.onChange(value)}
                           disabled={providers.length === 0}
                           placeholder="Select provider"
                           options={providers.map((provider) => ({
@@ -251,12 +267,12 @@ export function CredentialFormDialog({
             </div>
           </Form>
 
-          <div className="border-t border-[var(--agyn-border-subtle)] px-6 pb-6 pt-4">
-            <ScreenDialogFooter>
-              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+          <div className="border-t border-[var(--agyn-border-subtle)] px-6 pb-6">
+            <ScreenDialogFooter className="mt-6">
+              <Button variant="ghost" size="md" onClick={() => onOpenChange(false)} disabled={submitting}>
                 Cancel
               </Button>
-              <Button type="submit" form="llm-credential-form" disabled={submitting}>
+              <Button type="submit" form="llm-credential-form" variant="primary" size="md" disabled={submitting}>
                 {submitting ? 'Saving…' : mode === 'create' ? 'Create Credential' : 'Save Changes'}
               </Button>
             </ScreenDialogFooter>
@@ -277,9 +293,9 @@ function renderFieldInput(field: ProviderField, value: string, onChange: FieldCh
 
   if (field.type === 'select' && field.options) {
     return (
-      <SelectInput
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
+      <Dropdown
+        value={value || undefined}
+        onValueChange={onChange}
         placeholder="Select option"
         options={field.options.map((option) => ({ value: option, label: option }))}
       />

--- a/packages/platform-ui/src/features/llmSettings/components/ModelFormDialog.tsx
+++ b/packages/platform-ui/src/features/llmSettings/components/ModelFormDialog.tsx
@@ -240,7 +240,7 @@ export function ModelFormDialog({
                     <FormItem>
                       <FormLabel>Model Name</FormLabel>
                       <FormControl>
-                        <Input {...field} placeholder="assistant-prod" />
+                        <Input {...field} placeholder="assistant-prod" size="sm" />
                       </FormControl>
                       <FormDescription>Unique identifier referenced by agents.</FormDescription>
                       <FormMessage />
@@ -255,7 +255,7 @@ export function ModelFormDialog({
                     <FormItem>
                       <FormLabel>Provider Model Identifier</FormLabel>
                       <FormControl>
-                        <Input {...field} placeholder={providerPlaceholder} />
+                        <Input {...field} placeholder={providerPlaceholder} size="sm" />
                       </FormControl>
                       <FormDescription>Exact model slug as recognized by the provider.</FormDescription>
                       <FormMessage />
@@ -279,6 +279,7 @@ export function ModelFormDialog({
                             value: credentialOption.name,
                             label: credentialOption.name,
                           }))}
+                          size="sm"
                         />
                       </FormControl>
                       <FormDescription>
@@ -298,7 +299,7 @@ export function ModelFormDialog({
                     <FormItem>
                       <FormLabel>Mode</FormLabel>
                       <FormControl>
-                        <Input {...field} placeholder="chat" />
+                        <Input {...field} placeholder="chat" size="sm" />
                       </FormControl>
                       <FormDescription>LiteLLM mode (chat, completion, embedding, etc.).</FormDescription>
                     </FormItem>
@@ -352,7 +353,7 @@ export function ModelFormDialog({
           </Form>
 
           <div className="border-t border-[var(--agyn-border-subtle)] px-6 pb-6">
-            <ScreenDialogFooter className="mt-6">
+            <ScreenDialogFooter className="mt-6 mb-2 sm:mb-4">
               <Button variant="ghost" size="md" onClick={() => onOpenChange(false)} disabled={submitting}>
                 Cancel
               </Button>
@@ -390,7 +391,7 @@ function NumericField({ label, name, placeholder, control }: NumericFieldProps) 
         <FormItem>
           <FormLabel>{label}</FormLabel>
           <FormControl>
-            <Input type="number" step="any" {...field} placeholder={placeholder} />
+            <Input type="number" step="any" {...field} placeholder={placeholder} size="sm" />
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/packages/platform-ui/src/features/llmSettings/components/ModelFormDialog.tsx
+++ b/packages/platform-ui/src/features/llmSettings/components/ModelFormDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, type ReactElement } from 'react';
+import { X } from 'lucide-react';
 import { useForm, useWatch, type Control, type FieldValues } from 'react-hook-form';
 import {
   ScreenDialog,
@@ -9,9 +10,10 @@ import {
   ScreenDialogTitle,
 } from '@/components/Dialog';
 import { Button } from '@/components/Button';
+import { IconButton } from '@/components/IconButton';
 import { Input } from '@/components/Input';
 import { Textarea } from '@/components/Textarea';
-import { SelectInput } from '@/components/SelectInput';
+import { Dropdown } from '@/components/Dropdown';
 import { SwitchControl } from '@/components/SwitchControl';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/forms/Form';
 import type { CredentialRecord, ModelRecord, ProviderOption } from '../types';
@@ -202,15 +204,29 @@ export function ModelFormDialog({
 
   return (
     <ScreenDialog open={open} onOpenChange={onOpenChange}>
-      <ScreenDialogContent className="max-h-[90vh] p-0 sm:max-w-2xl">
+      <ScreenDialogContent className="max-h-[90vh] p-0 sm:max-w-2xl" hideCloseButton>
         <div className="flex max-h-[inherit] flex-col">
           <div className="border-b border-[var(--agyn-border-subtle)] px-6 pb-4 pt-6">
-            <ScreenDialogHeader>
-              <ScreenDialogTitle>{mode === 'create' ? 'Create Model' : `Edit Model — ${model?.id}`}</ScreenDialogTitle>
-              <ScreenDialogDescription>
-                Define LiteLLM model routing and guardrails for agent usage.
-              </ScreenDialogDescription>
-            </ScreenDialogHeader>
+            <div className="flex items-start justify-between gap-4">
+              <ScreenDialogHeader className="flex-1 gap-2">
+                <ScreenDialogTitle>
+                  {mode === 'create' ? 'Create Model' : `Edit Model — ${model?.id}`}
+                </ScreenDialogTitle>
+                <ScreenDialogDescription>
+                  Define LiteLLM model routing and guardrails for agent usage.
+                </ScreenDialogDescription>
+              </ScreenDialogHeader>
+              <IconButton
+                icon={<X className="h-4 w-4" />}
+                variant="ghost"
+                size="sm"
+                rounded={false}
+                aria-label="Close dialog"
+                title="Close"
+                className="shrink-0"
+                onClick={() => onOpenChange(false)}
+              />
+            </div>
           </div>
 
           <Form {...form}>
@@ -255,9 +271,9 @@ export function ModelFormDialog({
                     <FormItem>
                       <FormLabel>Credential</FormLabel>
                       <FormControl>
-                        <SelectInput
-                          value={field.value ?? ''}
-                          onChange={(event) => field.onChange(event.target.value)}
+                        <Dropdown
+                          value={field.value || undefined}
+                          onValueChange={(value) => field.onChange(value)}
                           placeholder="Select credential"
                           options={credentials.map((credentialOption) => ({
                             value: credentialOption.name,
@@ -335,12 +351,12 @@ export function ModelFormDialog({
             </div>
           </Form>
 
-          <div className="border-t border-[var(--agyn-border-subtle)] px-6 pb-6 pt-4">
-            <ScreenDialogFooter>
-              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+          <div className="border-t border-[var(--agyn-border-subtle)] px-6 pb-6">
+            <ScreenDialogFooter className="mt-6">
+              <Button variant="ghost" size="md" onClick={() => onOpenChange(false)} disabled={submitting}>
                 Cancel
               </Button>
-              <Button type="submit" form="llm-model-form" disabled={submitting}>
+              <Button type="submit" form="llm-model-form" variant="primary" size="md" disabled={submitting}>
                 {submitting ? 'Saving…' : mode === 'create' ? 'Create Model' : 'Save Changes'}
               </Button>
             </ScreenDialogFooter>

--- a/packages/platform-ui/src/features/llmSettings/components/TestCredentialDialog.tsx
+++ b/packages/platform-ui/src/features/llmSettings/components/TestCredentialDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type ReactElement } from 'react';
+import { X } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import {
   ScreenDialog,
@@ -9,9 +10,10 @@ import {
   ScreenDialogTitle,
 } from '@/components/Dialog';
 import { Button } from '@/components/Button';
+import { IconButton } from '@/components/IconButton';
 import { Input } from '@/components/Input';
 import { Textarea } from '@/components/Textarea';
-import { SelectInput } from '@/components/SelectInput';
+import { Dropdown } from '@/components/Dropdown';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/forms/Form';
 
 interface TestCredentialFormValues {
@@ -69,15 +71,27 @@ export function TestCredentialDialog({
 
   return (
     <ScreenDialog open={open} onOpenChange={onOpenChange}>
-      <ScreenDialogContent className="sm:max-w-lg">
-        <ScreenDialogHeader>
-          <ScreenDialogTitle>Test Credential — {credentialName}</ScreenDialogTitle>
-          <ScreenDialogDescription>
-            Send a LiteLLM health check call using this credential and optional sample input.
-          </ScreenDialogDescription>
-        </ScreenDialogHeader>
+      <ScreenDialogContent className="sm:max-w-lg" hideCloseButton>
+        <div className="flex items-start justify-between gap-4">
+          <ScreenDialogHeader className="flex-1 gap-2">
+            <ScreenDialogTitle>Test Credential — {credentialName}</ScreenDialogTitle>
+            <ScreenDialogDescription>
+              Send a LiteLLM health check call using this credential and optional sample input.
+            </ScreenDialogDescription>
+          </ScreenDialogHeader>
+          <IconButton
+            icon={<X className="h-4 w-4" />}
+            variant="ghost"
+            size="sm"
+            rounded={false}
+            aria-label="Close dialog"
+            title="Close"
+            className="shrink-0"
+            onClick={() => onOpenChange(false)}
+          />
+        </div>
         <Form {...form}>
-          <form id="llm-credential-test-form" onSubmit={handleSubmit} className="space-y-4">
+          <form id="llm-credential-test-form" onSubmit={handleSubmit} className="mt-4 space-y-4">
             <FormField
               control={form.control}
               name="model"
@@ -100,9 +114,9 @@ export function TestCredentialDialog({
                 <FormItem>
                   <FormLabel>Mode</FormLabel>
                   <FormControl>
-                    <SelectInput
-                      value={field.value}
-                      onChange={(event) => field.onChange(event.target.value)}
+                    <Dropdown
+                      value={field.value || undefined}
+                      onValueChange={(value) => field.onChange(value)}
                       disabled={healthCheckModesLoading}
                       placeholder="Select mode"
                       options={healthCheckModes.map((modeOption) => ({ value: modeOption, label: modeOption }))}
@@ -129,11 +143,11 @@ export function TestCredentialDialog({
             />
           </form>
         </Form>
-        <ScreenDialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+        <ScreenDialogFooter className="mt-6">
+          <Button variant="ghost" size="md" onClick={() => onOpenChange(false)} disabled={submitting}>
             Cancel
           </Button>
-          <Button type="submit" form="llm-credential-test-form" disabled={submitting}>
+          <Button type="submit" form="llm-credential-test-form" variant="primary" size="md" disabled={submitting}>
             {submitting ? 'Testing…' : 'Run Test'}
           </Button>
         </ScreenDialogFooter>

--- a/packages/platform-ui/src/features/llmSettings/components/TestModelDialog.tsx
+++ b/packages/platform-ui/src/features/llmSettings/components/TestModelDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type ReactElement } from 'react';
+import { X } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import {
   ScreenDialog,
@@ -9,9 +10,10 @@ import {
   ScreenDialogTitle,
 } from '@/components/Dialog';
 import { Button } from '@/components/Button';
+import { IconButton } from '@/components/IconButton';
 import { Input } from '@/components/Input';
 import { Textarea } from '@/components/Textarea';
-import { SelectInput } from '@/components/SelectInput';
+import { Dropdown } from '@/components/Dropdown';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel } from '@/components/forms/Form';
 import type { ModelRecord } from '../types';
 
@@ -72,15 +74,27 @@ export function TestModelDialog({
 
   return (
     <ScreenDialog open={open} onOpenChange={onOpenChange}>
-      <ScreenDialogContent className="sm:max-w-lg">
-        <ScreenDialogHeader>
-          <ScreenDialogTitle>Test Model — {model.id}</ScreenDialogTitle>
-          <ScreenDialogDescription>
-            Run a LiteLLM health check for this model with optional overrides.
-          </ScreenDialogDescription>
-        </ScreenDialogHeader>
+      <ScreenDialogContent className="sm:max-w-lg" hideCloseButton>
+        <div className="flex items-start justify-between gap-4">
+          <ScreenDialogHeader className="flex-1 gap-2">
+            <ScreenDialogTitle>Test Model — {model.id}</ScreenDialogTitle>
+            <ScreenDialogDescription>
+              Run a LiteLLM health check for this model with optional overrides.
+            </ScreenDialogDescription>
+          </ScreenDialogHeader>
+          <IconButton
+            icon={<X className="h-4 w-4" />}
+            variant="ghost"
+            size="sm"
+            rounded={false}
+            aria-label="Close dialog"
+            title="Close"
+            className="shrink-0"
+            onClick={() => onOpenChange(false)}
+          />
+        </div>
         <Form {...form}>
-          <form id="llm-model-test-form" onSubmit={handleSubmit} className="space-y-4">
+          <form id="llm-model-test-form" onSubmit={handleSubmit} className="mt-4 space-y-4">
             <FormField
               control={form.control}
               name="mode"
@@ -88,9 +102,9 @@ export function TestModelDialog({
                 <FormItem>
                   <FormLabel>Mode</FormLabel>
                   <FormControl>
-                    <SelectInput
-                      value={field.value}
-                      onChange={(event) => field.onChange(event.target.value)}
+                    <Dropdown
+                      value={field.value || undefined}
+                      onValueChange={(value) => field.onChange(value)}
                       disabled={healthCheckModesLoading}
                       placeholder="Select mode"
                       options={healthCheckModes.map((modeOption) => ({ value: modeOption, label: modeOption }))}
@@ -141,11 +155,11 @@ export function TestModelDialog({
             />
           </form>
         </Form>
-        <ScreenDialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+        <ScreenDialogFooter className="mt-6">
+          <Button variant="ghost" size="md" onClick={() => onOpenChange(false)} disabled={submitting}>
             Cancel
           </Button>
-          <Button type="submit" form="llm-model-test-form" disabled={submitting}>
+          <Button type="submit" form="llm-model-test-form" variant="primary" size="md" disabled={submitting}>
             {submitting ? 'Testing…' : 'Run Test'}
           </Button>
         </ScreenDialogFooter>

--- a/packages/platform-ui/src/pages/__tests__/settings-llm.test.tsx
+++ b/packages/platform-ui/src/pages/__tests__/settings-llm.test.tsx
@@ -666,8 +666,10 @@ describe('Settings/LLM page', () => {
     const modelInput = within(dialog).getByLabelText('Provider Model Identifier') as HTMLInputElement;
     expect(modelInput.getAttribute('placeholder')).toBe('gpt-4o-mini');
 
-    const credentialSelect = within(dialog).getByLabelText('Credential') as HTMLSelectElement;
-    await user.selectOptions(credentialSelect, 'zz-anthropic-legacy');
+    const credentialCombobox = within(dialog).getByRole('combobox', { name: 'Credential' });
+    await user.click(credentialCombobox);
+    const credentialOption = await screen.findByRole('option', { name: 'zz-anthropic-legacy' });
+    await user.click(credentialOption);
 
     await waitFor(() => expect(modelInput.getAttribute('placeholder')).toBe('claude-3-opus'));
     expect(
@@ -746,9 +748,12 @@ describe('Settings/LLM page', () => {
     const dialog = await screen.findByRole('dialog', { name: /Test Credential/i });
     const modeCombobox = within(dialog).getByRole('combobox');
     await waitFor(() => expect(modeCombobox).toBeEnabled());
-    const renderedOptions = Array.from(modeCombobox.querySelectorAll('option:not([hidden])')) as HTMLOptionElement[];
+    await user.click(modeCombobox);
+    const listbox = await screen.findByRole('listbox');
+    const renderedOptions = within(listbox).getAllByRole('option');
     const optionLabels = renderedOptions.map((option) => option.textContent?.trim());
     expect(optionLabels).toEqual(modeOptions);
+    await user.keyboard('{Escape}');
   });
 
   it('disables admin actions and shows banner when LiteLLM admin auth is missing', async () => {


### PR DESCRIPTION
## Summary
- forward id/aria props through `Dropdown` so form labels stay accessible
- refresh LLM settings dialogs with Dropdown triggers, IconButton close controls, and updated footer spacing/button sizes
- update Settings LLM tests to exercise Radix dropdown interactions

## Testing
- pnpm --filter @agyn/platform-ui test -- --reporter=basic
- pnpm --filter @agyn/platform-server exec -- vitest run --reporter=json --outputFile=packages/platform-server/server-tests.json

Closes #1238.
