### PR TITLE
feat: cancel pending thread actions

### DIFF
--- a/packages/platform-server/__tests__/agents.fail_fast.test.ts
+++ b/packages/platform-server/__tests__/agents.fail_fast.test.ts
@@ -11,6 +11,7 @@ import { RunEventsService } from '../src/events/run-events.service';
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
 import { TemplateRegistry } from '../src/graph-core/templateRegistry';
+import { RemindersService } from '../src/agents/reminders.service';
 
 class StubLLMProvisioner extends LLMProvisioner {
   async init(): Promise<void> {}
@@ -89,6 +90,7 @@ describe('Fail-fast behavior', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 

--- a/packages/platform-server/__tests__/agents.threads.controller.create.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.create.test.ts
@@ -7,6 +7,7 @@ import { RunEventsService } from '../src/events/run-events.service';
 import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
 import { TemplateRegistry } from '../src/graph-core/templateRegistry';
+import { RemindersService } from '../src/agents/reminders.service';
 
 const runEventsStub = {
   getRunSummary: async () => null,
@@ -73,6 +74,7 @@ async function setup(options: SetupOptions = {}) {
       { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
       { provide: LiveGraphRuntime, useValue: { getNodes: () => nodes } },
       { provide: TemplateRegistry, useValue: templateRegistryStub },
+      { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
     ],
   }).compile();
 

--- a/packages/platform-server/__tests__/agents.threads.controller.list.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.list.test.ts
@@ -7,6 +7,7 @@ import { ThreadCleanupCoordinator } from '../src/agents/threadCleanup.coordinato
 import { RunEventsService } from '../src/events/run-events.service';
 import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
 import { TemplateRegistry } from '../src/graph-core/templateRegistry';
+import { RemindersService } from '../src/agents/reminders.service';
 
 const runEventsStub = {
   getRunSummary: vi.fn(async () => null),
@@ -37,6 +38,7 @@ describe('AgentsThreadsController list endpoints', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -87,6 +89,7 @@ describe('AgentsThreadsController list endpoints', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -122,6 +125,7 @@ describe('AgentsThreadsController list endpoints', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -157,6 +161,7 @@ describe('AgentsThreadsController list endpoints', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -188,6 +193,7 @@ describe('AgentsThreadsController list endpoints', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -230,6 +236,7 @@ describe('AgentsThreadsController list endpoints', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -279,6 +286,7 @@ describe('AgentsThreadsController list endpoints', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -309,6 +317,7 @@ describe('AgentsThreadsController list endpoints', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 

--- a/packages/platform-server/__tests__/agents.threads.controller.patch.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.patch.test.ts
@@ -7,6 +7,7 @@ import { ThreadCleanupCoordinator } from '../src/agents/threadCleanup.coordinato
 import { RunEventsService } from '../src/events/run-events.service';
 import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
 import { TemplateRegistry } from '../src/graph-core/templateRegistry';
+import { RemindersService } from '../src/agents/reminders.service';
 
 const runEventsStub = {
   getRunSummary: async () => ({
@@ -55,6 +56,7 @@ describe('AgentsThreadsController PATCH threads/:id', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -92,6 +94,7 @@ describe('AgentsThreadsController PATCH threads/:id', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -123,6 +126,7 @@ describe('AgentsThreadsController PATCH threads/:id', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 

--- a/packages/platform-server/__tests__/agents.threads.controller.queued-messages.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.queued-messages.test.ts
@@ -195,7 +195,7 @@ describe('AgentsThreadsController DELETE /api/agents/threads/:threadId/queued-me
     expect(result).toEqual({ clearedCount: 0 });
   });
 
-  it('returns zero when runtime throws', async () => {
+  it('throws when runtime throws', async () => {
     const clearQueuedMessages = vi.fn(() => {
       throw new Error('boom');
     });
@@ -215,9 +215,7 @@ describe('AgentsThreadsController DELETE /api/agents/threads/:threadId/queued-me
       ],
     });
 
-    const result = await controller.clearQueuedMessages('thread-1');
-
-    expect(result).toEqual({ clearedCount: 0 });
+    await expect(controller.clearQueuedMessages('thread-1')).rejects.toBeInstanceOf(InternalServerErrorException);
   });
 
   it('throws when thread is missing', async () => {

--- a/packages/platform-server/__tests__/agents.threads.controller.send-message.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.send-message.test.ts
@@ -9,6 +9,7 @@ import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
 import { TemplateRegistry } from '../src/graph-core/templateRegistry';
 import type { ThreadStatus } from '@prisma/client';
 import { NotFoundException, ServiceUnavailableException } from '@nestjs/common';
+import { RemindersService } from '../src/agents/reminders.service';
 
 const runEventsStub = {
   getRunSummary: async () => null,
@@ -65,6 +66,7 @@ async function setup(options: SetupOptions = {}) {
       { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
       { provide: LiveGraphRuntime, useValue: { getNodes: () => nodes } },
       { provide: TemplateRegistry, useValue: templateRegistryStub },
+      { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
     ],
   }).compile();
 

--- a/packages/platform-server/__tests__/agents.threads.controller.terminate.run.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.terminate.run.test.ts
@@ -8,6 +8,7 @@ import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { NotFoundException } from '@nestjs/common';
 import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
 import { TemplateRegistry } from '../src/graph-core/templateRegistry';
+import { RemindersService } from '../src/agents/reminders.service';
 
 const runEventsStub = {
   getRunSummary: vi.fn(),
@@ -32,6 +33,7 @@ describe('AgentsThreadsController terminate run endpoint', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate, clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -56,6 +58,7 @@ describe('AgentsThreadsController terminate run endpoint', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate, clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -79,6 +82,7 @@ describe('AgentsThreadsController terminate run endpoint', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 

--- a/packages/platform-server/__tests__/agents.threads.controller.tool-output.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.tool-output.test.ts
@@ -8,6 +8,7 @@ import { RunSignalsRegistry } from '../src/agents/run-signals.service';
 import { NotImplementedException } from '@nestjs/common';
 import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
 import { TemplateRegistry } from '../src/graph-core/templateRegistry';
+import { RemindersService } from '../src/agents/reminders.service';
 
 describe('AgentsThreadsController tool output snapshot endpoint', () => {
   it('returns 501 when tool output persistence is unavailable', async () => {
@@ -24,6 +25,7 @@ describe('AgentsThreadsController tool output snapshot endpoint', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 
@@ -60,6 +62,7 @@ describe('AgentsThreadsController tool output snapshot endpoint', () => {
         { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
         { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
         { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
       ],
     }).compile();
 

--- a/packages/platform-server/src/agents/agent-node.utils.ts
+++ b/packages/platform-server/src/agents/agent-node.utils.ts
@@ -3,7 +3,7 @@ import type { LiveNode } from '../graph/liveGraph.types';
 import { TemplateRegistry } from '../graph-core/templateRegistry';
 
 export type AgentRuntimeInstance = Pick<AgentNode, 'invoke' | 'status'> &
-  Partial<Pick<AgentNode, 'listQueuedPreview'>>;
+  Partial<Pick<AgentNode, 'listQueuedPreview' | 'clearQueuedMessages'>>;
 
 export function isAgentRuntimeInstance(value: unknown): value is AgentRuntimeInstance {
   if (value instanceof AgentNode) return true;
@@ -16,6 +16,12 @@ export function hasQueuedPreviewCapability(
   value: AgentRuntimeInstance,
 ): value is AgentRuntimeInstance & Pick<AgentNode, 'listQueuedPreview'> {
   return typeof value.listQueuedPreview === 'function';
+}
+
+export function hasQueueManagementCapability(
+  value: AgentRuntimeInstance,
+): value is AgentRuntimeInstance & Pick<AgentNode, 'clearQueuedMessages'> {
+  return typeof value.clearQueuedMessages === 'function';
 }
 
 export function isAgentTemplate(template: string, registry: TemplateRegistry): boolean {

--- a/packages/platform-server/src/agents/threads.controller.ts
+++ b/packages/platform-server/src/agents/threads.controller.ts
@@ -486,7 +486,7 @@ export class AgentsThreadsController {
         stack,
         AgentsThreadsController.name,
       );
-      return { clearedCount: 0 } as const;
+      throw new InternalServerErrorException({ error: 'clear_failed' });
     }
   }
 

--- a/packages/platform-server/src/nodes/agent/agent.node.ts
+++ b/packages/platform-server/src/nodes/agent/agent.node.ts
@@ -687,6 +687,10 @@ export class AgentNode extends Node<AgentStaticConfig> implements OnModuleInit {
     return this.buffer.snapshot(threadId);
   }
 
+  public clearQueuedMessages(threadId: string): number {
+    return this.buffer.clearThread(threadId);
+  }
+
   addTool(toolNode: BaseToolNode<unknown>): void {
     const tool: FunctionTool = toolNode.getTool();
     const added = this.registerTool(tool, this.buildNodeToolSource(toolNode));

--- a/packages/platform-server/src/nodes/agent/messagesBuffer.ts
+++ b/packages/platform-server/src/nodes/agent/messagesBuffer.ts
@@ -98,12 +98,17 @@ export class MessagesBuffer {
     return s.lastEnqueueAt + this.debounceMs;
   }
 
-  /** Clear queued items for a thread. */
-  clearThread(thread: string): void {
+  /** Clear queued items for a thread. Returns number of removed messages. */
+  clearThread(thread: string): number {
     const s = this.threads.get(thread);
-    if (!s) return;
+    if (!s) return 0;
+    const removed = s.queue.length;
+    if (removed === 0) {
+      return 0;
+    }
     s.queue.length = 0;
     s.lastEnqueueAt = 0;
+    return removed;
   }
 
   destroy(): void {

--- a/packages/platform-server/src/nodes/tools/remind_me/remind_me.tool.ts
+++ b/packages/platform-server/src/nodes/tools/remind_me/remind_me.tool.ts
@@ -120,4 +120,15 @@ export class RemindMeFunctionTool extends FunctionTool<typeof remindMeInvocation
     this.onRegistryChanged?.(this.active.size, Date.now(), threadId);
     return clearedIds;
   }
+
+  clearTimerById(reminderId: string): string | null {
+    const entry = this.active.get(reminderId);
+    if (!entry) return null;
+
+    clearTimeout(entry.timer);
+    this.active.delete(reminderId);
+    const threadId = entry.reminder.threadId ?? null;
+    this.onRegistryChanged?.(this.active.size, Date.now(), threadId ?? undefined);
+    return threadId;
+  }
 }

--- a/packages/platform-ui/src/api/modules/threads.ts
+++ b/packages/platform-ui/src/api/modules/threads.ts
@@ -74,4 +74,10 @@ export const threads = {
     asData<{ items: { id: string; text: string; enqueuedAt?: string }[] }>(
       http.get(`/api/agents/threads/${encodeURIComponent(id)}/queued-messages`),
     ),
+  clearQueuedMessages: (id: string) =>
+    asData<{ clearedCount: number }>(http.delete(`/api/agents/threads/${encodeURIComponent(id)}/queued-messages`)),
+  cancelThreadReminders: (id: string) =>
+    asData<{ cancelledDb: number; clearedRuntime: number }>(
+      http.post(`/api/agents/threads/${encodeURIComponent(id)}/reminders/cancel`, {}),
+    ),
 };

--- a/packages/platform-ui/src/components/Conversation.tsx
+++ b/packages/platform-ui/src/components/Conversation.tsx
@@ -46,12 +46,17 @@ interface ConversationProps {
   collapsed?: boolean;
   scrollRef?: Ref<HTMLDivElement>;
   onScroll?: (event: UIEvent<HTMLDivElement>) => void;
+  onCancelQueuedMessage?: (queuedMessageId: string) => void;
+  onCancelReminder?: (reminderId: string) => void;
+  isCancelQueuedMessagesPending?: boolean;
+  cancellingReminderIds?: ReadonlySet<string>;
 }
 
 const EMPTY_QUEUED_MESSAGES: QueuedMessageData[] = [];
 const EMPTY_REMINDERS: ReminderData[] = [];
 const EMPTY_HEADER: ReactNode = null;
 const EMPTY_FOOTER: ReactNode = null;
+const EMPTY_REMINDER_IDS: ReadonlySet<string> = new Set();
 
 function ConversationImpl({
   runs,
@@ -64,6 +69,10 @@ function ConversationImpl({
   collapsed,
   scrollRef,
   onScroll,
+  onCancelQueuedMessage,
+  onCancelReminder,
+  isCancelQueuedMessagesPending = false,
+  cancellingReminderIds = EMPTY_REMINDER_IDS,
 }: ConversationProps) {
   const messagesRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const [runHeights, setRunHeights] = useState<Map<string, number>>(new Map());
@@ -188,6 +197,8 @@ function ConversationImpl({
                       <QueuedMessage
                         key={msg.id}
                         content={msg.content}
+                        onCancel={onCancelQueuedMessage ? () => onCancelQueuedMessage(msg.id) : undefined}
+                        isCancelling={isCancelQueuedMessagesPending}
                       />
                     ))}
 
@@ -198,6 +209,8 @@ function ConversationImpl({
                         content={reminder.content}
                         scheduledTime={reminder.scheduledTime}
                         date={reminder.date}
+                        onCancel={onCancelReminder ? () => onCancelReminder(reminder.id) : undefined}
+                        isCancelling={cancellingReminderIds.has(reminder.id)}
                       />
                     ))}
                   </div>
@@ -238,7 +251,11 @@ function areEqual(prev: ConversationProps, next: ConversationProps): boolean {
     prev.defaultCollapsed === next.defaultCollapsed &&
     prev.className === next.className &&
     prev.scrollRef === next.scrollRef &&
-    prev.onScroll === next.onScroll
+    prev.onScroll === next.onScroll &&
+    prev.onCancelQueuedMessage === next.onCancelQueuedMessage &&
+    prev.onCancelReminder === next.onCancelReminder &&
+    prev.isCancelQueuedMessagesPending === next.isCancelQueuedMessagesPending &&
+    prev.cancellingReminderIds === next.cancellingReminderIds
   );
 }
 

--- a/packages/platform-ui/src/components/IconButton.tsx
+++ b/packages/platform-ui/src/components/IconButton.tsx
@@ -2,7 +2,7 @@ import { type ButtonHTMLAttributes, type ReactNode } from 'react';
 
 interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'accent' | 'outline' | 'ghost' | 'danger';
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
   icon: ReactNode;
   rounded?: boolean;
 }
@@ -27,6 +27,7 @@ export function IconButton({
   };
   
   const sizes = {
+    xs: 'w-6 h-6 [&_svg]:w-3 [&_svg]:h-3',
     sm: 'w-8 h-8 [&_svg]:w-4 [&_svg]:h-4',
     md: 'w-10 h-10 [&_svg]:w-5 [&_svg]:h-5',
     lg: 'w-12 h-12 [&_svg]:w-6 [&_svg]:h-6',

--- a/packages/platform-ui/src/components/QueuedMessage.tsx
+++ b/packages/platform-ui/src/components/QueuedMessage.tsx
@@ -38,6 +38,7 @@ export function QueuedMessage({
                 size="sm"
                 variant="danger"
                 aria-label="Cancel queued message"
+                title="Cancel queued message"
                 disabled={isCancelling}
                 onClick={onCancel}
               />

--- a/packages/platform-ui/src/components/QueuedMessage.tsx
+++ b/packages/platform-ui/src/components/QueuedMessage.tsx
@@ -28,14 +28,14 @@ export function QueuedMessage({
 
         {/* Message Content */}
         <div className="flex flex-col gap-1 min-w-0">
-          <div className="flex items-start gap-2">
+          <div className="flex items-center gap-1.5">
             <span className="text-xs text-[var(--agyn-gray)]">User</span>
             {onCancel ? (
               <IconButton
                 icon={
-                  isCancelling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />
+                  isCancelling ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />
                 }
-                size="sm"
+                size="xs"
                 variant="danger"
                 aria-label="Cancel queued message"
                 title="Cancel queued message"

--- a/packages/platform-ui/src/components/QueuedMessage.tsx
+++ b/packages/platform-ui/src/components/QueuedMessage.tsx
@@ -1,14 +1,19 @@
 import { type ReactNode } from 'react';
-import { Clock } from 'lucide-react';
+import { Clock, Loader2, Trash2 } from 'lucide-react';
+import { IconButton } from './IconButton';
 
 interface QueuedMessageProps {
   content: ReactNode;
   className?: string;
+  onCancel?: () => void;
+  isCancelling?: boolean;
 }
 
 export function QueuedMessage({
   content,
   className = '',
+  onCancel,
+  isCancelling = false,
 }: QueuedMessageProps) {
   return (
     <div className={`flex justify-start mb-4 ${className}`}>
@@ -22,13 +27,23 @@ export function QueuedMessage({
         </div>
 
         {/* Message Content */}
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-[var(--agyn-gray)]">
-              User
-            </span>
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="flex items-start gap-2">
+            <span className="text-xs text-[var(--agyn-gray)]">User</span>
+            {onCancel ? (
+              <IconButton
+                icon={
+                  isCancelling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />
+                }
+                size="sm"
+                variant="danger"
+                aria-label="Cancel queued message"
+                disabled={isCancelling}
+                onClick={onCancel}
+              />
+            ) : null}
           </div>
-          <div className="text-[var(--agyn-gray)]">
+          <div className="text-[var(--agyn-gray)] break-words">
             {content}
           </div>
         </div>

--- a/packages/platform-ui/src/components/Reminder.tsx
+++ b/packages/platform-ui/src/components/Reminder.tsx
@@ -86,6 +86,7 @@ export function Reminder({
                 size="sm"
                 variant="danger"
                 aria-label="Cancel reminder"
+                title="Cancel reminder"
                 onClick={onCancel}
                 disabled={isCancelling}
               />

--- a/packages/platform-ui/src/components/Reminder.tsx
+++ b/packages/platform-ui/src/components/Reminder.tsx
@@ -1,11 +1,14 @@
 import { type ReactNode, useEffect, useState } from 'react';
-import { Bell } from 'lucide-react';
+import { Bell, Loader2, Trash2 } from 'lucide-react';
+import { IconButton } from './IconButton';
 
 interface ReminderProps {
   content: ReactNode;
   scheduledTime: string;
   date?: string;
   className?: string;
+  onCancel?: () => void;
+  isCancelling?: boolean;
 }
 
 function getCountdown(targetDate: Date): string {
@@ -28,6 +31,8 @@ export function Reminder({
   scheduledTime,
   date,
   className = '',
+  onCancel,
+  isCancelling = false,
 }: ReminderProps) {
   const [countdown, setCountdown] = useState<string>('');
   
@@ -60,8 +65,8 @@ export function Reminder({
         </div>
 
         {/* Message Content */}
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="flex items-start gap-2">
             <span className="text-xs" style={{ color: '#F59E0B' }}>
               User
             </span>
@@ -73,8 +78,20 @@ export function Reminder({
                 ({countdown})
               </span>
             )}
+            {onCancel ? (
+              <IconButton
+                icon={
+                  isCancelling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />
+                }
+                size="sm"
+                variant="danger"
+                aria-label="Cancel reminder"
+                onClick={onCancel}
+                disabled={isCancelling}
+              />
+            ) : null}
           </div>
-          <div style={{ color: '#F59E0B' }}>
+          <div style={{ color: '#F59E0B' }} className="break-words">
             {content}
           </div>
         </div>

--- a/packages/platform-ui/src/components/Reminder.tsx
+++ b/packages/platform-ui/src/components/Reminder.tsx
@@ -66,7 +66,7 @@ export function Reminder({
 
         {/* Message Content */}
         <div className="flex flex-col gap-1 min-w-0">
-          <div className="flex items-start gap-2">
+          <div className="flex items-center gap-1.5">
             <span className="text-xs" style={{ color: '#F59E0B' }}>
               User
             </span>
@@ -81,9 +81,9 @@ export function Reminder({
             {onCancel ? (
               <IconButton
                 icon={
-                  isCancelling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />
+                  isCancelling ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />
                 }
-                size="sm"
+                size="xs"
                 variant="danger"
                 aria-label="Cancel reminder"
                 title="Cancel reminder"

--- a/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
+++ b/packages/platform-ui/src/components/screens/ThreadsScreen.tsx
@@ -75,6 +75,10 @@ interface ThreadsScreenProps {
   draftFetchOptions?: (query: string) => Promise<AutocompleteOption[]>;
   onDraftRecipientChange?: (agentId: string | null, agentName: string | null) => void;
   onDraftCancel?: () => void;
+  onCancelQueuedMessage?: (queuedMessageId: string) => void;
+  onCancelReminder?: (reminderId: string) => void;
+  isCancelQueuedMessagesPending?: boolean;
+  cancellingReminderIds?: ReadonlySet<string>;
   className?: string;
 }
 
@@ -114,6 +118,10 @@ export default function ThreadsScreen({
   draftFetchOptions,
   onDraftRecipientChange,
   onDraftCancel,
+  onCancelQueuedMessage,
+  onCancelReminder,
+  isCancelQueuedMessagesPending,
+  cancellingReminderIds,
   className = '',
   conversationScrollRef,
   onConversationScroll,
@@ -569,6 +577,10 @@ export default function ThreadsScreen({
             collapsed={isRunsInfoCollapsed}
             scrollRef={conversationScrollRef}
             onScroll={onConversationScroll}
+            onCancelQueuedMessage={onCancelQueuedMessage}
+            onCancelReminder={onCancelReminder}
+            isCancelQueuedMessagesPending={isCancelQueuedMessagesPending}
+            cancellingReminderIds={cancellingReminderIds}
           />
         </div>
 

--- a/packages/platform-ui/src/features/reminders/api.ts
+++ b/packages/platform-ui/src/features/reminders/api.ts
@@ -108,3 +108,10 @@ export async function listReminders(
 
   throw new Error('Unexpected reminders response shape');
 }
+
+export function cancelReminder(reminderId: string) {
+  return http.post<{ threadId: string; cancelledDb: boolean; clearedRuntime: number }>(
+    `/api/agents/reminders/${encodeURIComponent(reminderId)}/cancel`,
+    {},
+  );
+}

--- a/packages/platform-ui/src/pages/AgentsThreads.tsx
+++ b/packages/platform-ui/src/pages/AgentsThreads.tsx
@@ -1598,6 +1598,10 @@ export function AgentsThreads() {
   const handleCancelQueuedMessage = useCallback(
     (queuedMessageId: string) => {
       if (!selectedThreadId || isDraftSelected) return;
+      const confirmCancel = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm('Cancel this queued message?')
+        : true;
+      if (!confirmCancel) return;
       cancelQueuedMessagesMutation.mutate({ threadId: selectedThreadId, queuedMessageId });
     },
     [selectedThreadId, isDraftSelected, cancelQueuedMessagesMutation],
@@ -1606,6 +1610,10 @@ export function AgentsThreads() {
   const handleCancelReminder = useCallback(
     (reminderId: string) => {
       if (!selectedThreadId || isDraftSelected) return;
+      const confirmCancel = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm('Cancel this reminder?')
+        : true;
+      if (!confirmCancel) return;
       cancelReminderMutation.mutate({ threadId: selectedThreadId, reminderId });
     },
     [selectedThreadId, isDraftSelected, cancelReminderMutation],

--- a/packages/platform-ui/src/pages/AgentsThreads.tsx
+++ b/packages/platform-ui/src/pages/AgentsThreads.tsx
@@ -1598,10 +1598,6 @@ export function AgentsThreads() {
   const handleCancelQueuedMessage = useCallback(
     (queuedMessageId: string) => {
       if (!selectedThreadId || isDraftSelected) return;
-      const confirmCancel = typeof window !== 'undefined' && typeof window.confirm === 'function'
-        ? window.confirm('Cancel this queued message?')
-        : true;
-      if (!confirmCancel) return;
       cancelQueuedMessagesMutation.mutate({ threadId: selectedThreadId, queuedMessageId });
     },
     [selectedThreadId, isDraftSelected, cancelQueuedMessagesMutation],
@@ -1610,10 +1606,6 @@ export function AgentsThreads() {
   const handleCancelReminder = useCallback(
     (reminderId: string) => {
       if (!selectedThreadId || isDraftSelected) return;
-      const confirmCancel = typeof window !== 'undefined' && typeof window.confirm === 'function'
-        ? window.confirm('Cancel this reminder?')
-        : true;
-      if (!confirmCancel) return;
       cancelReminderMutation.mutate({ threadId: selectedThreadId, reminderId });
     },
     [selectedThreadId, isDraftSelected, cancelReminderMutation],

--- a/packages/platform-ui/src/pages/__tests__/AgentsThreads.test.tsx
+++ b/packages/platform-ui/src/pages/__tests__/AgentsThreads.test.tsx
@@ -525,11 +525,16 @@ describe('AgentsThreads page', () => {
 
     renderAt(`/agents/threads/${thread.id}`);
 
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
     const cancelButton = await screen.findByRole('button', { name: 'Cancel queued message' });
     await user.click(cancelButton);
 
     await waitFor(() => expect(deleteCalls.length).toBeGreaterThan(0));
     await waitFor(() => expect(screen.queryByText('Queued message waiting')).not.toBeInTheDocument());
+
+    expect(confirmSpy).toHaveBeenCalledWith('Cancel this queued message?');
+    confirmSpy.mockRestore();
   });
 
   it('cancels a reminder from the conversation list', async () => {
@@ -559,11 +564,94 @@ describe('AgentsThreads page', () => {
 
     renderAt(`/agents/threads/${thread.id}`);
 
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
     const cancelButton = await screen.findByRole('button', { name: 'Cancel reminder' });
     await user.click(cancelButton);
 
     await waitFor(() => expect(cancelCalls.length).toBeGreaterThan(0));
     await waitFor(() => expect(screen.queryByText('Cancel this reminder')).not.toBeInTheDocument());
+
+    expect(confirmSpy).toHaveBeenCalledWith('Cancel this reminder?');
+    confirmSpy.mockRestore();
+  });
+
+  it('does not clear queued messages when confirmation is declined', async () => {
+    const user = userEvent.setup();
+    const threadId = '55555555-5555-4555-8555-555555555555';
+    const queuedMessage = { id: 'msg-queued-2', text: 'Do not cancel me' };
+    const thread = makeThread({ id: threadId });
+    registerThreadScenario({ thread, runs: [], queuedMessages: [queuedMessage] });
+    registerGraphAgents([]);
+
+    const deleteCalls: Array<Record<string, string>> = [];
+    server.use(
+      http.get('*/api/agents/threads/:threadId/queued-messages', ({ params }) => {
+        if (params.threadId === threadId) return HttpResponse.json({ items: [queuedMessage] });
+        return HttpResponse.json({ items: [] });
+      }),
+      http.get(abs('/api/agents/threads/:threadId/queued-messages'), ({ params }) => {
+        if (params.threadId === threadId) return HttpResponse.json({ items: [queuedMessage] });
+        return HttpResponse.json({ items: [] });
+      }),
+      http.delete('*/api/agents/threads/:threadId/queued-messages', ({ params }) => {
+        deleteCalls.push(params as Record<string, string>);
+        return HttpResponse.json({ clearedCount: 1 });
+      }),
+      http.delete(abs('/api/agents/threads/:threadId/queued-messages'), ({ params }) => {
+        deleteCalls.push(params as Record<string, string>);
+        return HttpResponse.json({ clearedCount: 1 });
+      }),
+    );
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    renderAt(`/agents/threads/${thread.id}`);
+
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel queued message' });
+    await user.click(cancelButton);
+
+    expect(confirmSpy).toHaveBeenCalledWith('Cancel this queued message?');
+    expect(deleteCalls).toHaveLength(0);
+    expect(await screen.findByText('Do not cancel me')).toBeInTheDocument();
+
+    confirmSpy.mockRestore();
+  });
+
+  it('does not cancel reminders when confirmation is declined', async () => {
+    const user = userEvent.setup();
+    const threadId = '66666666-6666-4666-8666-666666666666';
+    const reminder = makeReminder({ id: 'rem-cancel-2', threadId, note: 'Keep this reminder' });
+    const thread = makeThread({ id: threadId });
+    registerThreadScenario({ thread, runs: [], reminders: [reminder] });
+    registerGraphAgents([]);
+
+    const cancelCalls: Array<Record<string, string>> = [];
+    server.use(
+      http.get('*/api/agents/reminders', () => HttpResponse.json({ items: [reminder] })),
+      http.get(abs('/api/agents/reminders'), () => HttpResponse.json({ items: [reminder] })),
+      http.post('*/api/agents/reminders/:reminderId/cancel', ({ params }) => {
+        cancelCalls.push(params as Record<string, string>);
+        return HttpResponse.json({ threadId, cancelledDb: 1, clearedRuntime: 0 });
+      }),
+      http.post(abs('/api/agents/reminders/:reminderId/cancel'), ({ params }) => {
+        cancelCalls.push(params as Record<string, string>);
+        return HttpResponse.json({ threadId, cancelledDb: 1, clearedRuntime: 0 });
+      }),
+    );
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    renderAt(`/agents/threads/${thread.id}`);
+
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel reminder' });
+    await user.click(cancelButton);
+
+    expect(confirmSpy).toHaveBeenCalledWith('Cancel this reminder?');
+    expect(cancelCalls).toHaveLength(0);
+    expect(await screen.findByText('Keep this reminder')).toBeInTheDocument();
+
+    confirmSpy.mockRestore();
   });
 
   it('sends a message and clears the composer input', async () => {


### PR DESCRIPTION
## Summary
- add cancel endpoints for queued messages and reminders
- wire conversation UI with cancel controls and optimistic state
- extend backend/ui tests covering new cancellation flows

## Testing
- pnpm --filter @agyn/platform-server lint
- pnpm --filter @agyn/platform-server test
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test

Fixes #1252