### PR TITLE
fix: ignore workspace auto platform override

### DIFF
--- a/packages/platform-server/__tests__/helpers/services.stub.ts
+++ b/packages/platform-server/__tests__/helpers/services.stub.ts
@@ -1,0 +1,16 @@
+import { EnvService } from '../../src/env/env.service';
+import { NcpsKeyService } from '../../src/infra/ncps/ncpsKey.service';
+import type { ConfigService } from '../../src/core/services/config.service';
+import { registerTestConfig } from './config';
+
+export function createEnvServiceStub(): EnvService {
+  return new EnvService();
+}
+
+export function createConfigServiceStub(): ConfigService {
+  return registerTestConfig();
+}
+
+export function createNcpsKeyServiceStub(configService: ConfigService): NcpsKeyService {
+  return new NcpsKeyService(configService);
+}

--- a/packages/platform-server/__tests__/workspace.node.platform.test.ts
+++ b/packages/platform-server/__tests__/workspace.node.platform.test.ts
@@ -63,6 +63,15 @@ describe('WorkspaceNode platform selection', () => {
     expect(provider.ensureCalls[0]?.key.platform).toBe('linux/amd64');
   });
 
+  it('propagates explicit linux/arm64 override', async () => {
+    const { node, provider } = await createWorkspaceNode({ platform: 'linux/arm64' });
+
+    await node.provide('thread-arm64');
+
+    expect(provider.ensureCalls).toHaveLength(1);
+    expect(provider.ensureCalls[0]?.key.platform).toBe('linux/arm64');
+  });
+
   it('omits platform override when auto is selected', async () => {
     const { node, provider } = await createWorkspaceNode({}, 'auto');
 
@@ -70,5 +79,14 @@ describe('WorkspaceNode platform selection', () => {
 
     expect(provider.ensureCalls).toHaveLength(1);
     expect(provider.ensureCalls[0]?.key.platform).toBeUndefined();
+  });
+
+  it('throws when platform selection is invalid', async () => {
+    const { node, provider } = await createWorkspaceNode({}, 'windows/amd64');
+
+    await expect(node.provide('thread-invalid')).rejects.toThrowError(
+      /Unsupported workspace platform override: windows\/amd64/,
+    );
+    expect(provider.ensureCalls).toHaveLength(0);
   });
 });

--- a/packages/platform-server/__tests__/workspace.node.platform.test.ts
+++ b/packages/platform-server/__tests__/workspace.node.platform.test.ts
@@ -5,10 +5,13 @@ import {
   WorkspaceNode,
   type ContainerProviderStaticConfig,
 } from '../src/nodes/workspace/workspace.node';
-import { EnvService } from '../src/env/env.service';
-import { NcpsKeyService } from '../src/infra/ncps/ncpsKey.service';
 import { WorkspaceProviderStub } from './helpers/workspace-provider.stub';
