### PR TITLE
feat: show reasoning tokens in LLM event details

### DIFF
--- a/packages/platform-ui/src/components/RunEventDetails.tsx
+++ b/packages/platform-ui/src/components/RunEventDetails.tsx
@@ -770,10 +770,9 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
           requireReasoningContext: true,
           initialHasReasoningContext: candidate.initialReasoning ?? false,
         });
-        if (reasoningTokens === undefined && metrics.tokens !== undefined) {
-          reasoningTokens = metrics.tokens;
-        }
-        if (reasoningTokens !== undefined) {
+        const tokens = metrics.tokens;
+        if (tokens !== undefined && tokens > 0) {
+          reasoningTokens = tokens;
           break;
         }
       }
@@ -835,7 +834,7 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
                 {renderAssistantContent()}
                 {reasoningTokens !== undefined && (
                   <div
-                    className="flex items-center gap-2 text-sm text-[var(--agyn-dark)]"
+                    className="pl-5 flex items-center gap-2 text-sm text-[var(--agyn-dark)]"
                     data-testid="assistant-context-reasoning"
                   >
                     <Brain className="w-3.5 h-3.5 text-[var(--agyn-purple)]" />

--- a/packages/platform-ui/src/components/RunEventDetails.tsx
+++ b/packages/platform-ui/src/components/RunEventDetails.tsx
@@ -1,8 +1,7 @@
-import { Clock, MessageSquare, Bot, Wrench, FileText, Terminal, Users, ChevronDown, ChevronRight, Copy, User, Settings, ExternalLink } from 'lucide-react';
+import { Clock, MessageSquare, Bot, Brain, Wrench, FileText, Terminal, Users, ChevronDown, ChevronRight, Copy, User, Settings, ExternalLink } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { useToolOutputStreaming } from '@/hooks/useToolOutputStreaming';
-import { Badge } from './Badge';
 import { IconButton } from './IconButton';
 import { JsonViewer } from './JsonViewer';
 import { MarkdownContent } from './MarkdownContent';
@@ -731,29 +730,16 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
       ];
 
       let reasoningTokens: number | undefined;
-      let reasoningScore: number | undefined;
       for (const candidate of reasoningCandidates) {
         if (candidate === undefined) continue;
         const metrics = extractReasoningMetrics(candidate);
         if (reasoningTokens === undefined && metrics.tokens !== undefined) {
           reasoningTokens = metrics.tokens;
         }
-        if (reasoningScore === undefined && metrics.score !== undefined) {
-          reasoningScore = metrics.score;
-        }
-        if (reasoningTokens !== undefined && reasoningScore !== undefined) {
+        if (reasoningTokens !== undefined) {
           break;
         }
       }
-
-      const getReasoningVariant = () => {
-        if (reasoningTokens !== undefined) {
-          if (reasoningTokens < 50) return 'secondary';
-          if (reasoningTokens < 150) return 'default';
-          return 'error';
-        }
-        return 'neutral';
-      };
       const toolCallsRaw = message.tool_calls || message.toolCalls || additionalKwargs?.tool_calls;
       const toolCalls = Array.isArray(toolCallsRaw) ? toolCallsRaw.filter(isRecord) : [];
       const hasToolCalls = toolCalls.length > 0;
@@ -793,17 +779,6 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
                 />
               </div>
             )}
