### PR TITLE
fix: sanitize tool output text

### DIFF
--- a/packages/platform-server/__tests__/run-events.tool-output.persistence.test.ts
+++ b/packages/platform-server/__tests__/run-events.tool-output.persistence.test.ts
@@ -30,14 +30,17 @@ const baseTerminalArgs = {
 
 describe('RunEventsService tool output persistence resilience', () => {
   let warnSpy: SpyInstance;
+  let debugSpy: SpyInstance;
 
   beforeEach(() => {
     vi.clearAllMocks();
     warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    debugSpy = vi.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     warnSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 
   it('logs once and continues streaming when chunk persistence fails', async () => {
@@ -119,6 +122,182 @@ describe('RunEventsService tool output persistence resilience', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       'Tool output snapshot retrieval failed. Run `pnpm --filter @agyn/platform-server prisma migrate deploy` followed by `pnpm --filter @agyn/platform-server prisma generate` to install the latest schema.',
       expect.objectContaining({ eventId: 'event-1', runId: 'run-1' }),
+    );
+  });
+
+  it('decodes UTF-16LE chunk data with BOM before persisting', async () => {
+    const now = new Date();
+    const utf16leBuffer = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from('Hello', 'utf16le')]);
+    const rawData = utf16leBuffer.toString('binary');
+    const prismaClient = {
+      toolOutputChunk: {
+        create: vi.fn().mockImplementation(async ({ data }) => {
+          expect(data.data).toBe('Hello');
+          return {
+            eventId: data.eventId,
+            seqGlobal: data.seqGlobal,
+            seqStream: data.seqStream,
+            source: data.source,
+            data: data.data,
+            ts: now,
+          };
+        }),
+      },
+      toolOutputTerminal: {
+        upsert: vi.fn(),
+      },
+    } as Record<string, unknown>;
+    const prismaService = { getClient: () => prismaClient } as unknown as PrismaService;
+    const service = new RunEventsService(prismaService);
+
+    const result = await service.appendToolOutputChunk({ ...baseChunkArgs, data: rawData });
+
+    expect(result.data).toBe('Hello');
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Sanitized tool output for Postgres compatibility',
+      expect.objectContaining({
+        runId: 'run-1',
+        eventId: 'event-1',
+        field: 'chunk.data',
+        transcodedEncoding: 'utf16le',
+        strippedNullCount: 0,
+      }),
+    );
+  });
+
+  it('decodes UTF-16BE chunk data with BOM before persisting', async () => {
+    const now = new Date();
+    const leBody = Buffer.from('Hello', 'utf16le');
+    const beBody = Buffer.alloc(leBody.length);
+    for (let i = 0; i < leBody.length; i += 2) {
+      beBody[i] = leBody[i + 1]!;
+      beBody[i + 1] = leBody[i]!;
+    }
+    const utf16beBuffer = Buffer.concat([Buffer.from([0xfe, 0xff]), beBody]);
+    const rawData = utf16beBuffer.toString('binary');
+    const prismaClient = {
+      toolOutputChunk: {
+        create: vi.fn().mockImplementation(async ({ data }) => {
+          expect(data.data).toBe('Hello');
+          return {
+            eventId: data.eventId,
+            seqGlobal: data.seqGlobal,
+            seqStream: data.seqStream,
+            source: data.source,
+            data: data.data,
+            ts: now,
+          };
+        }),
+      },
+      toolOutputTerminal: {
+        upsert: vi.fn(),
+      },
+    } as Record<string, unknown>;
+    const prismaService = { getClient: () => prismaClient } as unknown as PrismaService;
+    const service = new RunEventsService(prismaService);
+
+    const result = await service.appendToolOutputChunk({ ...baseChunkArgs, data: rawData });
+
+    expect(result.data).toBe('Hello');
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Sanitized tool output for Postgres compatibility',
+      expect.objectContaining({
+        runId: 'run-1',
+        eventId: 'event-1',
+        field: 'chunk.data',
+        transcodedEncoding: 'utf16be',
+        strippedNullCount: 0,
+      }),
+    );
+  });
+
+  it('strips null bytes from chunk data before persisting', async () => {
+    const now = new Date();
+    const prismaClient = {
+      toolOutputChunk: {
+        create: vi.fn().mockImplementation(async ({ data }) => {
+          expect(data.data).toBe('abcdef');
+          return {
+            eventId: data.eventId,
+            seqGlobal: data.seqGlobal,
+            seqStream: data.seqStream,
+            source: data.source,
+            data: data.data,
+            ts: now,
+          };
+        }),
+      },
+      toolOutputTerminal: {
+        upsert: vi.fn(),
+      },
+    } as Record<string, unknown>;
+    const prismaService = { getClient: () => prismaClient } as unknown as PrismaService;
+    const service = new RunEventsService(prismaService);
+
+    const result = await service.appendToolOutputChunk({ ...baseChunkArgs, data: 'abc\u0000def' });
+
+    expect(result.data).toBe('abcdef');
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Sanitized tool output for Postgres compatibility',
+      expect.objectContaining({
+        runId: 'run-1',
+        eventId: 'event-1',
+        field: 'chunk.data',
+        strippedNullCount: 1,
+        transcodedEncoding: null,
+      }),
+    );
+  });
+
+  it('strips null bytes from terminal message before persisting', async () => {
+    const now = new Date();
+    const prismaClient = {
+      toolOutputChunk: {
+        create: vi.fn().mockResolvedValue({
+          eventId: baseChunkArgs.eventId,
+          seqGlobal: baseChunkArgs.seqGlobal,
+          seqStream: baseChunkArgs.seqStream,
+          source: baseChunkArgs.source,
+          data: baseChunkArgs.data,
+          ts: now,
+        }),
+      },
+      toolOutputTerminal: {
+        upsert: vi.fn().mockImplementation(async ({ create }) => {
+          expect(create.message).toBe('badnews');
+          return {
+            eventId: create.eventId,
+            exitCode: create.exitCode,
+            status: create.status,
+            bytesStdout: create.bytesStdout,
+            bytesStderr: create.bytesStderr,
+            totalChunks: create.totalChunks,
+            droppedChunks: create.droppedChunks,
+            savedPath: create.savedPath,
+            message: create.message,
+            ts: now,
+          };
+        }),
+      },
+    } as Record<string, unknown>;
+    const prismaService = { getClient: () => prismaClient } as unknown as PrismaService;
+    const service = new RunEventsService(prismaService);
+
+    const result = await service.finalizeToolOutputTerminal({
+      ...baseTerminalArgs,
+      message: 'bad\u0000news',
+    });
+
+    expect(result.message).toBe('badnews');
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Sanitized tool output for Postgres compatibility',
+      expect.objectContaining({
+        runId: 'run-1',
+        eventId: 'event-1',
+        field: 'terminal.message',
+        strippedNullCount: 1,
+        transcodedEncoding: null,
+      }),
     );
   });
 });

