### PR TITLE
fix: render memory tool inputs in generic view

### DIFF
--- a/packages/platform-ui/src/pages/AgentsRunScreen.tsx
+++ b/packages/platform-ui/src/pages/AgentsRunScreen.tsx
@@ -204,18 +204,21 @@ function aggregateTokens(events: RunTimelineEvent[]): TokenTotals {
 
 function inferToolSubtype(toolName: string | undefined, input: unknown): 'shell' | 'manage' | 'generic' {
   const normalized = (toolName ?? '').toLowerCase();
-  if (normalized.includes('shell') || normalized.includes('command') || normalized.includes('exec')) {
-    return 'shell';
+  if (normalized.includes('memory')) {
+    return 'generic';
   }
   if (normalized.includes('manage') || normalized.includes('delegate') || normalized.includes('call_agent')) {
     return 'manage';
+  }
+  if (normalized.includes('shell') || normalized.includes('command') || normalized.includes('exec')) {
+    return 'shell';
   }
   if (typeof input === 'object' && input !== null) {
     const candidate = input as Record<string, unknown>;
     if (typeof candidate.command === 'string' && typeof candidate.worker === 'string') {
       return 'manage';
     }
-    if (typeof candidate.command === 'string' || typeof candidate.cwd === 'string') {
+    if (typeof candidate.command === 'string' && typeof candidate.cwd === 'string') {
       return 'shell';
     }
   }

--- a/packages/platform-ui/src/pages/AgentsRunScreen.tsx
+++ b/packages/platform-ui/src/pages/AgentsRunScreen.tsx
@@ -210,7 +210,7 @@ function inferToolSubtype(toolName: string | undefined, input: unknown): 'shell'
   if (normalized.includes('manage') || normalized.includes('delegate') || normalized.includes('call_agent')) {
     return 'manage';
   }
-  if (normalized.includes('shell') || normalized.includes('command') || normalized.includes('exec')) {
+  if (normalized.includes('shell') || normalized.includes('exec')) {
     return 'shell';
   }
   if (typeof input === 'object' && input !== null) {

--- a/packages/platform-ui/src/pages/__tests__/AgentsRunScreen.test.tsx
+++ b/packages/platform-ui/src/pages/__tests__/AgentsRunScreen.test.tsx
@@ -292,6 +292,124 @@ describe('AgentsRunScreen', () => {
     expect(normalizedOutput.subthreadId).toBe('child-subthread');
   });
 
+  it('treats memory tool executions as generic even when inputs include command data', async () => {
+    const event = buildEvent({
+      toolExecution: {
+        toolName: 'memory_write',
+        toolCallId: 'call-memory',
+        execStatus: 'success',
+        input: JSON.stringify({
+          command: 'store',
+          key: 'workspace-state',
+          payload: { value: 'snapshot' },
+        }),
+        output: '{}',
+        errorMessage: null,
+        raw: null,
+      },
+    });
+
+    runsHookMocks.summary.mockReturnValue(buildSummary());
+    runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
+
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+          <Routes>
+            <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      const latest = latestRunScreenProps<{ events: Array<{ data: { toolSubtype?: string } }> }>();
+      expect(latest).toBeDefined();
+      expect(latest?.events).toHaveLength(1);
+      expect(latest?.events[0].data.toolSubtype).toBe('generic');
+    });
+  });
+
+  it('infers manage subtype when tool input includes worker and command fields', async () => {
+    const event = buildEvent({
+      toolExecution: {
+        toolName: 'workflow_dispatch',
+        toolCallId: 'call-manage',
+        execStatus: 'success',
+        input: JSON.stringify({
+          worker: 'agent-007',
+          command: 'fetch_reports',
+        }),
+        output: '{}',
+        errorMessage: null,
+        raw: null,
+      },
+    });
+
+    runsHookMocks.summary.mockReturnValue(buildSummary());
+    runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
+
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+          <Routes>
+            <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      const latest = latestRunScreenProps<{ events: Array<{ data: { toolSubtype?: string } }> }>();
+      expect(latest).toBeDefined();
+      expect(latest?.events).toHaveLength(1);
+      expect(latest?.events[0].data.toolSubtype).toBe('manage');
+    });
+  });
+
+  it('infers shell subtype from cwd and command pairing when tool name is ambiguous', async () => {
+    const event = buildEvent({
+      toolExecution: {
+        toolName: 'executor',
+        toolCallId: 'call-shell',
+        execStatus: 'success',
+        input: JSON.stringify({
+          command: 'ls -la',
+          cwd: '/tmp',
+        }),
+        output: '{}',
+        errorMessage: null,
+        raw: null,
+      },
+    });
+
+    runsHookMocks.summary.mockReturnValue(buildSummary());
+    runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
+
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+          <Routes>
+            <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      const latest = latestRunScreenProps<{ events: Array<{ data: { toolSubtype?: string } }> }>();
+      expect(latest).toBeDefined();
+      expect(latest?.events).toHaveLength(1);
+      expect(latest?.events[0].data.toolSubtype).toBe('shell');
+    });
+  });
+
   it('extracts Anthropic style function_call output entries as tool calls', async () => {
     const anthropicAssistant: ContextItem = {
       id: 'ctx-anthropic-assistant',


### PR DESCRIPTION
## Summary
- ensure memory tool executions render with the generic JSON viewer
- tighten shell/manage subtype heuristics to avoid command-only matches
- add AgentsRunScreen tests covering subtype inference scenarios

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test -- --reporter=basic

Closes #1244
