### PR TITLE
feat(ui): rename graph tab label

### DIFF
--- a/packages/platform-ui/src/layout/RootLayout.tsx
+++ b/packages/platform-ui/src/layout/RootLayout.tsx
@@ -35,7 +35,7 @@ const MENU_ITEMS: MenuItem[] = [
     label: 'Agents',
     icon: <Network className="w-5 h-5" />,
     items: [
-      { id: 'graph', label: 'Graph', icon: <GitBranch className="w-4 h-4" /> },
+      { id: 'graph', label: 'Team', icon: <GitBranch className="w-4 h-4" /> },
       { id: 'threads', label: 'Threads', icon: <MessageSquare className="w-4 h-4" /> },
       { id: 'reminders', label: 'Reminders', icon: <Bell className="w-4 h-4" /> },
       { id: 'memory', label: 'Memory', icon: <Brain className="w-4 h-4" /> },

--- a/packages/platform-ui/stories/MainLayout.stories.tsx
+++ b/packages/platform-ui/stories/MainLayout.stories.tsx
@@ -20,7 +20,7 @@ const defaultMenuItems: MenuItem[] = [
     label: 'Agents',
     icon: <Network className="w-5 h-5" />,
     items: [
-      { id: 'graph', label: 'Graph', icon: <GitBranch className="w-4 h-4" /> },
+      { id: 'graph', label: 'Team', icon: <GitBranch className="w-4 h-4" /> },
       { id: 'threads', label: 'Threads', icon: <MessageSquare className="w-4 h-4" /> },
       { id: 'reminders', label: 'Reminders', icon: <Bell className="w-4 h-4" /> },
     ],

--- a/packages/platform-ui/stories/Sidebar.stories.tsx
+++ b/packages/platform-ui/stories/Sidebar.stories.tsx
@@ -19,7 +19,7 @@ const defaultMenuItems: MenuItem[] = [
     label: 'Agents',
     icon: <Network className="w-5 h-5" />,
     items: [
-      { id: 'graph', label: 'Graph', icon: <GitBranch className="w-4 h-4" /> },
+      { id: 'graph', label: 'Team', icon: <GitBranch className="w-4 h-4" /> },
       { id: 'threads', label: 'Threads', icon: <MessageSquare className="w-4 h-4" /> },
       { id: 'reminders', label: 'Reminders', icon: <Bell className="w-4 h-4" /> },
     ],

--- a/packages/platform-ui/stories/decorators/withMainLayout.tsx
+++ b/packages/platform-ui/stories/decorators/withMainLayout.tsx
@@ -21,7 +21,7 @@ const defaultMenuItems: MenuItem[] = [
     label: 'Agents',
     icon: <Network className="w-5 h-5" />,
     items: [
-      { id: 'graph', label: 'Graph', icon: <GitBranch className="w-4 h-4" /> },
+      { id: 'graph', label: 'Team', icon: <GitBranch className="w-4 h-4" /> },
       { id: 'threads', label: 'Threads', icon: <MessageSquare className="w-4 h-4" /> },
       { id: 'reminders', label: 'Reminders', icon: <Bell className="w-4 h-4" /> },
       { id: 'memory', label: 'Memory', icon: <Brain className="w-4 h-4" /> },


### PR DESCRIPTION
## Summary
- rename the Agents → graph menu label to "Team" in the main layout while leaving id `graph` and route `/agents/graph` intact
- align Storybook decorators and stories so design references match production UI

IDs and routes remain unchanged (`graph` / `/agents/graph`). Tests pass locally.

## Testing
- pnpm lint
- pnpm test
- pnpm build
- pnpm --filter @agyn/platform-server exec vitest run --reporter=json --outputFile vitest-server.json
- pnpm --filter @agyn/platform-ui test -- --reporter=dot

Closes #1282