--- a/packages/platform-server/__tests__/tools/shell.combined.output.test.ts
+++ b/packages/platform-server/__tests__/tools/shell.combined.output.test.ts
@@ -4,7 +4,7 @@ import { ShellCommandNode } from '../../src/nodes/tools/shell_command/shell_comm
 import type { ContainerHandle } from '../../src/infra/container/container.handle';
 import { ExecIdleTimeoutError, ExecTimeoutError } from '../../src/utils/execTimeout';
 
-type OutputChunk = { source: 'stdout' | 'stderr'; data: string };
+type OutputChunk = { source: 'stdout' | 'stderr'; data: string | Buffer };
 
 class SequenceContainer implements ContainerHandle {
   constructor(private readonly chunks: OutputChunk[], private readonly exitCode = 0) {}
@@ -16,9 +16,10 @@ class SequenceContainer implements ContainerHandle {
     const stdoutParts: string[] = [];
     const stderrParts: string[] = [];
     for (const chunk of this.chunks) {
-      if (chunk.source === 'stdout') stdoutParts.push(chunk.data);
-      else stderrParts.push(chunk.data);
-      options?.onOutput?.(chunk.source, Buffer.from(chunk.data, 'utf8'));
+      const buffer = typeof chunk.data === 'string' ? Buffer.from(chunk.data, 'utf8') : chunk.data;
+      if (chunk.source === 'stdout') stdoutParts.push(buffer.toString('utf8'));
+      else stderrParts.push(buffer.toString('utf8'));
+      options?.onOutput?.(chunk.source, buffer);
     }
     return { stdout: stdoutParts.join(''), stderr: stderrParts.join(''), exitCode: this.exitCode };
   }
@@ -149,6 +150,39 @@ describe('ShellCommandTool combined output', () => {
     expect(terminalArgs).toMatchObject({ status: 'success', exitCode: 0 });
     expect(terminalArgs.bytesStdout).toBe(Buffer.byteLength('alpha\ngamma\n', 'utf8'));
     expect(terminalArgs.bytesStderr).toBe(Buffer.byteLength('beta\n', 'utf8'));
+  });
+
+  it('decodes UTF-16LE stdout chunks with BOM before persistence', async () => {
+    const utf16Chunk = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from('Hello world', 'utf16le')]);
+    const chunks: OutputChunk[] = [{ source: 'stdout', data: utf16Chunk }];
+    const container = new SequenceContainer(chunks);
+    const { tool, runEvents } = createToolWithContainer(container);
+
+    const result = await tool.executeStreaming({ command: 'cat utf16-le.txt' }, ctx as any, streamingOptions);
+
+    expect(result).toBe('Hello world');
+    expect(runEvents.appendToolOutputChunk).toHaveBeenCalledTimes(1);
+    const persisted = runEvents.appendToolOutputChunk.mock.calls[0][0]?.data as string;
+    expect(persisted).toBe('Hello world');
+    expect(persisted.includes('\u0000')).toBe(false);
+  });
+
+  it('handles BOM split across stdout chunks when decoding UTF-16LE output', async () => {
+    const chunkA = Buffer.from([0xff]);
+    const chunkB = Buffer.concat([Buffer.from([0xfe]), Buffer.from('Hi there', 'utf16le')]);
+    const chunks: OutputChunk[] = [
+      { source: 'stdout', data: chunkA },
+      { source: 'stdout', data: chunkB },
+    ];
+    const container = new SequenceContainer(chunks);
+    const { tool, runEvents } = createToolWithContainer(container);
+
+    const result = await tool.executeStreaming({ command: 'cat utf16-split.txt' }, ctx as any, streamingOptions);
+
+    expect(result).toBe('Hi there');
+    const payloadTexts = runEvents.appendToolOutputChunk.mock.calls.map((call) => call[0]?.data as string);
+    expect(payloadTexts.join('')).toBe('Hi there');
+    payloadTexts.forEach((text) => expect(text.includes('\u0000')).toBe(false));
   });
 
   it('removes CSI sequences that span chunk boundaries (streaming)', async () => {


### PR DESCRIPTION
## Summary
- transcode BOM-based UTF-16 tool output to UTF-8 and strip NUL bytes before persistence
- add per-event structured debug logging when sanitization occurs
- extend run-events persistence tests for UTF-16 LE/BE and NUL stripping regressions

## Testing
- `pnpm --filter @agyn/platform-server lint`
- `pnpm --filter @agyn/platform-server test -- --runInBand --reporter=basic --silent`

Resolves #1250
