### PR TITLE
ci: docker-runner Dockerfile install with --ignore-scripts

### DIFF
--- a/packages/docker-runner/Dockerfile
+++ b/packages/docker-runner/Dockerfile
@@ -23,7 +23,8 @@ FROM base AS build
 
 COPY . .
 
-RUN pnpm install --filter @agyn/docker-runner... --offline --frozen-lockfile
+# Avoid workspace-wide postinstall/prepare (platform-server runs prisma generate)
+RUN pnpm install --filter @agyn/docker-runner... --offline --frozen-lockfile --ignore-scripts
 
 RUN pnpm --filter @agyn/docker-runner run build
 


### PR DESCRIPTION
## Summary
- ensure docker-runner Dockerfile installs dependencies without triggering workspace lifecycle scripts by adding --ignore-scripts to the pnpm install step

## Testing
- pnpm --filter @agyn/docker-runner lint
- pnpm --filter @agyn/docker-runner test

Fixes #1300