### PR TITLE
ci: skip docker-runner scripts during deploy

### DIFF
--- a/packages/docker-runner/Dockerfile
+++ b/packages/docker-runner/Dockerfile
@@ -28,7 +28,8 @@ RUN pnpm install --filter @agyn/docker-runner... --offline --frozen-lockfile --i
 
 RUN pnpm --filter @agyn/docker-runner run build
 
-RUN pnpm deploy --filter @agyn/docker-runner --prod --legacy /opt/app
+# pnpm deploy copies workspace deps and re-runs postinstall/prepare; skip scripts
+RUN PNPM_SKIP_POSTINSTALL=1 PNPM_SKIP_PREPARE=1 npm_config_ignore_scripts=true pnpm deploy --filter @agyn/docker-runner --prod --legacy /opt/app
 
 FROM node:20-slim AS runtime
 


### PR DESCRIPTION
## Summary\n- set PNPM_SKIP_POSTINSTALL/PNPM_SKIP_PREPARE/npm_config_ignore_scripts=true for the deploy layer so pnpm doesn't rerun workspace prepare hooks\n- this keeps docker-runner builds from invoking prisma generate when deploying filtered artifacts\n\nRefs #1313