### PR TITLE
docs: add README bootstrap quick setup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Agyn Platform
+> Quick setup: follow the [Bootstrap guide](https://github.com/agynio/bootstrap) to set up prerequisites and a local dev environment for this repo.
+
 A multi-service agents platform with a NestJS API, React UI, and Git-backed graph orchestration.
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Agyn Platform
-> Quick setup: follow the [Bootstrap guide](https://github.com/agynio/bootstrap) to set up prerequisites and a local dev environment for this repo.
+> [!NOTE]
+> Quick setup: use the Bootstrap repo to run prebuilt Platform Server and UI images locally — https://github.com/agynio/bootstrap
 
+# Agyn Platform
 A multi-service agents platform with a NestJS API, React UI, and Git-backed graph orchestration.
 
 ## Overview


### PR DESCRIPTION
## Summary
- add the required quick setup blockquote linking to the Bootstrap guide immediately under the title

## Testing
- pnpm --filter @agyn/platform-server test
- pnpm --filter @agyn/platform-server lint

Closes #1284