### PR TITLE
ci: skip docker-runner scripts during build

### DIFF
--- a/packages/docker-runner/Dockerfile
+++ b/packages/docker-runner/Dockerfile
@@ -23,7 +23,8 @@ FROM base AS build
 
 COPY . .
 
-RUN pnpm install --filter @agyn/docker-runner... --offline --frozen-lockfile
+# Avoid workspace-wide postinstall/prepare (platform-server runs prisma generate)
+RUN pnpm install --filter @agyn/docker-runner... --offline --frozen-lockfile --ignore-scripts
 
 RUN pnpm --filter @agyn/docker-runner run build
 


### PR DESCRIPTION
## Summary
- skip workspace-wide install scripts when building docker-runner so Prisma generate does not run without Postgres

## Testing
- pnpm --filter @agyn/platform-server lint
- pnpm --filter @agyn/platform-server test -- --runInBand --reporter=basic

Relates to #1313
