### PR TITLE
feat: raise thread message cap

### DIFF
--- a/packages/platform-server/__tests__/agents.threads.controller.create.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.create.test.ts
@@ -113,7 +113,7 @@ describe('AgentsThreadsController POST /api/agents/threads', () => {
     const { controller, createThreadWithInitialMessage } = await setup();
 
     await expect(
-      controller.createThread({ text: 'a'.repeat(8001), agentNodeId: 'agent-1' } as any),
+      controller.createThread({ text: 'a'.repeat(100001), agentNodeId: 'agent-1' } as any),
     ).rejects.toMatchObject({
       status: 400,
       response: { error: 'bad_message_payload' },

--- a/packages/platform-server/__tests__/agents.threads.controller.send-message.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.send-message.test.ts
@@ -104,6 +104,16 @@ describe('AgentsThreadsController POST /api/agents/threads/:threadId/messages', 
     });
   });
 
+  it('rejects when message exceeds limit', async () => {
+    const { controller } = await setup();
+    const overLimit = 'a'.repeat(100001);
+
+    await expect(controller.sendThreadMessage('thread-1', { text: overLimit })).rejects.toMatchObject({
+      status: 400,
+      response: { error: 'bad_message_payload' },
+    });
+  });
+
   it('returns not found when thread does not exist', async () => {
     const { controller } = await setup({ thread: null, latestAgentNodeId: null });
     expect.assertions(2);

--- a/packages/platform-server/src/agents/threads.controller.ts
+++ b/packages/platform-server/src/agents/threads.controller.ts
@@ -49,7 +49,7 @@ export const RunEventStatusValues: ReadonlyArray<RunEventStatus> = ['pending', '
 const isRunEventType = (value: string): value is RunEventType => (RunEventTypeValues as ReadonlyArray<string>).includes(value);
 const isRunEventStatus = (value: string): value is RunEventStatus => (RunEventStatusValues as ReadonlyArray<string>).includes(value);
 
-const THREAD_MESSAGE_MAX_LENGTH = 8000;
+const THREAD_MESSAGE_MAX_LENGTH = 100000;
 
 export class ListRunMessagesQueryDto {
   @IsIn(RunMessageTypeValues)

--- a/packages/platform-ui/src/pages/AgentsThreads.tsx
+++ b/packages/platform-ui/src/pages/AgentsThreads.tsx
@@ -168,8 +168,12 @@ function containerDisplayName(container: ContainerItem): string {
   return container.name;
 }
 
+const MAX_MESSAGE_LENGTH_LABEL = THREAD_MESSAGE_MAX_LENGTH.toLocaleString();
+const MESSAGE_LENGTH_LIMIT_PROMPT = `Please enter a message up to ${MAX_MESSAGE_LENGTH_LABEL} characters.`;
+const MESSAGE_LENGTH_LIMIT_NOTIFICATION = `Messages are limited to ${MAX_MESSAGE_LENGTH_LABEL} characters.`;
+
 const sendMessageErrorMap: Record<string, string> = {
-  bad_message_payload: 'Please enter a message up to 8000 characters.',
+  bad_message_payload: MESSAGE_LENGTH_LIMIT_PROMPT,
   thread_not_found: 'Thread not found. It may have been removed.',
   thread_closed: 'This thread is resolved. Reopen it to send messages.',
   agent_unavailable: 'Agent is not currently available for this thread.',
@@ -178,7 +182,7 @@ const sendMessageErrorMap: Record<string, string> = {
 };
 
 const createThreadErrorMap: Record<string, string> = {
-  bad_message_payload: 'Please enter a message up to 8000 characters.',
+  bad_message_payload: MESSAGE_LENGTH_LIMIT_PROMPT,
   agent_unavailable: 'Agent is not currently available for new threads.',
   agent_unready: 'Agent is starting up. Try again shortly.',
   create_failed: 'Failed to create the thread. Please retry.',
@@ -604,10 +608,9 @@ export function AgentsThreads() {
         lastPersistedTextRef.current = '';
         return;
       }
-      const limited = value.slice(0, THREAD_MESSAGE_MAX_LENGTH);
-      if (limited === lastPersistedTextRef.current) return;
-      writeDraft(threadId, limited, userEmail);
-      lastPersistedTextRef.current = limited;
+      if (value === lastPersistedTextRef.current) return;
+      writeDraft(threadId, value, userEmail);
+      lastPersistedTextRef.current = value;
     },
     [userEmail],
   );
@@ -2017,7 +2020,7 @@ export function AgentsThreads() {
           return;
         }
         if (trimmed.length > THREAD_MESSAGE_MAX_LENGTH) {
-          notifyError('Messages are limited to 8000 characters.');
+          notifyError(MESSAGE_LENGTH_LIMIT_NOTIFICATION);
           return;
         }
         createThread({ draftId: draft.id, agentNodeId, text: trimmed });
@@ -2031,7 +2034,7 @@ export function AgentsThreads() {
         return;
       }
       if (trimmed.length > THREAD_MESSAGE_MAX_LENGTH) {
-        notifyError('Messages are limited to 8000 characters.');
+        notifyError(MESSAGE_LENGTH_LIMIT_NOTIFICATION);
         return;
       }
       cancelDraftSave();

--- a/packages/platform-ui/src/utils/__tests__/draftStorage.test.ts
+++ b/packages/platform-ui/src/utils/__tests__/draftStorage.test.ts
@@ -45,13 +45,14 @@ describe('writeDraft / readDraft', () => {
     expect(new Date(stored!.updatedAt).toString()).not.toBe('Invalid Date');
   });
 
-  it('truncates drafts to the message max length', () => {
+  it('retains full drafts beyond the message limit', () => {
     const longText = 'x'.repeat(THREAD_MESSAGE_MAX_LENGTH + 100);
     writeDraft(THREAD_ID, longText, USER_EMAIL);
 
     const stored = readDraft(THREAD_ID, USER_EMAIL);
 
-    expect(stored?.text.length).toBe(THREAD_MESSAGE_MAX_LENGTH);
+    expect(stored?.text.length).toBe(longText.length);
+    expect(stored?.text).toBe(longText);
   });
 
   it('clears storage when writing an empty draft', () => {

--- a/packages/platform-ui/src/utils/draftStorage.ts
+++ b/packages/platform-ui/src/utils/draftStorage.ts
@@ -1,6 +1,6 @@
 const STORAGE_PREFIX = 'ui.draft.threads';
 const STORAGE_VERSION = 1;
-export const THREAD_MESSAGE_MAX_LENGTH = 8000;
+export const THREAD_MESSAGE_MAX_LENGTH = 100000;
 
 type DraftRecord = {
   version: number;
@@ -36,7 +36,7 @@ export function readDraft(threadId: string, userEmail?: string | null): { text: 
     if (!parsed || typeof parsed !== 'object') return null;
     if (parsed.version !== STORAGE_VERSION) return null;
     if (typeof parsed.text !== 'string') return null;
-    const text = parsed.text.slice(0, THREAD_MESSAGE_MAX_LENGTH);
+    const text = parsed.text;
     return {
       text,
       updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date(0).toISOString(),
@@ -56,10 +56,9 @@ export function writeDraft(threadId: string, text: string, userEmail?: string | 
     clearDraft(threadId, userEmail);
     return;
   }
-  const limited = text.slice(0, THREAD_MESSAGE_MAX_LENGTH);
   const payload: DraftRecord = {
     version: STORAGE_VERSION,
-    text: limited,
+    text,
     updatedAt: new Date().toISOString(),
     userEmail: typeof userEmail === 'string' && userEmail.trim().length > 0 ? userEmail : null,
   };


### PR DESCRIPTION
## Summary
- raise the thread message limit to 100,000 characters across server and UI
- remove draft truncation, surface composer warnings, and enforce limit via validation
- refresh server, UI, and storage tests to cover the new cap and limit messaging

## Testing
- pnpm lint
- pnpm test
- pnpm --filter @agyn/platform-server test -- --reporter=json --no-color --silent
- pnpm --filter @agyn/platform-ui test -- --reporter=json --no-color --silent

Closes #1262