-import { clearTestConfig, registerTestConfig } from './helpers/config';
+import { clearTestConfig } from './helpers/config';
+import {
+  createConfigServiceStub,
+  createEnvServiceStub,
+  createNcpsKeyServiceStub,
+} from './helpers/services.stub';
 
 type WorkspaceNodeContext = {
   node: WorkspaceNode;
@@ -16,10 +19,10 @@ type WorkspaceNodeContext = {
 };
 
 describe('WorkspaceNode platform selection', () => {
-  let configService: ReturnType<typeof registerTestConfig>;
+  let configService: ReturnType<typeof createConfigServiceStub>;
 
   beforeEach(() => {
-    configService = registerTestConfig();
+    configService = createConfigServiceStub();
   });
 
   afterEach(() => {
@@ -30,8 +33,8 @@ describe('WorkspaceNode platform selection', () => {
     config: Partial<ContainerProviderStaticConfig> = {},
   ): Promise<WorkspaceNodeContext> => {
     const provider = new WorkspaceProviderStub();
-    const envService = new EnvService();
-    const ncpsKeyService = new NcpsKeyService(configService);
+    const envService = createEnvServiceStub();
+    const ncpsKeyService = createNcpsKeyServiceStub(configService);
     const node = new WorkspaceNode(provider, configService, ncpsKeyService, envService);
     node.init({ nodeId: 'workspace-node' });
     const parsedConfig = ContainerProviderStaticConfigSchema.parse(config);

--- a/packages/platform-server/__tests__/workspace.node.platform.test.ts
+++ b/packages/platform-server/__tests__/workspace.node.platform.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { WorkspaceNode, type ContainerProviderStaticConfig } from '../src/nodes/workspace/workspace.node';
+import type { ConfigService } from '../src/core/services/config.service';
+import type { EnvService } from '../src/env/env.service';
+import type { NcpsKeyService } from '../src/infra/ncps/ncpsKey.service';
+import { WorkspaceProviderStub } from './helpers/workspace-provider.stub';
+
+type WorkspaceNodeContext = {
+  node: WorkspaceNode;
+  provider: WorkspaceProviderStub;
+};
+
+async function createWorkspaceNode(config: Partial<ContainerProviderStaticConfig>): Promise<WorkspaceNodeContext> {
+  const provider = new WorkspaceProviderStub();
+  const envService = {
+    resolveProviderEnv: vi.fn().mockResolvedValue({}),
+  } as unknown as EnvService;
+
+  const configService = {
+    dockerMirrorUrl: undefined,
+    ncpsEnabled: false,
+    ncpsUrl: undefined,
+    workspaceNetworkName: 'agents_net',
+  } as unknown as ConfigService;
+
+  const ncpsKeyService = {
+    getKeysForInjection: vi.fn().mockReturnValue([]),
+  } as unknown as NcpsKeyService;
+
+  const node = new WorkspaceNode(provider, configService, ncpsKeyService, envService);
+  node.init({ nodeId: 'workspace-node' });
+  await node.setConfig(config as ContainerProviderStaticConfig);
+
+  return { node, provider };
+}
+
+describe('WorkspaceNode platform selection', () => {
+  it('defaults to linux/arm64 when unset', async () => {
+    const { node, provider } = await createWorkspaceNode({});
+
+    await node.provide('thread-default');
+
+    expect(provider.ensureCalls).toHaveLength(1);
+    expect(provider.ensureCalls[0]?.key.platform).toBe('linux/arm64');
+  });
+
+  it('propagates explicit platform overrides', async () => {
+    const { node, provider } = await createWorkspaceNode({ platform: 'linux/amd64' });
+
+    await node.provide('thread-override');
+
+    expect(provider.ensureCalls).toHaveLength(1);
+    expect(provider.ensureCalls[0]?.key.platform).toBe('linux/amd64');
+  });
+
+  it('omits platform override when auto is selected', async () => {
+    const { node, provider } = await createWorkspaceNode({
+      platform: 'auto' as unknown as ContainerProviderStaticConfig['platform'],
+    });
+
+    await node.provide('thread-auto');
+
+    expect(provider.ensureCalls).toHaveLength(1);
+    expect(provider.ensureCalls[0]?.key.platform).toBeUndefined();
+  });
+});

--- a/packages/platform-server/src/nodes/workspace/workspace.node.ts
+++ b/packages/platform-server/src/nodes/workspace/workspace.node.ts
@@ -98,7 +98,8 @@ export class WorkspaceNode extends Node<ContainerProviderStaticConfig> {
   }
 
   async provide(threadId: string): Promise<WorkspaceHandle> {
-    const platform: Platform = this.config?.platform ?? DEFAULT_PLATFORM;
+    const selected = this.config?.platform as Platform | 'auto' | undefined;
+    const platform: Platform | undefined = selected === 'auto' ? undefined : selected ?? DEFAULT_PLATFORM;
     const networkName = this.configService.workspaceNetworkName;
 
     const { spec, nixConfigInjected } = await this.buildWorkspaceSpec(threadId, networkName);

--- a/packages/platform-server/src/nodes/workspace/workspace.node.ts
+++ b/packages/platform-server/src/nodes/workspace/workspace.node.ts
@@ -78,9 +78,6 @@ const DEFAULT_TTL_SECONDS = 86_400;
 const DOCKER_HOST_ENV = 'tcp://localhost:2375';
 const DEFAULT_DOCKER_MIRROR = 'http://registry-mirror:5000';
 
-export const isSupportedPlatform = (value: string): value is Platform =>
-  (SUPPORTED_PLATFORMS as readonly string[]).includes(value as Platform);
-
 @Injectable({ scope: Scope.TRANSIENT })
 export class WorkspaceNode extends Node<ContainerProviderStaticConfig> {
   constructor(
@@ -101,23 +98,8 @@ export class WorkspaceNode extends Node<ContainerProviderStaticConfig> {
   }
 
   async provide(threadId: string): Promise<WorkspaceHandle> {
-    const hasExplicitSelection =
-      this.config && Object.hasOwn(this.config as Record<string, unknown>, 'platform');
-    const rawSelection = hasExplicitSelection
-      ? (this.config as Record<string, unknown>).platform
-      : undefined;
-    const selection = typeof rawSelection === 'string' ? rawSelection : undefined;
-
-    let platform: Platform | undefined;
-    if (!hasExplicitSelection) {
-      platform = DEFAULT_PLATFORM;
-    } else if (selection === 'auto') {
-      platform = undefined;
-    } else if (selection && isSupportedPlatform(selection)) {
-      platform = selection;
-    } else {
-      platform = undefined;
-    }
+    const selected = this.config?.platform as string | undefined;
+    const platform: Platform | undefined = selected === 'auto' ? undefined : (selected ?? DEFAULT_PLATFORM);
     const networkName = this.configService.workspaceNetworkName;
 
     const { spec, nixConfigInjected } = await this.buildWorkspaceSpec(threadId, networkName);


### PR DESCRIPTION
## Summary
- ensure WorkspaceNode skips Docker platform overrides when UI selection is auto
- preserve default and explicit platform behavior with targeted tests
- add regression coverage for auto/default/override cases

## Testing
- pnpm lint
- pnpm test -- --reporter=basic

Closes #1267