### PR TITLE
feat: add filter-aware timeline totals

### DIFF
--- a/packages/platform-server/__tests__/run-events.totals.test.ts
+++ b/packages/platform-server/__tests__/run-events.totals.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RunEventStatus, RunEventType } from '@prisma/client';
+import { RunEventsService } from '../src/events/run-events.service';
+
+describe('RunEventsService getRunEventTotals', () => {
+  it('aggregates event counts and token usage with filters applied', async () => {
+    const count = vi.fn().mockResolvedValue(12);
+    const aggregate = vi.fn().mockResolvedValue({
+      _sum: {
+        inputTokens: 100,
+        cachedInputTokens: 10,
+        outputTokens: 80,
+        reasoningTokens: 5,
+        totalTokens: 195,
+      },
+    });
+
+    const prismaStub = {
+      getClient: () => ({
+        runEvent: { count },
+        lLMCall: { aggregate },
+      }),
+    } as unknown as Parameters<typeof RunEventsService>[0];
+
+    const service = new RunEventsService(prismaStub);
+
+    const totals = await service.getRunEventTotals({
+      runId: 'run-1',
+      types: [RunEventType.llm_call],
+      statuses: [RunEventStatus.success],
+    });
+
+    expect(count).toHaveBeenCalledWith({
+      where: {
+        runId: 'run-1',
+        type: { in: [RunEventType.llm_call] },
+        status: { in: [RunEventStatus.success] },
+      },
+    });
+    expect(aggregate).toHaveBeenCalledWith({
+      where: {
+        event: {
+          runId: 'run-1',
+          type: { in: [RunEventType.llm_call] },
+          status: { in: [RunEventStatus.success] },
+        },
+      },
+      _sum: {
+        inputTokens: true,
+        cachedInputTokens: true,
+        outputTokens: true,
+        reasoningTokens: true,
+        totalTokens: true,
+      },
+    });
+    expect(totals).toEqual({
+      eventCount: 12,
+      tokenUsage: {
+        input: 100,
+        cached: 10,
+        output: 80,
+        reasoning: 5,
+        total: 195,
+      },
+    });
+  });
+
+  it('falls back to zeroed totals when aggregates are null', async () => {
+    const count = vi.fn().mockResolvedValue(0);
+    const aggregate = vi.fn().mockResolvedValue({ _sum: {} });
+
+    const prismaStub = {
+      getClient: () => ({
+        runEvent: { count },
+        lLMCall: { aggregate },
+      }),
+    } as unknown as Parameters<typeof RunEventsService>[0];
+
+    const service = new RunEventsService(prismaStub);
+
+    const totals = await service.getRunEventTotals({ runId: 'run-2' });
+
+    expect(count).toHaveBeenCalledWith({ where: { runId: 'run-2' } });
+    expect(aggregate).toHaveBeenCalledWith({
+      where: {
+        event: {
+          runId: 'run-2',
+        },
+      },
+      _sum: {
+        inputTokens: true,
+        cachedInputTokens: true,
+        outputTokens: true,
+        reasoningTokens: true,
+        totalTokens: true,
+      },
+    });
+    expect(totals).toEqual({
+      eventCount: 0,
+      tokenUsage: {
+        input: 0,
+        cached: 0,
+        output: 0,
+        reasoning: 0,
+        total: 0,
+      },
+    });
+  });
+});

--- a/packages/platform-ui/src/api/hooks/runs.ts
+++ b/packages/platform-ui/src/api/hooks/runs.ts
@@ -48,3 +48,17 @@ export function useRunTimelineEvents(
     refetchOnWindowFocus: false,
   });
 }
+
+export function useRunTimelineEventTotals(runId: string | undefined, filters: { types: string[]; statuses: string[] }) {
+  return useQuery({
+    enabled: !!runId,
+    queryKey: ['agents', 'runs', runId, 'timeline', 'events', 'totals', filters],
+    queryFn: () =>
+      runs.timelineEventTotals(runId as string, {
+        types: filters.types.length > 0 ? filters.types.join(',') : undefined,
+        statuses: filters.statuses.length > 0 ? filters.statuses.join(',') : undefined,
+      }),
+    staleTime: 15000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/packages/platform-ui/src/api/modules/runs.ts
+++ b/packages/platform-ui/src/api/modules/runs.ts
@@ -4,6 +4,7 @@ import type {
   RunMeta,
   RunTimelineEventsResponse,
   RunTimelineSummary,
+  RunTimelineTotalsResponse,
   ToolOutputSnapshot,
 } from '@/api/types/agents';
 
@@ -37,6 +38,15 @@ export const runs = {
           limit: params.limit,
           order: params.order,
           ...buildCursorParams(params),
+        },
+      }),
+    ),
+  timelineEventTotals: (runId: string, params?: { types?: string; statuses?: string }) =>
+    asData<RunTimelineTotalsResponse>(
+      http.get<RunTimelineTotalsResponse>(`/api/agents/runs/${encodeURIComponent(runId)}/events/totals`, {
+        params: {
+          ...(params?.types ? { types: params.types } : {}),
+          ...(params?.statuses ? { statuses: params.statuses } : {}),
         },
       }),
     ),

--- a/packages/platform-ui/src/api/types/agents.ts
+++ b/packages/platform-ui/src/api/types/agents.ts
@@ -165,6 +165,24 @@ export type RunTimelineEventsResponse = {
   nextCursor: RunTimelineEventsCursor | null;
 };
 
+export type RunTimelineTotalsResponse = {
+  runId: string;
+  filters: {
+    types: RunEventType[];
+    statuses: RunEventStatus[];
+  };
+  totals: {
+    eventCount: number;
+    tokenUsage: {
+      input: number;
+      cached: number;
+      output: number;
+      reasoning: number;
+      total: number;
+    };
+  };
+};
+
 export type ToolOutputSource = 'stdout' | 'stderr';
 
 export type ToolOutputChunk = {

--- a/packages/platform-ui/src/components/screens/RunScreen.tsx
+++ b/packages/platform-ui/src/components/screens/RunScreen.tsx
@@ -140,7 +140,7 @@ export default function RunScreen({
 
   const formatNumber = (value: number) => value.toLocaleString();
 
-  const totalEvents = events.length;
+  const totalEvents = statistics.totalEvents ?? events.length;
   const runsByStatus = {
     running: events.filter((event) => event.status === 'running').length,
     finished: events.filter((event) => event.status === 'finished').length,


### PR DESCRIPTION
## Summary
- add /runs/:runId/events/totals plus aggregation service + coverage
- surface totals via shared API/types + new hook, then consume it in AgentsRunScreen/RunScreen with throttled refetching
- add frontend + backend tests to prove the totals stay in sync with filters and pagination

Closes #1292.

## Testing
- pnpm --filter @agyn/platform-server lint
- pnpm --filter @agyn/platform-server test
- pnpm --filter @agyn/platform-server exec -- vitest run --reporter=json --outputFile ../../server-vitest.json (tests: 757 passed / 0 failed / 12 skipped)
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test (Test Files 80 passed; 400 tests passed / 0 failed / 0 skipped)