-            {(reasoningTokens !== undefined || reasoningScore !== undefined) && (
-              <Badge variant={getReasoningVariant()} className="ml-auto">
-                <span className="text-xs">
-                  {reasoningTokens !== undefined ? (
-                    <span>{reasoningTokens.toLocaleString()} tokens</span>
-                  ) : (
-                    <span>Score: {reasoningScore}</span>
-                  )}
-                </span>
-              </Badge>
-            )}
           </div>
           <div className="ml-5 space-y-3">
             {(role === 'system' || role === 'user') && (
@@ -821,6 +796,17 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
             {role === 'assistant' && (
               <div className="space-y-3">
                 {renderAssistantContent()}
+                {reasoningTokens !== undefined && (
+                  <div
+                    className="flex items-center gap-2 text-sm text-[var(--agyn-dark)]"
+                    data-testid="assistant-context-reasoning"
+                  >
+                    <Brain className="w-3.5 h-3.5 text-[var(--agyn-purple)]" />
+                    <span className="font-medium">
+                      Reasoning tokens: {reasoningTokens.toLocaleString()}
+                    </span>
+                  </div>
+                )}
                 {hasToolCalls &&
                   renderFunctionCalls(toolCalls, expandedToolCalls, toggleToolCall, `context-${index}`)}
               </div>

--- a/packages/platform-ui/src/components/RunEventDetails.tsx
+++ b/packages/platform-ui/src/components/RunEventDetails.tsx
@@ -361,6 +361,7 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
     const assistantContext = asRecordArray(event.data.assistantContext);
     const response = asString(event.data.response);
     const totalTokens = asNumber(event.data.tokens?.total);
+    const reasoningTokens = asNumber(event.data.tokens?.reasoning);
     const cost = typeof event.data.cost === 'string' ? event.data.cost : '';
     const model = asString(event.data.model);
     const toolCalls = Array.isArray(event.data.toolCalls)
@@ -478,6 +479,17 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
                 <div className="text-sm text-[var(--agyn-gray)]">No response available</div>
               )}
             </div>
+            {reasoningTokens !== undefined && (
+              <div className="mt-4">
+                <h3 className="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">Reasoning</h3>
+                <div className="border border-[var(--agyn-border-subtle)] rounded-[10px] p-4 bg-[var(--agyn-bg-light)]">
+                  <div className="flex items-center justify-between text-sm text-[var(--agyn-dark)]">
+                    <span>Tokens</span>
+                    <span className="font-medium">{reasoningTokens.toLocaleString()}</span>
+                  </div>
+                </div>
+              </div>
+            )}
             {toolCalls.length > 0 && (
               <div className="mt-4">
                 <h3 className="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">Invoked tools</h3>

--- a/packages/platform-ui/src/components/RunEventDetails.tsx
+++ b/packages/platform-ui/src/components/RunEventDetails.tsx
@@ -696,6 +696,22 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
       const timestamp = formatTimestamp(message.timestamp);
       const additionalKwargs = isRecord(message.additional_kwargs) ? message.additional_kwargs : undefined;
       const tokensRecord = isRecord(message.tokens) ? message.tokens : undefined;
+      const contentJson = isRecord(message.contentJson) ? message.contentJson : undefined;
+      const metadataRecord = isRecord(message.metadata) ? message.metadata : undefined;
+      const usageRecord = isRecord(message.usage) ? message.usage : undefined;
+      const additionalUsage = isRecord(additionalKwargs?.usage) ? (additionalKwargs?.usage as Record<string, unknown>) : undefined;
+      const contentUsage = isRecord(contentJson?.usage) ? (contentJson.usage as Record<string, unknown>) : undefined;
+      const metadataUsage = isRecord(metadataRecord?.usage) ? (metadataRecord.usage as Record<string, unknown>) : undefined;
+      const usageDetailsCandidates: unknown[] = [
+        contentUsage?.['output_tokens_details'],
+        contentUsage?.['outputTokensDetails'],
+        usageRecord?.['output_tokens_details'],
+        usageRecord?.['outputTokensDetails'],
+        metadataUsage?.['output_tokens_details'],
+        metadataUsage?.['outputTokensDetails'],
+        additionalUsage?.['output_tokens_details'],
+        additionalUsage?.['outputTokensDetails'],
+      ];
 
       const reasoningCandidates: unknown[] = [
         message.reasoning,
@@ -703,6 +719,15 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
         tokensRecord?.reasoning,
         tokensRecord?.reasoningTokens,
         message.reasoningTokens,
+        ...usageDetailsCandidates,
+        usageRecord,
+        additionalUsage,
+        contentUsage,
+        metadataUsage,
+        contentJson?.reasoning,
+        metadataRecord?.reasoning,
+        contentJson,
+        metadataRecord,
       ];
 
       let reasoningTokens: number | undefined;

--- a/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
@@ -153,6 +153,8 @@ describe('RunEventDetails – LLM outputs', () => {
     const reasoningRow = within(panel).getByTestId('assistant-context-reasoning');
     expect(reasoningRow).toHaveTextContent('Reasoning tokens: 64');
 
+    expect(reasoningRow).toHaveClass('pl-5');
+
     const toolCallButton = within(panel).getByRole('button', { name: /summarize/i });
     const relation = reasoningRow.compareDocumentPosition(toolCallButton);
     expect(relation & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
@@ -174,6 +176,37 @@ describe('RunEventDetails – LLM outputs', () => {
               output_tokens: 120,
               total_tokens: 200,
             },
+          },
+        ],
+        response: 'Latest assistant response',
+        model: 'gpt-4o',
+      },
+    };
+
+    render(
+      <MemoryRouter>
+        <RunEventDetails event={event} />
+      </MemoryRouter>,
+    );
+
+    const panel = screen.getByTestId('assistant-context-panel');
+    expect(within(panel).queryByTestId('assistant-context-reasoning')).not.toBeInTheDocument();
+    expect(within(panel).queryByText(/Reasoning tokens:/)).not.toBeInTheDocument();
+  });
+
+  it('omits reasoning tokens row when reasoning tokens are zero', () => {
+    const event: RunEvent = {
+      id: 'evt-llm-context-zero-reasoning',
+      type: 'llm',
+      timestamp: '2024-01-01T00:01:20.000Z',
+      data: {
+        context: [],
+        assistantContext: [
+          {
+            id: 'ctx-assistant-zero-reasoning',
+            role: 'assistant',
+            content: 'Assistant output zero reasoning',
+            reasoning: { tokens: 0 },
           },
         ],
         response: 'Latest assistant response',

--- a/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
@@ -23,6 +23,7 @@ describe('RunEventDetails – LLM outputs', () => {
             id: 'ctx-output',
             role: 'assistant',
             content: 'Persisted assistant output',
+            reasoning: 40,
           },
         ],
         response: 'Latest assistant response',
@@ -39,6 +40,7 @@ describe('RunEventDetails – LLM outputs', () => {
     expect(screen.getByText('Assistant responses for this call')).toBeInTheDocument();
     const assistantPanel = screen.getByTestId('assistant-context-panel');
     expect(within(assistantPanel).getByText('Persisted assistant output')).toBeInTheDocument();
+    expect(within(assistantPanel).getByText('40 tokens')).toBeInTheDocument();
     expect(screen.getByText('No new context for this call.')).toBeInTheDocument();
 
     const loadMoreButton = screen.getByRole('button', { name: 'Load more' });
@@ -81,7 +83,7 @@ describe('RunEventDetails – LLM outputs', () => {
     expect(screen.getByText(/"echo 1"/)).toBeInTheDocument();
   });
 
-  it('renders a reasoning block when reasoning tokens are provided', () => {
+  it('renders a reasoning block above the output when reasoning tokens are provided', () => {
     const event: RunEvent = {
       id: 'evt-llm-reasoning',
       type: 'llm',
@@ -101,12 +103,11 @@ describe('RunEventDetails – LLM outputs', () => {
       </MemoryRouter>,
     );
 
-    const reasoningHeading = screen.getByText('Reasoning');
-    expect(reasoningHeading).toBeInTheDocument();
-    const reasoningSection = reasoningHeading.closest('div');
-    expect(reasoningSection).not.toBeNull();
-    const withinContainer = within(reasoningSection as HTMLElement);
-    expect(withinContainer.getByText('Tokens')).toBeInTheDocument();
-    expect(withinContainer.getByText('250')).toBeInTheDocument();
+    const reasoningLabel = screen.getByText('Reasoning');
+    const outputLabel = screen.getByText('Output');
+    expect(reasoningLabel).toBeInTheDocument();
+    expect(reasoningLabel.tagName).toBe('SPAN');
+    expect(reasoningLabel.compareDocumentPosition(outputLabel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText('250 tokens')).toBeInTheDocument();
   });
 });

--- a/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
@@ -158,6 +158,40 @@ describe('RunEventDetails – LLM outputs', () => {
     expect(relation & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it('omits reasoning tokens row when only generic usage totals exist', () => {
+    const event: RunEvent = {
+      id: 'evt-llm-context-no-reasoning',
+      type: 'llm',
+      timestamp: '2024-01-01T00:01:10.000Z',
+      data: {
+        context: [],
+        assistantContext: [
+          {
+            id: 'ctx-assistant-no-reasoning',
+            role: 'assistant',
+            content: 'Assistant output without reasoning',
+            usage: {
+              output_tokens: 120,
+              total_tokens: 200,
+            },
+          },
+        ],
+        response: 'Latest assistant response',
+        model: 'gpt-4o',
+      },
+    };
+
+    render(
+      <MemoryRouter>
+        <RunEventDetails event={event} />
+      </MemoryRouter>,
+    );
+
+    const panel = screen.getByTestId('assistant-context-panel');
+    expect(within(panel).queryByTestId('assistant-context-reasoning')).not.toBeInTheDocument();
+    expect(within(panel).queryByText(/Reasoning tokens:/)).not.toBeInTheDocument();
+  });
+
   it('shows invoked tool calls for llm events using the shared function-call UI', () => {
     const event: RunEvent = {
       id: 'evt-llm-tools',

--- a/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
@@ -80,4 +80,33 @@ describe('RunEventDetails – LLM outputs', () => {
     expect(screen.getByText(/command:/i)).toBeInTheDocument();
     expect(screen.getByText(/"echo 1"/)).toBeInTheDocument();
   });
+
+  it('renders a reasoning block when reasoning tokens are provided', () => {
+    const event: RunEvent = {
+      id: 'evt-llm-reasoning',
+      type: 'llm',
+      timestamp: '2024-01-01T00:02:00.000Z',
+      data: {
+        response: 'Here is my answer.',
+        tokens: {
+          total: 1200,
+          reasoning: 250,
+        },
+      },
+    };
+
+    render(
+      <MemoryRouter>
+        <RunEventDetails event={event} />
+      </MemoryRouter>,
+    );
+
+    const reasoningHeading = screen.getByText('Reasoning');
+    expect(reasoningHeading).toBeInTheDocument();
+    const reasoningSection = reasoningHeading.closest('div');
+    expect(reasoningSection).not.toBeNull();
+    const withinContainer = within(reasoningSection as HTMLElement);
+    expect(withinContainer.getByText('Tokens')).toBeInTheDocument();
+    expect(withinContainer.getByText('250')).toBeInTheDocument();
+  });
 });

--- a/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
@@ -56,6 +56,64 @@ describe('RunEventDetails – LLM outputs', () => {
     });
   });
 
+  it('surfaces reasoning tokens embedded in assistant context usage snapshots', () => {
+    const event: RunEvent = {
+      id: 'evt-llm-context-usage',
+      type: 'llm',
+      timestamp: '2024-01-01T00:00:30.000Z',
+      data: {
+        context: [],
+        assistantContext: [
+          {
+            id: 'ctx-assistant-usage',
+            role: 'assistant',
+            content: 'Assistant reasoning-rich context',
+            contentJson: {
+              output: [
+                {
+                  type: 'reasoning',
+                  summary: [{ type: 'text', text: 'thinking...' }],
+                  reasoning: [],
+                },
+                {
+                  type: 'message',
+                  role: 'assistant',
+                  content: [
+                    {
+                      type: 'output_text',
+                      text: 'Assistant reasoning-rich context',
+                      annotations: [],
+                    },
+                  ],
+                },
+              ],
+              usage: {
+                input_tokens: 144,
+                output_tokens: 120,
+                total_tokens: 264,
+                output_tokens_details: {
+                  reasoning_tokens: 42,
+                },
+              },
+            },
+          },
+        ],
+        response: 'Latest assistant response',
+        model: 'gpt-4o',
+      },
+    };
+
+    render(
+      <MemoryRouter>
+        <RunEventDetails event={event} />
+      </MemoryRouter>,
+    );
+
+    const panel = screen.getByTestId('assistant-context-panel');
+    expect(within(panel).getByText('Assistant reasoning-rich context')).toBeInTheDocument();
+    expect(within(panel).getByText('42 tokens')).toBeInTheDocument();
+  });
+
   it('shows invoked tool calls for llm events using the shared function-call UI', () => {
     const event: RunEvent = {
       id: 'evt-llm-tools',


### PR DESCRIPTION
## Summary
- add reasoning tokens section to the LLM event output panel
- render token count with shared styling and tests

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test -- --reporter=basic
- pnpm --filter @agyn/platform-server lint
- pnpm --filter @agyn/platform-server test

Resolves #1255