### PR TITLE
Add docker-runner to GHCR workflow

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -29,6 +29,11 @@ jobs:
             dockerfile: packages/platform-ui/Dockerfile
             context: .
             cache-scope: platform-ui
+          - name: docker-runner
+            image: ghcr.io/agynio/docker-runner
+            dockerfile: packages/docker-runner/Dockerfile
+            context: .
+            cache-scope: docker-runner
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- add docker-runner image to docker-ghcr workflow matrix so docker-runner builds publish alongside other images

## Testing
- actionlint .github/workflows/docker-ghcr.yml

Fixes #1300