### PR TITLE
fix: preserve node config whitespace

### DIFF
--- a/packages/platform-ui/src/components/agents/GraphLayout.tsx
+++ b/packages/platform-ui/src/components/agents/GraphLayout.tsx
@@ -770,13 +770,11 @@ export function GraphLayout({ services }: GraphLayoutProps) {
 
       const baseConfig = { ...(node.config ?? {}) } as Record<string, unknown>;
       delete baseConfig.kind;
-      delete baseConfig.title;
       delete baseConfig.template;
 
       const patch = { ...(nextConfig ?? {}) } as Record<string, unknown>;
       const rawTitleUpdate = typeof patch.title === 'string' ? (patch.title as string) : undefined;
       delete patch.kind;
-      delete patch.title;
       delete patch.template;
 
       const updatedConfig: Record<string, unknown> = {
@@ -789,10 +787,9 @@ export function GraphLayout({ services }: GraphLayoutProps) {
       };
 
       if (rawTitleUpdate !== undefined) {
-        const trimmedTitle = rawTitleUpdate.trim();
         const currentTitle = typeof node.title === 'string' ? node.title : '';
-        if (trimmedTitle !== currentTitle) {
-          updates.title = trimmedTitle;
+        if (rawTitleUpdate !== currentTitle) {
+          updates.title = rawTitleUpdate;
         }
       }
 

--- a/packages/platform-ui/src/components/nodeProperties/WorkspaceSection.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/WorkspaceSection.tsx
@@ -177,8 +177,7 @@ export function WorkspaceSection({
               value={cpuLimit ?? ''}
               onChange={(event) => {
                 const rawValue = event.target.value;
-                const normalized = rawValue.trim();
-                onCpuLimitChange(normalized.length > 0 ? normalized : undefined);
+                onCpuLimitChange(rawValue.length > 0 ? rawValue : undefined);
               }}
               size="sm"
             />
@@ -190,8 +189,7 @@ export function WorkspaceSection({
               value={memoryLimit ?? ''}
               onChange={(event) => {
                 const rawValue = event.target.value;
-                const normalized = rawValue.trim();
-                onMemoryLimitChange(normalized.length > 0 ? normalized : undefined);
+                onMemoryLimitChange(rawValue.length > 0 ? rawValue : undefined);
               }}
               size="sm"
             />

--- a/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.tool.test.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.tool.test.tsx
@@ -142,6 +142,36 @@ describe('NodePropertiesSidebar - shell tool', () => {
     await user.click(logToggle);
     expect(onConfigChange).toHaveBeenCalledWith(expect.objectContaining({ logToPid1: false }));
   });
+
+  it('preserves trailing whitespace in the shell tool prompt value', () => {
+    const onConfigChange = vi.fn();
+
+    const config: NodeConfig = {
+      kind: 'Tool',
+      title: 'Shell Tool',
+      template: 'shellTool',
+    } as NodeConfig;
+    const state: NodeState = { status: 'ready' };
+
+    render(
+      <NodePropertiesSidebar
+        config={config}
+        state={state}
+        onConfigChange={onConfigChange}
+        onProvision={vi.fn()}
+        onDeprovision={vi.fn()}
+        canProvision={false}
+        canDeprovision={true}
+        isActionPending={false}
+      />,
+    );
+
+    const promptTextarea = screen.getByPlaceholderText('Describe how shell access should be used...') as HTMLTextAreaElement;
+    onConfigChange.mockClear();
+    fireEvent.change(promptTextarea, { target: { value: 'Run read-only diagnostics ' } });
+
+    expect(onConfigChange.mock.calls.at(-1)?.[0]).toEqual({ prompt: 'Run read-only diagnostics ' });
+  });
 });
 
 describe('NodePropertiesSidebar - manage tool', () => {

--- a/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.workspace.test.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/__tests__/NodePropertiesSidebar.workspace.test.tsx
@@ -137,7 +137,7 @@ describe('NodePropertiesSidebar workspace limits', () => {
       const cpuCalls = onConfigChange.mock.calls.filter((call) =>
         Object.prototype.hasOwnProperty.call(call[0], 'cpu_limit'),
       );
-      expect(cpuCalls.at(-1)?.[0]).toEqual({ cpu_limit: '500m' });
+      expect(cpuCalls.at(-1)?.[0]).toEqual({ cpu_limit: ' 500m ' });
     });
 
     onConfigChange.mockClear();
@@ -156,7 +156,7 @@ describe('NodePropertiesSidebar workspace limits', () => {
       const memoryCalls = onConfigChange.mock.calls.filter((call) =>
         Object.prototype.hasOwnProperty.call(call[0], 'memory_limit'),
       );
-      expect(memoryCalls.at(-1)?.[0]).toEqual({ memory_limit: '1Gi' });
+      expect(memoryCalls.at(-1)?.[0]).toEqual({ memory_limit: ' 1Gi ' });
     });
 
     onConfigChange.mockClear();

--- a/packages/platform-ui/src/components/nodeProperties/index.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/index.tsx
@@ -63,26 +63,9 @@ function NodePropertiesSidebar(props: NodePropertiesSidebarProps) {
 
   const handleConfigChange = useCallback(
     (partial: Partial<NodeConfig>) => {
-      if (!onConfigChange) {
-        return;
-      }
-
-      if (nodeKind !== 'Agent') {
-        onConfigChange(partial);
-        return;
-      }
-
-      if (!Object.prototype.hasOwnProperty.call(partial, 'title')) {
-        onConfigChange(partial);
-        return;
-      }
-
-      const rawTitle = partial.title;
-      const stringTitle = typeof rawTitle === 'string' ? rawTitle : '';
-      const trimmedTitle = stringTitle.trim();
-      onConfigChange({ ...partial, title: trimmedTitle });
+      onConfigChange?.(partial);
     },
-    [nodeKind, onConfigChange],
+    [onConfigChange],
   );
 
   const secretSuggestions = useMemo(() => (Array.isArray(secretKeys) ? secretKeys : []), [secretKeys]);

--- a/packages/platform-ui/src/components/nodeProperties/views/AgentNodeConfigView.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/views/AgentNodeConfigView.tsx
@@ -54,8 +54,7 @@ function AgentNodeConfigContent({ config, onConfigChange, nodeId, graphNodes, gr
     (value: string) => {
       setAgentNameDirty(true);
       setAgentNameInput(value);
-      const trimmed = value.trim();
-      const normalizedNext = trimmed.length > 0 ? trimmed : undefined;
+      const normalizedNext = value.length > 0 ? value : undefined;
       const normalizedCurrent = agentNameValue.length > 0 ? agentNameValue : undefined;
       if (normalizedNext === normalizedCurrent) {
         return;
@@ -66,12 +65,9 @@ function AgentNodeConfigContent({ config, onConfigChange, nodeId, graphNodes, gr
   );
 
   const handleAgentNameBlur = useCallback(() => {
-    const trimmed = agentNameInput.trim();
-    const nextInputValue = trimmed.length > 0 ? trimmed : '';
-    setAgentNameInput(nextInputValue);
     setAgentNameDirty(false);
 
-    const normalizedNext = trimmed.length > 0 ? trimmed : undefined;
+    const normalizedNext = agentNameInput.length > 0 ? agentNameInput : undefined;
     const normalizedCurrent = agentNameValue.length > 0 ? agentNameValue : undefined;
     if (normalizedNext === normalizedCurrent) {
       return;
@@ -84,8 +80,7 @@ function AgentNodeConfigContent({ config, onConfigChange, nodeId, graphNodes, gr
     (value: string) => {
       setAgentRoleDirty(true);
       setAgentRoleInput(value);
-      const trimmed = value.trim();
-      const normalizedNext = trimmed.length > 0 ? trimmed : undefined;
+      const normalizedNext = value.length > 0 ? value : undefined;
       const normalizedCurrent = agentRoleValue.length > 0 ? agentRoleValue : undefined;
       if (normalizedNext === normalizedCurrent) {
         return;
@@ -96,12 +91,9 @@ function AgentNodeConfigContent({ config, onConfigChange, nodeId, graphNodes, gr
   );
 
   const handleAgentRoleBlur = useCallback(() => {
-    const trimmed = agentRoleInput.trim();
-    const nextInputValue = trimmed.length > 0 ? trimmed : '';
-    setAgentRoleInput(nextInputValue);
     setAgentRoleDirty(false);
 
-    const normalizedNext = trimmed.length > 0 ? trimmed : undefined;
+    const normalizedNext = agentRoleInput.length > 0 ? agentRoleInput : undefined;
     const normalizedCurrent = agentRoleValue.length > 0 ? agentRoleValue : undefined;
     if (normalizedNext === normalizedCurrent) {
       return;
@@ -112,7 +104,7 @@ function AgentNodeConfigContent({ config, onConfigChange, nodeId, graphNodes, gr
 
   const handleAgentModelChange = useCallback(
     (value: string) => {
-      onConfigChange?.({ model: value.trim() });
+      onConfigChange?.({ model: value });
     },
     [onConfigChange],
   );
@@ -133,8 +125,7 @@ function AgentNodeConfigContent({ config, onConfigChange, nodeId, graphNodes, gr
 
   const handleAgentRestrictionMessageChange = useCallback(
     (value: string) => {
-      const trimmed = value.trim();
-      onConfigChange?.({ restrictionMessage: trimmed.length > 0 ? trimmed : undefined });
+      onConfigChange?.({ restrictionMessage: value.length > 0 ? value : undefined });
     },
     [onConfigChange],
   );

--- a/packages/platform-ui/src/components/nodeProperties/views/ToolNodeConfigView.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/views/ToolNodeConfigView.tsx
@@ -17,8 +17,7 @@ export function ToolNodeConfigView(props: NodePropertiesViewProps<'Tool'>) {
 
   const handlePromptChange = useCallback(
     (value: string) => {
-      const trimmed = value.trim();
-      onConfigChange?.({ prompt: trimmed.length > 0 ? trimmed : undefined });
+      onConfigChange?.({ prompt: value.length > 0 ? value : undefined });
     },
     [onConfigChange],
   );

--- a/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/CallAgentToolTemplateView.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/CallAgentToolTemplateView.tsx
@@ -28,16 +28,14 @@ export function CallAgentToolTemplateView(props: NodePropertiesViewProps<'Tool'>
 
   const handleDescriptionChange = useCallback(
     (value: string) => {
-      const trimmed = value.trim();
-      onConfigChange?.({ description: trimmed.length > 0 ? trimmed : undefined });
+      onConfigChange?.({ description: value.length > 0 ? value : undefined });
     },
     [onConfigChange],
   );
 
   const handlePromptChange = useCallback(
     (value: string) => {
-      const trimmed = value.trim();
-      onConfigChange?.({ prompt: trimmed.length > 0 ? trimmed : undefined });
+      onConfigChange?.({ prompt: value.length > 0 ? value : undefined });
     },
     [onConfigChange],
   );

--- a/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/GithubCloneRepoToolTemplateView.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/GithubCloneRepoToolTemplateView.tsx
@@ -82,8 +82,7 @@ export function GithubCloneRepoToolTemplateView(props: NodePropertiesViewProps<'
 
   const handlePromptChange = useCallback(
     (value: string) => {
-      const trimmed = value.trim();
-      onConfigChange?.({ prompt: trimmed.length > 0 ? trimmed : undefined });
+      onConfigChange?.({ prompt: value.length > 0 ? value : undefined });
     },
     [onConfigChange],
   );

--- a/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/MemoryToolTemplateView.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/MemoryToolTemplateView.tsx
@@ -20,16 +20,14 @@ export function MemoryToolTemplateView(props: NodePropertiesViewProps<'Tool'>) {
 
   const handleDescriptionChange = useCallback(
     (value: string) => {
-      const trimmed = value.trim();
-      onConfigChange?.({ description: trimmed.length > 0 ? trimmed : undefined });
+      onConfigChange?.({ description: value.length > 0 ? value : undefined });
     },
     [onConfigChange],
   );
 
   const handlePromptChange = useCallback(
     (value: string) => {
-      const trimmed = value.trim();
-      onConfigChange?.({ prompt: trimmed.length > 0 ? trimmed : undefined });
+      onConfigChange?.({ prompt: value.length > 0 ? value : undefined });
     },
     [onConfigChange],
   );

--- a/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/SendSlackMessageToolTemplateView.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/SendSlackMessageToolTemplateView.tsx
@@ -58,8 +58,7 @@ export function SendSlackMessageToolTemplateView(props: NodePropertiesViewProps<
 
   const handlePromptChange = useCallback(
     (value: string) => {
-      const trimmed = value.trim();
-      onConfigChange?.({ prompt: trimmed.length > 0 ? trimmed : undefined });
+      onConfigChange?.({ prompt: value.length > 0 ? value : undefined });
     },
     [onConfigChange],
   );

--- a/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/ShellToolTemplateView.tsx
+++ b/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/ShellToolTemplateView.tsx
@@ -109,8 +109,7 @@ export function ShellToolTemplateView(props: NodePropertiesViewProps<'Tool'>) {
 
   const handlePromptChange = useCallback(
     (value: string) => {
-      const trimmed = value.trim();
-      onConfigChange?.({ prompt: trimmed.length > 0 ? trimmed : undefined } as Partial<NodeConfig>);
+      onConfigChange?.({ prompt: value.length > 0 ? value : undefined } as Partial<NodeConfig>);
     },
     [onConfigChange],
   );

--- a/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/useToolNameField.ts
+++ b/packages/platform-ui/src/components/nodeProperties/views/toolTemplates/useToolNameField.ts
@@ -34,9 +34,7 @@ export function useToolNameField({ config, onConfigChange }: ToolNodeProps): Too
   const handleChange = useCallback(
     (rawValue: string) => {
       setInputValue(rawValue);
-      const normalized = rawValue.trim();
-
-      if (normalized.length === 0) {
+      if (rawValue.length === 0) {
         setInputError(null);
         if (toolName !== '') {
           onConfigChange?.({ name: undefined });
@@ -44,14 +42,14 @@ export function useToolNameField({ config, onConfigChange }: ToolNodeProps): Too
         return;
       }
 
-      if (!isValidToolName(normalized)) {
+      if (!isValidToolName(rawValue)) {
         setInputError('Name must match ^[a-z0-9_]{1,64}$');
         return;
       }
 
       setInputError(null);
-      if (normalized !== toolName) {
-        onConfigChange?.({ name: normalized });
+      if (rawValue !== toolName) {
+        onConfigChange?.({ name: rawValue });
       }
     },
     [onConfigChange, toolName],
@@ -64,4 +62,3 @@ export function useToolNameField({ config, onConfigChange }: ToolNodeProps): Too
     onChange: handleChange,
   } satisfies ToolNameFieldState;
 }
-

--- a/packages/platform-ui/src/features/graph/__tests__/GraphLayout.integration.test.tsx
+++ b/packages/platform-ui/src/features/graph/__tests__/GraphLayout.integration.test.tsx
@@ -452,7 +452,7 @@ describe('GraphLayout', () => {
     const lastCall = updateNode.mock.calls.at(-1);
     expect(lastCall?.[0]).toBe('node-1');
     expect(lastCall?.[1]).toEqual({
-      config: { systemPrompt: 'New prompt' },
+      config: { title: 'Updated Agent', systemPrompt: 'New prompt' },
       title: 'Updated Agent',
     });
 
@@ -526,15 +526,15 @@ describe('GraphLayout', () => {
     await waitFor(() => expect(updateNode).toHaveBeenCalled());
     const payload = updateNode.mock.calls.at(-1)?.[1] as { config: Record<string, unknown>; title?: string };
     expect(payload).toBeDefined();
-    expect(payload?.config).toEqual({ name: 'Atlas', role: 'Navigator' });
-    expect(payload?.title).toBe('');
+    expect(payload?.config).toEqual({ title: '   ', name: 'Atlas', role: 'Navigator' });
+    expect(payload?.title).toBe('   ');
     const sidebarCountBeforeRefresh = sidebarProps.length;
     graph.nodes = graph.nodes.map((node) =>
       node.id === 'node-1'
         ? {
             ...node,
-            title: '',
-            config: { ...(node.config ?? {}), title: '', name: 'Atlas', role: 'Navigator' },
+            title: '   ',
+            config: { ...(node.config ?? {}), title: '   ', name: 'Atlas', role: 'Navigator' },
           }
         : node,
     );
@@ -554,8 +554,8 @@ describe('GraphLayout', () => {
       config: Record<string, unknown>;
       displayTitle?: string;
     };
-    expect(refreshedSidebar.config).toEqual(expect.objectContaining({ title: '' }));
-    expect(refreshedSidebar.displayTitle).toBe('');
+    expect(refreshedSidebar.config).toEqual(expect.objectContaining({ title: '   ' }));
+    expect(refreshedSidebar.displayTitle).toBe('   ');
   });
 
   it('persists agent title edits and restores the saved value after refresh', async () => {
@@ -618,7 +618,10 @@ describe('GraphLayout', () => {
       config: Record<string, unknown>;
       title?: string;
     };
-    expect(payload).toEqual({ config: { name: 'Atlas', role: 'Navigator' }, title: 'Mission Control' });
+    expect(payload).toEqual({
+      config: { title: 'Mission Control', name: 'Atlas', role: 'Navigator' },
+      title: 'Mission Control',
+    });
 
     graph.nodes = graph.nodes.map((node) =>
       node.id === 'node-1'
@@ -712,7 +715,9 @@ describe('GraphLayout', () => {
       config: Record<string, unknown>;
       title?: string;
     };
-    expect(payload).toEqual({ config: { name: 'Voyager', role: 'Pathfinder' } });
+    expect(payload).toEqual({
+      config: { title: 'Mission Control', name: 'Voyager', role: 'Pathfinder' },
+    });
 
     const sidebarCountBeforeRefresh = sidebarProps.length;
     graph.nodes = graph.nodes.map((node) =>
@@ -811,7 +816,7 @@ describe('GraphLayout', () => {
       config: Record<string, unknown>;
       title?: string;
     };
-    expect(payload).toEqual({ config: { name: 'Orion', role: 'Pathfinder' } });
+    expect(payload).toEqual({ config: { title: '', name: 'Orion', role: 'Pathfinder' } });
 
     const sidebarCountBeforeRefresh = sidebarProps.length;
     graph.nodes = graph.nodes.map((node) =>
@@ -1733,14 +1738,14 @@ describe('GraphLayout', () => {
     const lastCall = updateNode.mock.calls.at(-1);
     expect(lastCall?.[0]).toBe('agent-2');
     const payload = lastCall?.[1] as { config: Record<string, unknown>; title?: string };
-    expect(payload.title).toBe('Updated Agent');
+    expect(payload.title).toBe('  Updated Agent  ');
     expect(payload.config).toMatchObject({
+      title: '  Updated Agent  ',
       systemPrompt: 'Updated prompt',
       debounceMs: 325,
       role: 'Navigator',
     });
     expect(payload.config).not.toHaveProperty('kind');
-    expect(payload.config).not.toHaveProperty('title');
     expect(payload.config).not.toHaveProperty('template');
   });
 });


### PR DESCRIPTION
## Summary
- remove trimming logic across agent, tool, workspace node config inputs so raw whitespace is preserved and validation handles errors
- enhance tool name validation/UX to show errors instead of silently trimming, plus align shell/workspace fields with new behavior
- expand NodePropertiesSidebar tests to cover whitespace retention for agent/tool/workspace fields

## Testing
- pnpm --filter platform-ui test
- pnpm lint

Closes #1308