### PR TITLE
feat: add workspace runtime provider abstraction

### DIFF
--- a/packages/platform-server/__e2e__/graph.socket.gateway.e2e.test.ts
+++ b/packages/platform-server/__e2e__/graph.socket.gateway.e2e.test.ts
@@ -106,7 +106,7 @@ class WorkspaceProviderStub extends WorkspaceProvider {
       stdin,
       stdout,
       stderr,
-      close: async () => ({ exitCode: 0 }),
+      close: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     };
   }
 
@@ -128,7 +128,7 @@ class WorkspaceProviderStub extends WorkspaceProvider {
       stdout,
       stderr,
       resize: async () => undefined,
-      close: async () => ({ exitCode: 0 }),
+      close: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     };
   }
 

--- a/packages/platform-server/__e2e__/graph.socket.gateway.e2e.test.ts
+++ b/packages/platform-server/__e2e__/graph.socket.gateway.e2e.test.ts
@@ -22,10 +22,16 @@ import {
   type WorkspaceSpec,
   type ExecRequest,
   type ExecResult,
-  type InteractiveExecRequest,
-  type InteractiveExecSession,
   type DestroyWorkspaceOptions,
 } from '../src/workspace/providers/workspace.provider';
+import type {
+  WorkspaceTerminalSession,
+  WorkspaceTerminalSessionRequest,
+  WorkspaceStdioSession,
+  WorkspaceStdioSessionRequest,
+  WorkspaceLogsRequest,
+  WorkspaceLogsSession,
+} from '../src/workspace/runtime/workspace.runtime.provider';
 
 class LiveGraphRuntimeStub {
   subscribe() {
@@ -72,23 +78,42 @@ class WorkspaceProviderStub extends WorkspaceProvider {
       network: true,
       networkAliases: true,
       dockerInDocker: true,
-      interactiveExec: true,
-      execResize: true,
+      stdioSession: true,
+      terminalSession: true,
+      logsSession: true,
     } as const;
   }
 
-  async ensureWorkspace(_key: WorkspaceKey, _spec: WorkspaceSpec): Promise<{ workspaceId: string; created: boolean }> {
-    return { workspaceId: 'stub-workspace', created: false };
+  async ensureWorkspace(_key: WorkspaceKey, _spec: WorkspaceSpec) {
+    return { workspaceId: 'stub-workspace', created: false, providerType: 'docker', status: 'running' as const };
   }
 
   async exec(_workspaceId: string, _request: ExecRequest): Promise<ExecResult> {
     return { stdout: '', stderr: '', exitCode: 0 };
   }
 
-  async openInteractiveExec(
+  async openStdioSession(
     _workspaceId: string,
-    _request: InteractiveExecRequest,
-  ): Promise<InteractiveExecSession> {
+    _request: WorkspaceStdioSessionRequest,
+  ): Promise<WorkspaceStdioSession> {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    setTimeout(() => {
+      stdout.write('ready\n');
+    }, 50);
+    return {
+      stdin,
+      stdout,
+      stderr,
+      close: async () => ({ exitCode: 0 }),
+    };
+  }
+
+  async openTerminalSession(
+    _workspaceId: string,
+    _request: WorkspaceTerminalSessionRequest,
+  ): Promise<WorkspaceTerminalSession> {
     const stdin = new PassThrough();
     const stdout = new PassThrough();
     const stderr = new PassThrough();
@@ -97,16 +122,23 @@ class WorkspaceProviderStub extends WorkspaceProvider {
       stdout.write('ready\n');
     }, 50);
     return {
+      sessionId: execId,
       execId,
       stdin,
       stdout,
       stderr,
+      resize: async () => undefined,
       close: async () => ({ exitCode: 0 }),
     };
   }
 
-  async resize(_execId: string, _size: { cols: number; rows: number }): Promise<void> {
-    return;
+  async openLogsSession(
+    _workspaceId: string,
+    _request: WorkspaceLogsRequest,
+  ): Promise<WorkspaceLogsSession> {
+    const stream = new PassThrough();
+    setImmediate(() => stream.end());
+    return { stream, close: async () => { stream.end(); } };
   }
 
   async destroyWorkspace(_workspaceId: string, _options?: DestroyWorkspaceOptions): Promise<void> {
@@ -114,6 +146,10 @@ class WorkspaceProviderStub extends WorkspaceProvider {
   }
 
   async touchWorkspace(_workspaceId: string): Promise<void> {
+    return;
+  }
+
+  async putArchive(): Promise<void> {
     return;
   }
 }

--- a/packages/platform-server/__tests__/containerStream.util.test.ts
+++ b/packages/platform-server/__tests__/containerStream.util.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { createUtf8Collector } from '../src/infra/container/containerStream.util';
+
+describe('createUtf8Collector', () => {
+  it('caps retained output when limit is provided', () => {
+    const collector = createUtf8Collector(4);
+    collector.append('ab');
+    collector.append('cd');
+    collector.append('ef');
+    collector.flush();
+
+    expect(collector.getText()).toBe('abcd');
+    expect(collector.isTruncated()).toBe(true);
+  });
+
+  it('retains full output when below limit', () => {
+    const collector = createUtf8Collector(10);
+    collector.append('hello');
+    collector.flush();
+
+    expect(collector.getText()).toBe('hello');
+    expect(collector.isTruncated()).toBe(false);
+  });
+});

--- a/packages/platform-server/__tests__/e2e/terminal.gateway.e2e.test.ts
+++ b/packages/platform-server/__tests__/e2e/terminal.gateway.e2e.test.ts
@@ -96,7 +96,7 @@ class TestWorkspaceProvider extends WorkspaceProvider {
     const close = async () => {
       this.closeCalls += 1;
       setImmediate(() => stdout.end());
-      return { exitCode: 0 };
+      return { exitCode: 0, stdout: '', stderr: '' };
     };
 
     const execId = 'exec-test';

--- a/packages/platform-server/__tests__/e2e/terminal.gateway.e2e.test.ts
+++ b/packages/platform-server/__tests__/e2e/terminal.gateway.e2e.test.ts
@@ -14,10 +14,16 @@ import {
   type WorkspaceSpec,
   type ExecRequest,
   type ExecResult,
-  type InteractiveExecRequest,
-  type InteractiveExecSession,
   type DestroyWorkspaceOptions,
 } from '../../src/workspace/providers/workspace.provider';
+import type {
+  WorkspaceTerminalSession,
+  WorkspaceTerminalSessionRequest,
+  WorkspaceStdioSession,
+  WorkspaceStdioSessionRequest,
+  WorkspaceLogsRequest,
+  WorkspaceLogsSession,
+} from '../../src/workspace/runtime/workspace.runtime.provider';
 import { waitFor, waitForWsClose } from '../helpers/ws';
 
 type TerminalMessage = {
@@ -40,20 +46,28 @@ class TestWorkspaceProvider extends WorkspaceProvider {
       network: true,
       networkAliases: true,
       dockerInDocker: true,
-      interactiveExec: true,
-      execResize: true,
+      stdioSession: false,
+      terminalSession: true,
+      logsSession: false,
     } as const;
   }
 
-  async ensureWorkspace(_key: WorkspaceKey, _spec: WorkspaceSpec): Promise<{ workspaceId: string; created: boolean }> {
-    return { workspaceId: 'test-workspace', created: true };
+  async ensureWorkspace(_key: WorkspaceKey, _spec: WorkspaceSpec) {
+    return { workspaceId: 'test-workspace', created: true, providerType: 'docker', status: 'running' as const };
   }
 
   async exec(_workspaceId: string, _request: ExecRequest): Promise<ExecResult> {
     return { stdout: '/bin/bash\n', stderr: '', exitCode: 0 };
   }
 
-  async openInteractiveExec(_workspaceId: string, _request: InteractiveExecRequest): Promise<InteractiveExecSession> {
+  async openStdioSession(): Promise<WorkspaceStdioSession> {
+    throw new Error('stdio sessions not supported in TestWorkspaceProvider');
+  }
+
+  async openTerminalSession(
+    _workspaceId: string,
+    _request: WorkspaceTerminalSessionRequest,
+  ): Promise<WorkspaceTerminalSession> {
     const stdin = new PassThrough();
     const stdout = new PassThrough();
     this.stdin = stdin;
@@ -85,11 +99,20 @@ class TestWorkspaceProvider extends WorkspaceProvider {
       return { exitCode: 0 };
     };
 
-    return { stdin, stdout, stderr: undefined, close, execId: 'exec-test' };
+    const execId = 'exec-test';
+    const sessionId = execId;
+    const resize = async (size: { cols: number; rows: number }) => {
+      this.resizes.push({ execId, ...size });
+    };
+
+    return { stdin, stdout, stderr: undefined, close, execId, sessionId, resize };
   }
 
-  async resize(execId: string, size: { cols: number; rows: number }) {
-    this.resizes.push({ execId, ...size });
+  async openLogsSession(
+    _workspaceId: string,
+    _request: WorkspaceLogsRequest,
+  ): Promise<WorkspaceLogsSession> {
+    throw new Error('log sessions not supported in TestWorkspaceProvider');
   }
 
   async destroyWorkspace(_workspaceId: string, _options?: DestroyWorkspaceOptions): Promise<void> {
@@ -97,6 +120,10 @@ class TestWorkspaceProvider extends WorkspaceProvider {
   }
 
   async touchWorkspace(): Promise<void> {
+    return;
+  }
+
+  async putArchive(): Promise<void> {
     return;
   }
 }

--- a/packages/platform-server/__tests__/graph.mcp.integration.test.ts
+++ b/packages/platform-server/__tests__/graph.mcp.integration.test.ts
@@ -109,7 +109,7 @@ class StubWorkspaceProvider extends WorkspaceProvider {
     const stdin = new PassThrough();
     const stdout = new PassThrough();
     setImmediate(() => stdout.end());
-    return { stdin, stdout, stderr: undefined, close: async () => ({ exitCode: 0 }) };
+    return { stdin, stdout, stderr: undefined, close: async () => ({ exitCode: 0, stdout: '', stderr: '' }) };
   }
 
   async openTerminalSession(
@@ -127,7 +127,7 @@ class StubWorkspaceProvider extends WorkspaceProvider {
       stdout,
       stderr: undefined,
       resize: async () => undefined,
-      close: async () => ({ exitCode: 0 }),
+      close: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     };
   }
 

--- a/packages/platform-server/__tests__/localMcpServer.heartbeat.test.ts
+++ b/packages/platform-server/__tests__/localMcpServer.heartbeat.test.ts
@@ -3,6 +3,7 @@ import { LocalMCPServerNode } from '../src/nodes/mcp/localMcpServer.node';
 import { PassThrough } from 'node:stream';
 import { createModuleRefStub } from './helpers/module-ref.stub';
 import { WorkspaceProviderStub, WorkspaceNodeStub } from './helpers/workspace-provider.stub';
+import type { WorkspaceStdioSessionRequest } from '../src/workspace/runtime/workspace.runtime.provider';
 
 function createBlockingMcpMock() {
   const tools = [
@@ -67,7 +68,7 @@ function createBlockingMcpMock() {
 class BlockingWorkspaceProvider extends WorkspaceProviderStub {
   public readonly mock = createBlockingMcpMock();
 
-  override async openInteractiveExec(_workspaceId: string, _request: any) {
+  override async openStdioSession(_workspaceId: string, _request: WorkspaceStdioSessionRequest) {
     const { stream } = this.mock.createFreshStreamPair();
     const stdin = new PassThrough();
     const stdout = new PassThrough();
@@ -78,7 +79,12 @@ class BlockingWorkspaceProvider extends WorkspaceProviderStub {
       stream.end();
     });
     stream.pipe(stdout);
-    return { execId: 'blocking', stdin, stdout, close: async () => ({ exitCode: 0 }) };
+    return {
+      stdin,
+      stdout,
+      stderr: new PassThrough(),
+      close: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    };
   }
 }
 

--- a/packages/platform-server/__tests__/localMcpServer.test.ts
+++ b/packages/platform-server/__tests__/localMcpServer.test.ts
@@ -106,12 +106,12 @@ function createInProcessMock() {
     });
 
     const close = async () => {
-      if (closed) return { exitCode: 0 };
+      if (closed) return { exitCode: 0, stdout: '', stderr: '' };
       closed = true;
       stdin.end();
       stdout.end();
       stderr.end();
-      return { exitCode: 0 };
+      return { exitCode: 0, stdout: '', stderr: '' };
     };
 
     return { stdin, stdout, stderr, close };

--- a/packages/platform-server/__tests__/terminal.gateway.test.ts
+++ b/packages/platform-server/__tests__/terminal.gateway.test.ts
@@ -148,7 +148,7 @@ describe('ContainerTerminalGateway (custom websocket server)', () => {
       stdinBuffer += chunk.toString();
     });
     const stdout = new PassThrough();
-    const closeExec = vi.fn().mockResolvedValue({ exitCode: 0 });
+    const closeExec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
 
     const providerMocks = {
       openInteractiveExec: vi.fn().mockResolvedValue({
@@ -255,7 +255,7 @@ describe('ContainerTerminalGateway (custom websocket server)', () => {
       openInteractiveExec: vi.fn().mockImplementation(() => {
         const stdin = new PassThrough();
         const stdout = new PassThrough();
-        const closeExec = vi.fn().mockResolvedValue({ exitCode: 0 });
+        const closeExec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
         return {
           stdin,
           stdout,
@@ -342,7 +342,7 @@ describe('ContainerTerminalGateway (custom websocket server)', () => {
 
     const stdin = new PassThrough();
     const stdout = new PassThrough();
-    const closeExec = vi.fn().mockResolvedValue({ exitCode: 0 });
+    const closeExec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
     const providerMocks = {
       openInteractiveExec: vi.fn().mockResolvedValue({
         stdin,
@@ -440,7 +440,7 @@ describe('ContainerTerminalGateway (custom websocket server)', () => {
 
       const stdin = new PassThrough();
       const stdout = new PassThrough();
-      const closeExec = vi.fn().mockResolvedValue({ exitCode: 0 });
+      const closeExec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
 
       const providerMocks = {
         openInteractiveExec: vi.fn().mockResolvedValue({

--- a/packages/platform-server/__tests__/terminal.gateway.test.ts
+++ b/packages/platform-server/__tests__/terminal.gateway.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ContainerTerminalGateway } from '../src/infra/container/terminal.gateway';
 import type { TerminalSessionsService, TerminalSessionRecord } from '../src/infra/container/terminal.sessions.service';
-import type { WorkspaceProvider } from '../src/workspace/providers/workspace.provider';
+import { WorkspaceProvider } from '../src/workspace/providers/workspace.provider';
 import { waitFor, waitForWsClose } from './helpers/ws';
 
 const createSessionRecord = (overrides: Partial<TerminalSessionRecord> = {}): TerminalSessionRecord => {

--- a/packages/platform-server/__tests__/terminal.sessions.service.test.ts
+++ b/packages/platform-server/__tests__/terminal.sessions.service.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TerminalSessionsService } from '../src/infra/container/terminal.sessions.service';
-import type { WorkspaceProvider } from '../src/workspace/providers/workspace.provider';
+import { WorkspaceProvider } from '../src/workspace/providers/workspace.provider';
 
 describe('TerminalSessionsService', () => {
   let provider: Pick<WorkspaceProvider, 'exec'>;

--- a/packages/platform-server/src/infra/container/terminal.gateway.ts
+++ b/packages/platform-server/src/infra/container/terminal.gateway.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { TerminalSessionsService, type TerminalSessionRecord } from './terminal.sessions.service';
 import { WorkspaceProvider } from '../../workspace/providers/workspace.provider';
 import { WorkspaceHandle } from '../../workspace/workspace.handle';
+import type { WorkspaceExecResult } from '../../workspace/runtime/workspace.runtime.provider';
 
 const QuerySchema = z
   .object({ sessionId: z.string().uuid(), token: z.string().min(1) })
@@ -246,7 +247,7 @@ export class ContainerTerminalGateway {
     let stdin: NodeJS.WritableStream | null = null;
     let stdout: NodeJS.ReadableStream | null = null;
     let stderr: NodeJS.ReadableStream | null = null;
-    let closeExec: (() => Promise<{ exitCode: number }>) | null = null;
+    let closeExec: (() => Promise<WorkspaceExecResult>) | null = null;
     let closed = false;
     let onMessage: ((raw: RawDataLike) => void) | null = null;
     let onClose: (() => void) | null = null;

--- a/packages/platform-server/src/infra/infra.module.ts
+++ b/packages/platform-server/src/infra/infra.module.ts
@@ -21,7 +21,7 @@ import { ContainerTerminalController } from './container/containerTerminal.contr
 import { ContainerEventProcessor } from './container/containerEvent.processor';
 import { DockerWorkspaceEventsWatcher } from './container/containerEvent.watcher';
 import { WorkspaceProvider } from '../workspace/providers/workspace.provider';
-import { DockerWorkspaceProvider } from '../workspace/providers/docker.workspace.provider';
+import { DockerWorkspaceRuntimeProvider } from '../workspace/providers/docker.workspace.provider';
 
 @Module({
   imports: [CoreModule, VaultModule],
@@ -65,7 +65,7 @@ import { DockerWorkspaceProvider } from '../workspace/providers/docker.workspace
     },
     {
       provide: WorkspaceProvider,
-      useFactory: (containerService: ContainerService) => new DockerWorkspaceProvider(containerService),
+      useFactory: (containerService: ContainerService) => new DockerWorkspaceRuntimeProvider(containerService),
       inject: [ContainerService],
     },
     TerminalSessionsService,

--- a/packages/platform-server/src/nodes/mcp/localMcpServer.node.ts
+++ b/packages/platform-server/src/nodes/mcp/localMcpServer.node.ts
@@ -219,7 +219,7 @@ export class LocalMCPServerNode extends Node<z.infer<typeof LocalMcpServerStatic
     try {
       // Create temporary transport and client for discovery
       tempTransport = new WorkspaceExecTransport(async () =>
-        tempWorkspace.openInteractiveExec(['sh', '-lc', cmdToRun], {
+        tempWorkspace.openStdioSession(['sh', '-lc', cmdToRun], {
           tty: false,
           env: envArr,
           workdir,
@@ -388,7 +388,7 @@ export class LocalMCPServerNode extends Node<z.infer<typeof LocalMcpServerStatic
     try {
       // Create transport and client for this tool call
       transport = new WorkspaceExecTransport(async () =>
-        container.openInteractiveExec(['sh', '-lc', cmdToRun], {
+        container.openStdioSession(['sh', '-lc', cmdToRun], {
           tty: false,
           env: envArr,
           workdir,

--- a/packages/platform-server/src/nodes/mcp/workspaceExecTransport.ts
+++ b/packages/platform-server/src/nodes/mcp/workspaceExecTransport.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { PassThrough } from 'node:stream';
 
-import type { InteractiveExecSession } from '../../workspace/providers/workspace.provider';
+import type { WorkspaceStdioSession } from '../../workspace/runtime/workspace.runtime.provider';
 import type { JSONRPCMessage } from './types';
 
 class ReadBufferInline {
@@ -38,7 +38,7 @@ export class WorkspaceExecTransport {
 
   private readonly logger = new Logger(WorkspaceExecTransport.name);
   private readonly readBuffer = new ReadBufferInline();
-  private session: InteractiveExecSession | null = null;
+  private session: WorkspaceStdioSession | null = null;
   private stdin?: NodeJS.WritableStream;
   private stdout = new PassThrough();
   private stderr = new PassThrough();
@@ -47,7 +47,7 @@ export class WorkspaceExecTransport {
   private readonly id = ++WorkspaceExecTransport.seq;
   private started = false;
 
-  constructor(private startSession: () => Promise<InteractiveExecSession>) {}
+  constructor(private startSession: () => Promise<WorkspaceStdioSession>) {}
 
   async start(): Promise<void> {
     if (this.started) {

--- a/packages/platform-server/src/workspace/providers/workspace.provider.ts
+++ b/packages/platform-server/src/workspace/providers/workspace.provider.ts
@@ -1,98 +1,38 @@
-import type { Platform } from '../../core/constants';
+import {
+  WorkspaceRuntimeProvider,
+  type DestroyWorkspaceOptions as RuntimeDestroyWorkspaceOptions,
+  type WorkspaceExecRequest,
+  type WorkspaceExecResult,
+  type WorkspaceKey,
+  type WorkspaceLogsRequest,
+  type WorkspaceLogsSession,
+  type WorkspaceRuntimeCapabilities,
+  type WorkspaceRuntimeProviderType,
+  type WorkspaceSpec,
+  type WorkspaceStatus,
+  type WorkspaceStdioSession,
+  type WorkspaceStdioSessionRequest,
+  type WorkspaceTerminalSession,
+  type WorkspaceTerminalSessionRequest,
+} from '../runtime/workspace.runtime.provider';
 
-export type WorkspaceKey = {
-  threadId: string;
-  role: 'workspace';
-  platform?: Platform;
-  nodeId?: string;
+export type WorkspaceProviderCapabilities = WorkspaceRuntimeCapabilities;
+export type ExecRequest = WorkspaceExecRequest;
+export type ExecResult = WorkspaceExecResult;
+export type InteractiveExecRequest = WorkspaceStdioSessionRequest & { tty?: boolean };
+export type InteractiveExecSession = WorkspaceStdioSession & { execId: string };
+export type DestroyWorkspaceOptions = RuntimeDestroyWorkspaceOptions;
+
+export type WorkspaceLogsRequestCompat = WorkspaceLogsRequest;
+export type WorkspaceLogsSessionCompat = WorkspaceLogsSession;
+export type WorkspaceTerminalSessionCompat = WorkspaceTerminalSession;
+export type WorkspaceTerminalSessionRequestCompat = WorkspaceTerminalSessionRequest;
+
+export abstract class WorkspaceProvider extends WorkspaceRuntimeProvider {}
+
+export {
+  WorkspaceKey,
+  WorkspaceSpec,
+  WorkspaceStatus,
+  WorkspaceRuntimeProviderType as WorkspaceProviderType,
 };
-
-export type WorkspaceStatus = 'starting' | 'running' | 'stopped' | 'deleted' | 'error';
-
-export type WorkspaceSpec = {
-  image?: string;
-  workingDir?: string;
-  env?: Record<string, string>;
-  persistentVolume?: {
-    mountPath: string;
-  };
-  network?: {
-    name: string;
-    aliases?: string[];
-  };
-  dockerInDocker?: {
-    enabled: boolean;
-    mirrorUrl?: string;
-  };
-  resources?: {
-    cpuNano?: number;
-    memoryBytes?: number;
-  };
-  ttlSeconds?: number;
-};
-
-export type WorkspaceProviderCapabilities = {
-  persistentVolume: boolean;
-  network: boolean;
-  networkAliases: boolean;
-  dockerInDocker: boolean;
-  interactiveExec: boolean;
-  execResize: boolean;
-};
-
-export type ExecRequest = {
-  command: string | string[];
-  workdir?: string;
-  env?: Record<string, string> | string[];
-  timeoutMs?: number;
-  idleTimeoutMs?: number;
-  killOnTimeout?: boolean;
-  tty?: boolean;
-  signal?: AbortSignal;
-  onOutput?: (source: 'stdout' | 'stderr', chunk: Buffer) => void;
-  logToPid1?: boolean;
-};
-
-export type ExecResult = {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-};
-
-export type InteractiveExecRequest = {
-  command: string | string[];
-  workdir?: string;
-  env?: Record<string, string> | string[];
-  tty?: boolean;
-  demuxStderr?: boolean;
-};
-
-export type InteractiveExecSession = {
-  execId: string;
-  stdin: NodeJS.WritableStream;
-  stdout: NodeJS.ReadableStream;
-  stderr?: NodeJS.ReadableStream;
-  close: () => Promise<{ exitCode: number }>;
-};
-
-export type DestroyWorkspaceOptions = {
-  force?: boolean;
-  removePersistentVolume?: boolean;
-};
-
-/**
- * Base abstraction for workspace providers.
- * Acts as the Nest injection token so alternative implementations or routers
- * can extend this class without changing consumers.
- */
-export abstract class WorkspaceProvider {
-  abstract capabilities(): WorkspaceProviderCapabilities;
-  abstract ensureWorkspace(key: WorkspaceKey, spec: WorkspaceSpec): Promise<{ workspaceId: string; created: boolean }>;
-  abstract exec(workspaceId: string, request: ExecRequest): Promise<ExecResult>;
-  abstract openInteractiveExec(workspaceId: string, request: InteractiveExecRequest): Promise<InteractiveExecSession>;
-  abstract destroyWorkspace(workspaceId: string, options?: DestroyWorkspaceOptions): Promise<void>;
-
-  resize?(execId: string, size: { cols: number; rows: number }): Promise<void>;
-  putArchive?(workspaceId: string, data: Buffer | NodeJS.ReadableStream, options?: { path?: string }): Promise<void>;
-  touchWorkspace?(workspaceId: string): Promise<void>;
-}

--- a/packages/platform-server/src/workspace/runtime/workspace.runtime.provider.ts
+++ b/packages/platform-server/src/workspace/runtime/workspace.runtime.provider.ts
@@ -1,0 +1,133 @@
+import type { Platform } from '../../core/constants';
+
+export type WorkspaceRuntimeProviderType = 'docker';
+
+export type WorkspaceStatus = 'starting' | 'running' | 'stopped' | 'deleted' | 'error';
+
+export type WorkspaceKey = {
+  threadId: string;
+  role: 'workspace';
+  platform?: Platform;
+  nodeId?: string;
+};
+
+export type WorkspaceSpec = {
+  image?: string;
+  workingDir?: string;
+  env?: Record<string, string>;
+  persistentVolume?: {
+    mountPath: string;
+  };
+  network?: {
+    name: string;
+    aliases?: string[];
+  };
+  dockerInDocker?: {
+    enabled: boolean;
+    mirrorUrl?: string;
+  };
+  resources?: {
+    cpuNano?: number;
+    memoryBytes?: number;
+  };
+  ttlSeconds?: number;
+};
+
+export type WorkspaceRuntimeCapabilities = {
+  persistentVolume: boolean;
+  network: boolean;
+  networkAliases: boolean;
+  dockerInDocker: boolean;
+  stdioSession: boolean;
+  terminalSession: boolean;
+  logsSession: boolean;
+};
+
+export type WorkspaceExecRequest = {
+  command: string | string[];
+  workdir?: string;
+  env?: Record<string, string> | string[];
+  timeoutMs?: number;
+  idleTimeoutMs?: number;
+  killOnTimeout?: boolean;
+  tty?: boolean;
+  signal?: AbortSignal;
+  onOutput?: (source: 'stdout' | 'stderr', chunk: Buffer) => void;
+  logToPid1?: boolean;
+};
+
+export type WorkspaceExecResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+export type WorkspaceStdioSessionRequest = {
+  command: string | string[];
+  workdir?: string;
+  env?: Record<string, string> | string[];
+  tty?: boolean;
+  demuxStderr?: boolean;
+};
+
+export type WorkspaceStdioSession = {
+  stdin: NodeJS.WritableStream;
+  stdout: NodeJS.ReadableStream;
+  stderr?: NodeJS.ReadableStream;
+  close: () => Promise<WorkspaceExecResult>;
+};
+
+export type WorkspaceTerminalSessionRequest = WorkspaceStdioSessionRequest & {
+  size?: { cols: number; rows: number };
+};
+
+export type WorkspaceTerminalSession = WorkspaceStdioSession & {
+  sessionId: string;
+  execId: string;
+  resize: (size: { cols: number; rows: number }) => Promise<void>;
+};
+
+export type WorkspaceLogsRequest = {
+  follow?: boolean;
+  since?: number;
+  tail?: number;
+  stdout?: boolean;
+  stderr?: boolean;
+  timestamps?: boolean;
+};
+
+export type WorkspaceLogsSession = {
+  stream: NodeJS.ReadableStream;
+  close: () => Promise<void>;
+};
+
+export type DestroyWorkspaceOptions = {
+  force?: boolean;
+  removePersistentVolume?: boolean;
+};
+
+export type EnsureWorkspaceResult = {
+  workspaceId: string;
+  created: boolean;
+  providerType: WorkspaceRuntimeProviderType;
+  status: WorkspaceStatus;
+};
+
+export abstract class WorkspaceRuntimeProvider {
+  abstract capabilities(): WorkspaceRuntimeCapabilities;
+  abstract ensureWorkspace(key: WorkspaceKey, spec: WorkspaceSpec): Promise<EnsureWorkspaceResult>;
+  abstract exec(workspaceId: string, request: WorkspaceExecRequest): Promise<WorkspaceExecResult>;
+  abstract openStdioSession(workspaceId: string, request: WorkspaceStdioSessionRequest): Promise<WorkspaceStdioSession>;
+  abstract openTerminalSession(
+    workspaceId: string,
+    request: WorkspaceTerminalSessionRequest,
+  ): Promise<WorkspaceTerminalSession>;
+  abstract openLogsSession(workspaceId: string, request: WorkspaceLogsRequest): Promise<WorkspaceLogsSession>;
+  abstract destroyWorkspace(workspaceId: string, options?: DestroyWorkspaceOptions): Promise<void>;
+  abstract putArchive(
+    workspaceId: string,
+    data: Buffer | NodeJS.ReadableStream,
+    options?: { path?: string },
+  ): Promise<void>;
+  abstract touchWorkspace(workspaceId: string): Promise<void>;
+}

--- a/packages/platform-server/src/workspace/workspace.handle.ts
+++ b/packages/platform-server/src/workspace/workspace.handle.ts
@@ -16,7 +16,7 @@ type LegacyInteractiveExecSession = {
   stdin: NodeJS.WritableStream;
   stdout: NodeJS.ReadableStream;
   stderr?: NodeJS.ReadableStream;
-  close: () => Promise<{ exitCode: number }>;
+  close: () => Promise<WorkspaceExecResult>;
 };
 
 type LegacyInteractiveExecRequest = {

--- a/packages/platform-server/src/workspace/workspace.handle.ts
+++ b/packages/platform-server/src/workspace/workspace.handle.ts
@@ -1,15 +1,36 @@
 import type {
-  WorkspaceProvider,
-  ExecRequest,
-  ExecResult,
-  InteractiveExecRequest,
-  InteractiveExecSession,
-} from './providers/workspace.provider';
+  DestroyWorkspaceOptions,
+  WorkspaceExecRequest,
+  WorkspaceExecResult,
+  WorkspaceLogsRequest,
+  WorkspaceLogsSession,
+  WorkspaceRuntimeProvider,
+  WorkspaceStdioSession,
+  WorkspaceStdioSessionRequest,
+  WorkspaceTerminalSession,
+  WorkspaceTerminalSessionRequest,
+} from './runtime/workspace.runtime.provider';
 
-export class WorkspaceHandle {
+type LegacyInteractiveExecSession = {
+  execId: string;
+  stdin: NodeJS.WritableStream;
+  stdout: NodeJS.ReadableStream;
+  stderr?: NodeJS.ReadableStream;
+  close: () => Promise<{ exitCode: number }>;
+};
+
+type LegacyInteractiveExecRequest = {
+  command: string | string[];
+  workdir?: string;
+  env?: Record<string, string> | string[];
+  tty?: boolean;
+  demuxStderr?: boolean;
+};
+
+export class WorkspaceRuntimeHandle {
   constructor(
-    private readonly provider: WorkspaceProvider,
-    private readonly workspaceId: string,
+    protected readonly provider: WorkspaceRuntimeProvider,
+    protected readonly workspaceId: string,
   ) {}
 
   get id(): string {
@@ -20,47 +41,138 @@ export class WorkspaceHandle {
     return this.workspaceId.substring(0, 12);
   }
 
-  async exec(command: string | string[], options: Omit<ExecRequest, 'command'> = {}): Promise<ExecResult> {
+  async exec(
+    command: string | string[],
+    options: Omit<WorkspaceExecRequest, 'command'> = {},
+  ): Promise<WorkspaceExecResult> {
     return this.provider.exec(this.workspaceId, { ...options, command });
   }
 
-  async openInteractiveExec(
+  async openStdioSession(
     command: string | string[],
-    options: Omit<InteractiveExecRequest, 'command'> = {},
-  ): Promise<InteractiveExecSession> {
-    return this.provider.openInteractiveExec(this.workspaceId, { ...options, command });
+    options: Omit<WorkspaceStdioSessionRequest, 'command'> = {},
+  ): Promise<WorkspaceStdioSession> {
+    return this.provider.openStdioSession(this.workspaceId, { ...options, command });
   }
 
-  async resizeExec(execId: string, size: { cols: number; rows: number }): Promise<void> {
-    if (!this.provider.resize) throw new Error('Workspace provider does not support resize');
-    await this.provider.resize(execId, size);
+  async openTerminalSession(
+    command: string | string[],
+    options: Omit<WorkspaceTerminalSessionRequest, 'command'> = {},
+  ): Promise<WorkspaceTerminalSession> {
+    return this.provider.openTerminalSession(this.workspaceId, { ...options, command });
   }
 
-  async destroy(options?: { force?: boolean; removePersistentVolume?: boolean }): Promise<void> {
-    await this.provider.destroyWorkspace(this.workspaceId, options);
+  async openLogsSession(options: WorkspaceLogsRequest = {}): Promise<WorkspaceLogsSession> {
+    return this.provider.openLogsSession(this.workspaceId, options);
   }
 
-  async putArchive(data: Buffer | NodeJS.ReadableStream, options: { path?: string } = { path: '/tmp' }): Promise<void> {
-    if (!this.provider.putArchive) throw new Error('Workspace provider does not support putArchive');
+  async putArchive(
+    data: Buffer | NodeJS.ReadableStream,
+    options: { path?: string } = { path: '/tmp' },
+  ): Promise<void> {
     await this.provider.putArchive(this.workspaceId, data, options);
   }
 
   async touch(): Promise<void> {
-    if (this.provider.touchWorkspace) {
-      await this.provider.touchWorkspace(this.workspaceId);
+    await this.provider.touchWorkspace(this.workspaceId);
+  }
+
+  async destroy(options?: DestroyWorkspaceOptions): Promise<void> {
+    await this.provider.destroyWorkspace(this.workspaceId, options);
+  }
+}
+
+export class WorkspaceHandle extends WorkspaceRuntimeHandle {
+  private readonly terminalSessions = new Map<string, WorkspaceTerminalSession>();
+
+  async openInteractiveExec(
+    command: string | string[],
+    options: Omit<LegacyInteractiveExecRequest, 'command'> = {},
+  ): Promise<LegacyInteractiveExecSession> {
+    const providerAny = this.provider as {
+      openInteractiveExec?: (
+        workspaceId: string,
+        request: LegacyInteractiveExecRequest,
+      ) => Promise<LegacyInteractiveExecSession>;
+    };
+    const supportsTerminal = typeof (this.provider as { openTerminalSession?: unknown }).openTerminalSession === 'function';
+    const supportsStdio = typeof (this.provider as { openStdioSession?: unknown }).openStdioSession === 'function';
+
+    const useTty = options.tty ?? false;
+
+    if ((!supportsTerminal || (!supportsStdio && !useTty)) && providerAny.openInteractiveExec) {
+      return providerAny.openInteractiveExec(this.workspaceId, { ...options, command });
     }
+
+    if (!useTty) {
+      const session = await this.openStdioSession(command, {
+        workdir: options.workdir,
+        env: options.env,
+        demuxStderr: options.demuxStderr ?? true,
+        tty: false,
+      });
+
+      const execId = `stdio-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+      return {
+        execId,
+        stdin: session.stdin,
+        stdout: session.stdout,
+        stderr: session.stderr,
+        close: session.close,
+      };
+    }
+
+    const session = await this.openTerminalSession(command, {
+      workdir: options.workdir,
+      env: options.env,
+      demuxStderr: options.demuxStderr ?? false,
+    });
+
+    this.terminalSessions.set(session.execId, session);
+
+    return {
+      execId: session.execId,
+      stdin: session.stdin,
+      stdout: session.stdout,
+      stderr: session.stderr,
+      close: async () => {
+        try {
+          return await session.close();
+        } finally {
+          this.terminalSessions.delete(session.execId);
+        }
+      },
+    };
+  }
+
+  async resizeExec(execId: string, size: { cols: number; rows: number }): Promise<void> {
+    const session = this.terminalSessions.get(execId);
+    if (session) {
+      await session.resize(size);
+      return;
+    }
+
+    const providerAny = this.provider as {
+      resize?: (execId: string, size: { cols: number; rows: number }) => Promise<void>;
+    };
+
+    if (providerAny.resize) {
+      await providerAny.resize(execId, size);
+      return;
+    }
+
+    throw new Error('terminal_session_not_found');
   }
 
   async openInteractive(
     command: string | string[],
-    options: Omit<InteractiveExecRequest, 'command'> = {},
-  ): Promise<{
-    execId: string;
-    stdin: NodeJS.WritableStream;
-    stdout: NodeJS.ReadableStream;
-    stderr?: NodeJS.ReadableStream;
-    close: () => Promise<{ exitCode: number }>;
-  }> {
+    options: Omit<LegacyInteractiveExecRequest, 'command'> = {},
+  ): Promise<LegacyInteractiveExecSession> {
     return this.openInteractiveExec(command, options);
+  }
+
+  override async destroy(options?: DestroyWorkspaceOptions): Promise<void> {
+    this.terminalSessions.clear();
+    await super.destroy(options);
   }
 }


### PR DESCRIPTION
## Summary
- add WorkspaceRuntimeProvider and runtime handle layer
- retrofit Docker runtime, workspace node wiring, and MCP transport to new abstractions
- update terminal gateway/tests and provider stubs to new contracts

## Testing
- pnpm --filter @agyn/platform-server exec vitest run --reporter dot
- pnpm lint

Resolves #1260