### PR TITLE
fix: normalize terminal websocket base fallback

### DIFF
--- a/packages/platform-ui/src/components/monitoring/__tests__/ContainerTerminalDialog.test.tsx
+++ b/packages/platform-ui/src/components/monitoring/__tests__/ContainerTerminalDialog.test.tsx
@@ -264,7 +264,19 @@ describe('toWsUrl', () => {
   it('uses API base env for relative paths', () => {
     vi.stubEnv('VITE_API_BASE_URL', 'http://localhost:3010');
     const url = toWsUrl('/api/containers/terminal/session');
-    expect(url).toBe('ws://localhost:3010/api/containers/terminal/session');
+    const expectedBase = new URL('http://localhost:3010');
+    expectedBase.protocol = expectedBase.protocol === 'https:' ? 'wss:' : 'ws:';
+    const expected = new URL('/api/containers/terminal/session', expectedBase).toString();
+    expect(url).toBe(expected);
+  });
+
+  it('falls back to window origin when env is relative', () => {
+    vi.stubEnv('VITE_API_BASE_URL', '/');
+    const url = toWsUrl('/api/containers/terminal/session');
+    const expectedBase = new URL(window.location.origin);
+    expectedBase.protocol = expectedBase.protocol === 'https:' ? 'wss:' : 'ws:';
+    const expected = new URL('/api/containers/terminal/session', expectedBase).toString();
+    expect(url).toBe(expected);
   });
 
   it('returns absolute websocket URLs unchanged', () => {

--- a/packages/platform-ui/src/components/monitoring/toWsUrl.ts
+++ b/packages/platform-ui/src/components/monitoring/toWsUrl.ts
@@ -1,18 +1,25 @@
+import { getSocketBaseUrl } from '@/config';
+
+function resolveSocketBase(): URL {
+  const fallbackBase = getSocketBaseUrl();
+  const raw = import.meta.env?.VITE_API_BASE_URL;
+
+  if (typeof raw === 'string' && raw.trim()) {
+    try {
+      const resolved = new URL(raw.trim(), typeof window !== 'undefined' ? window.location.origin : fallbackBase);
+      return resolved;
+    } catch {
+      throw new Error('terminal: invalid VITE_API_BASE_URL value');
+    }
+  }
+
+  return new URL(fallbackBase);
+}
+
 export function toWsUrl(path: string): string {
   if (path.startsWith('ws://') || path.startsWith('wss://')) return path;
 
-  const apiBase = import.meta.env?.VITE_API_BASE_URL;
-  if (!apiBase || typeof apiBase !== 'string' || !apiBase.trim()) {
-    throw new Error('terminal: VITE_API_BASE_URL is not configured');
-  }
-
-  let baseUrl: URL;
-  try {
-    baseUrl = new URL(apiBase);
-  } catch {
-    throw new Error('terminal: invalid VITE_API_BASE_URL value');
-  }
-
+  const baseUrl = resolveSocketBase();
   baseUrl.protocol = baseUrl.protocol === 'https:' ? 'wss:' : baseUrl.protocol === 'http:' ? 'ws:' : baseUrl.protocol;
 
   const resolved = new URL(path, baseUrl);


### PR DESCRIPTION
## Summary
- reuse sanitized socket base and window origin to resolve websocket URLs when VITE_API_BASE_URL is relative
- keep explicit env parsing errors for invalid values while tolerating slash-only configs
- extend terminal dialog tests to cover relative fallback behavior

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test
