### PR TITLE
fix(ui): add LLM context history action

### DIFF
--- a/packages/platform-server/__tests__/agents.threads.controller.llm-context.test.ts
+++ b/packages/platform-server/__tests__/agents.threads.controller.llm-context.test.ts
@@ -1,0 +1,93 @@
+import { Test } from '@nestjs/testing';
+import { ValidationPipe, type INestApplication } from '@nestjs/common';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { AgentsThreadsController } from '../src/agents/threads.controller';
+import { AgentsPersistenceService } from '../src/agents/agents.persistence.service';
+import { ThreadCleanupCoordinator } from '../src/agents/threadCleanup.coordinator';
+import { RunEventsService } from '../src/events/run-events.service';
+import { RunSignalsRegistry } from '../src/agents/run-signals.service';
+import { LiveGraphRuntime } from '../src/graph-core/liveGraph.manager';
+import { TemplateRegistry } from '../src/graph-core/templateRegistry';
+import { RemindersService } from '../src/agents/reminders.service';
+
+describe('AgentsThreadsController llm context endpoint', () => {
+  let app: INestApplication;
+
+  const listLlmContextItems = vi.fn(async () => ({
+    items: [
+      {
+        rowId: 'row-1',
+        idx: 3,
+        isNew: false,
+        contextItem: {
+          id: 'ctx-1',
+          role: 'user',
+          contentText: 'hello',
+          contentJson: null,
+          metadata: null,
+          sizeBytes: 5,
+          createdAt: new Date('2025-12-01T00:00:00.000Z').toISOString(),
+        },
+      },
+    ],
+    nextCursor: null,
+  }));
+  const runEventsStub = {
+    listLlmContextItems,
+  } as unknown as RunEventsService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AgentsThreadsController],
+      providers: [
+        { provide: AgentsPersistenceService, useValue: {} },
+        { provide: ThreadCleanupCoordinator, useValue: { closeThreadWithCascade: vi.fn() } },
+        { provide: RunEventsService, useValue: runEventsStub },
+        { provide: RunSignalsRegistry, useValue: { register: vi.fn(), activateTerminate: vi.fn(), clear: vi.fn() } },
+        { provide: LiveGraphRuntime, useValue: { getNodes: vi.fn(() => []) } },
+        { provide: TemplateRegistry, useValue: { getMeta: vi.fn(() => undefined) } satisfies Pick<TemplateRegistry, 'getMeta'> },
+        { provide: RemindersService, useValue: { cancelThreadReminders: vi.fn(), cancelReminder: vi.fn() } },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication(new FastifyAdapter());
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    listLlmContextItems.mockClear();
+  });
+
+  it('parses limit query values for llm context pagination', async () => {
+    const response = await app.getHttpAdapter().getInstance().inject({
+      method: 'GET',
+      url: '/api/agents/runs/run-1/events/event-1/llm-context?limit=100',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toMatchObject({
+      items: [
+        {
+          rowId: 'row-1',
+          idx: 3,
+          isNew: false,
+          contextItem: { id: 'ctx-1', role: 'user' },
+        },
+      ],
+      nextCursor: null,
+    });
+    expect(listLlmContextItems).toHaveBeenCalledWith({
+      runId: 'run-1',
+      eventId: 'event-1',
+      limit: 100,
+      cursor: undefined,
+    });
+  });
+});

--- a/packages/platform-server/__tests__/run-events.context-items.test.ts
+++ b/packages/platform-server/__tests__/run-events.context-items.test.ts
@@ -193,6 +193,52 @@ if (!shouldRunDbTests) {
       await cleanup(thread.id, run.id, Array.from(new Set(ids)));
     });
 
+    it('paginates llm context items newest-first', async () => {
+      const { thread, run } = await createThreadAndRun();
+      const ids = await createContextItems([
+        { role: ContextItemRole.system, contentText: 'system prompt' },
+        { role: ContextItemRole.user, contentText: 'latest user input' },
+        { role: ContextItemRole.assistant, contentText: 'assistant reply' },
+      ]);
+
+      const [systemId, userId, assistantId] = ids;
+      const event = await runEvents.startLLMCall({
+        runId: run.id,
+        threadId: thread.id,
+        contextItemIds: [systemId, userId, assistantId],
+        newContextItemIds: [userId],
+      });
+
+      const firstPage = await runEvents.listLlmContextItems({
+        runId: run.id,
+        eventId: event.id,
+        limit: 2,
+      });
+
+      expect(firstPage).not.toBeNull();
+      expect(firstPage?.items).toHaveLength(2);
+      expect(firstPage?.items.map((item) => item.contextItem.id)).toEqual([assistantId, userId]);
+      expect(firstPage?.items[1]?.isNew).toBe(true);
+      expect(firstPage?.nextCursor).toBeTruthy();
+
+      const nextCursor = firstPage?.nextCursor;
+      if (!nextCursor) throw new Error('Missing cursor for second page');
+
+      const secondPage = await runEvents.listLlmContextItems({
+        runId: run.id,
+        eventId: event.id,
+        limit: 2,
+        cursor: nextCursor,
+      });
+
+      expect(secondPage).not.toBeNull();
+      expect(secondPage?.items).toHaveLength(1);
+      expect(secondPage?.items[0]?.contextItem.id).toBe(systemId);
+      expect(secondPage?.nextCursor).toBeNull();
+
+      await cleanup(thread.id, run.id, Array.from(new Set(ids)));
+    });
+
     it('promotes outputs from call N into call N+1 inputs', async () => {
       const { thread, run } = await createThreadAndRun();
       const createdIds = new Set<string>();

--- a/packages/platform-server/src/agents/threads.controller.ts
+++ b/packages/platform-server/src/agents/threads.controller.ts
@@ -20,7 +20,7 @@ import {
 import { IsBooleanString, IsIn, IsInt, IsOptional, IsString, IsISO8601, Max, Min, ValidateIf } from 'class-validator';
 import { AgentsPersistenceService } from './agents.persistence.service';
 import { RemindersService } from './reminders.service';
-import { Transform, Expose } from 'class-transformer';
+import { Transform, Expose, Type } from 'class-transformer';
 import type { RunEventStatus, RunEventType, RunMessageType, ThreadStatus } from '@prisma/client';
 import { ThreadCleanupCoordinator } from './threadCleanup.coordinator';
 import type { ThreadMetrics } from './threads.metrics.service';
@@ -50,6 +50,15 @@ const isRunEventType = (value: string): value is RunEventType => (RunEventTypeVa
 const isRunEventStatus = (value: string): value is RunEventStatus => (RunEventStatusValues as ReadonlyArray<string>).includes(value);
 
 const THREAD_MESSAGE_MAX_LENGTH = 100000;
+
+const parseLlmContextLimit = (value: unknown): number | undefined => {
+  if (value === undefined || value === null || value === '') return undefined;
+  const parsed = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 200) {
+    throw new BadRequestException({ error: 'bad_limit' });
+  }
+  return parsed;
+};
 
 const collectFilterTokens = (input?: string | string[]): string[] => {
   if (!input) return [];
@@ -144,14 +153,14 @@ export class RunEventOutputQueryDto {
 
 export class RunEventLlmContextQueryDto {
   @IsOptional()
-  @Transform(({ value }) => (value !== undefined ? parseInt(value, 10) : undefined))
+  @Type(() => Number)
   @IsInt()
   @Min(1)
   @Max(200)
   limit?: number;
 
   @IsOptional()
-  @Transform(({ value }) => (value !== undefined ? parseInt(value, 10) : undefined))
+  @Type(() => Number)
   @IsInt()
   @Min(0)
   cursorIdx?: number;
@@ -665,6 +674,7 @@ export class AgentsThreadsController {
     @Param('eventId') eventId: string,
     @Query() query: RunEventLlmContextQueryDto,
   ) {
+    const limit = parseLlmContextLimit(query.limit as unknown);
     if (
       (query.cursorIdx !== undefined && !query.cursorRowId) ||
       (query.cursorIdx === undefined && query.cursorRowId)
@@ -675,7 +685,7 @@ export class AgentsThreadsController {
     const result = await this.runEvents.listLlmContextItems({
       runId,
       eventId,
-      limit: query.limit,
+      limit,
       cursor: query.cursorIdx !== undefined && query.cursorRowId
         ? { idx: query.cursorIdx, rowId: query.cursorRowId }
         : undefined,

--- a/packages/platform-server/src/agents/threads.controller.ts
+++ b/packages/platform-server/src/agents/threads.controller.ts
@@ -142,6 +142,25 @@ export class RunEventOutputQueryDto {
   order?: 'asc' | 'desc';
 }
 
+export class RunEventLlmContextQueryDto {
+  @IsOptional()
+  @Transform(({ value }) => (value !== undefined ? parseInt(value, 10) : undefined))
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => (value !== undefined ? parseInt(value, 10) : undefined))
+  @IsInt()
+  @Min(0)
+  cursorIdx?: number;
+
+  @IsOptional()
+  @IsString()
+  cursorRowId?: string;
+}
+
 export class ListThreadsQueryDto {
   @IsOptional()
   @IsBooleanString()
@@ -638,6 +657,35 @@ export class AgentsThreadsController {
         'Tool output persistence unavailable. Run `pnpm --filter @agyn/platform-server prisma migrate deploy` followed by `pnpm --filter @agyn/platform-server prisma generate` to install the latest schema.',
       );
     }
+  }
+
+  @Get('runs/:runId/events/:eventId/llm-context')
+  async listLlmContextItems(
+    @Param('runId') runId: string,
+    @Param('eventId') eventId: string,
+    @Query() query: RunEventLlmContextQueryDto,
+  ) {
+    if (
+      (query.cursorIdx !== undefined && !query.cursorRowId) ||
+      (query.cursorIdx === undefined && query.cursorRowId)
+    ) {
+      throw new BadRequestException({ error: 'cursor_mismatch' });
+    }
+
+    const result = await this.runEvents.listLlmContextItems({
+      runId,
+      eventId,
+      limit: query.limit,
+      cursor: query.cursorIdx !== undefined && query.cursorRowId
+        ? { idx: query.cursorIdx, rowId: query.cursorRowId }
+        : undefined,
+    });
+
+    if (!result) {
+      throw new NotFoundException({ error: 'event_not_found' });
+    }
+
+    return result;
   }
 
   @Patch('threads/:threadId')

--- a/packages/platform-server/src/events/run-events.service.ts
+++ b/packages/platform-server/src/events/run-events.service.ts
@@ -152,6 +152,14 @@ const RUN_EVENT_STATUSES: ReadonlyArray<RunEventStatus> = [
   RunEventStatus.cancelled,
 ] as const;
 
+export type LlmContextDeltaStatus =
+  | 'available'
+  | 'empty'
+  | 'unavailable'
+  | 'redacted'
+  | 'first_call'
+  | 'unknown';
+
 export type RunTimelineEvent = {
   id: string;
   runId: string;
@@ -175,6 +183,7 @@ export type RunTimelineEvent = {
     topP: number | null;
     stopReason: string | null;
     inputContextItems: LLMInputContextItem[];
+    contextDeltaStatus: LlmContextDeltaStatus;
     responseText: string | null;
     rawResponse: unknown;
     toolCalls: Array<{ callId: string; name: string; arguments: unknown }>;
@@ -742,6 +751,11 @@ export class RunEventsService {
         isNew: Boolean(row.isNew),
       }));
     const linkedToolExecutionIds = event.llmCall?.toolExecutions?.map((exec) => exec.eventId) ?? [];
+    const contextDeltaStatus: LlmContextDeltaStatus = inputContextItems.length === 0
+      ? 'unavailable'
+      : inputContextItems.some((row) => row.isNew)
+        ? 'available'
+        : 'empty';
     const llmCall = event.llmCall
       ? {
           provider: event.llmCall.provider ?? null,
@@ -750,6 +764,7 @@ export class RunEventsService {
           topP: event.llmCall.topP ?? null,
           stopReason: event.llmCall.stopReason ?? null,
           inputContextItems,
+          contextDeltaStatus,
           responseText: event.llmCall.responseText ?? null,
           rawResponse: this.toPlainJson(event.llmCall.rawResponse ?? null),
           toolCalls: event.llmCall.toolCalls.map((tc) => ({

--- a/packages/platform-server/src/events/run-events.service.ts
+++ b/packages/platform-server/src/events/run-events.service.ts
@@ -73,6 +73,23 @@ export type SerializedContextItem = {
   createdAt: string;
 };
 
+export type LlmContextPageCursor = {
+  idx: number;
+  rowId: string;
+};
+
+export type LlmContextPageItem = {
+  rowId: string;
+  idx: number;
+  isNew: boolean;
+  contextItem: SerializedContextItem;
+};
+
+export type LlmContextPage = {
+  items: LlmContextPageItem[];
+  nextCursor: LlmContextPageCursor | null;
+};
+
 type LLMInputContextRole =
   | 'system'
   | 'user'
@@ -1247,6 +1264,87 @@ export class RunEventsService {
       if (found) ordered.push(found);
     }
     return ordered;
+  }
+
+  async listLlmContextItems(params: {
+    runId: string;
+    eventId: string;
+    limit?: number;
+    cursor?: LlmContextPageCursor;
+  }): Promise<LlmContextPage | null> {
+    const event = await this.prisma.runEvent.findFirst({
+      where: {
+        id: params.eventId,
+        runId: params.runId,
+        type: RunEventType.llm_call,
+      },
+      select: { id: true },
+    });
+
+    if (!event) return null;
+
+    const where: Prisma.LLMCallContextItemWhereInput = {
+      llmCallEventId: params.eventId,
+      direction: LLMCallContextItemDirection.input,
+    };
+
+    if (params.cursor) {
+      where.OR = [
+        { idx: { lt: params.cursor.idx } },
+        {
+          AND: [
+            { idx: { equals: params.cursor.idx } },
+            { id: { lt: params.cursor.rowId } },
+          ],
+        },
+      ];
+    }
+
+    const pageLimit = params.limit ?? 50;
+    const rows = await this.prisma.lLMCallContextItem.findMany({
+      where,
+      orderBy: [{ idx: 'desc' }, { id: 'desc' }],
+      take: pageLimit + 1,
+      select: {
+        id: true,
+        idx: true,
+        isNew: true,
+        contextItem: {
+          select: {
+            id: true,
+            role: true,
+            contentText: true,
+            contentJson: true,
+            metadata: true,
+            sizeBytes: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    const slice = rows.slice(0, pageLimit);
+    const items: LlmContextPageItem[] = slice.map((row) => ({
+      rowId: row.id,
+      idx: row.idx,
+      isNew: row.isNew,
+      contextItem: this.serializeContextItem(row.contextItem),
+    }));
+
+    if (items.length === 0) {
+      return { items: [], nextCursor: null };
+    }
+
+    const hasNext = rows.length > pageLimit;
+    const last = items[items.length - 1];
+    const nextCursor = hasNext
+      ? {
+          idx: last.idx,
+          rowId: last.rowId,
+        }
+      : null;
+
+    return { items, nextCursor };
   }
 
   private async createEvent(

--- a/packages/platform-ui/__tests__/components/RunEventDetails.context.test.tsx
+++ b/packages/platform-ui/__tests__/components/RunEventDetails.context.test.tsx
@@ -35,11 +35,11 @@ describe('RunEventDetails context pagination', () => {
     expect(screen.getByText('New message')).toBeInTheDocument();
     expect(screen.queryByText('Older message 1')).not.toBeInTheDocument();
     expect(screen.queryByText('Older message 2')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View context history' })).toBeInTheDocument();
     expect(screen.queryByText('New')).not.toBeInTheDocument();
 
     const container = screen.getByTestId('context-scroll-container');
-    expect(container.firstElementChild?.textContent).toContain('Load more');
+    expect(container.firstElementChild?.textContent).toContain('View context history');
   });
 
   it('reveals older context items in order when loading more', async () => {
@@ -51,7 +51,7 @@ describe('RunEventDetails context pagination', () => {
 
     render(<RunEventDetails event={event} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    fireEvent.click(screen.getByRole('button', { name: 'View context history' }));
 
     await waitFor(() => expect(screen.getByText('Older message 1')).toBeInTheDocument());
     expect(screen.getByText('Older message 2')).toBeInTheDocument();
@@ -73,13 +73,13 @@ describe('RunEventDetails context pagination', () => {
 
     render(<RunEventDetails event={event} />);
 
-    expect(screen.getByText('No new context for this call.')).toBeInTheDocument();
+    expect(screen.getByText('No new context items are marked for this call.')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    fireEvent.click(screen.getByRole('button', { name: 'View context history' }));
 
     await waitFor(() => expect(screen.getByText('Older message 1')).toBeInTheDocument());
     expect(screen.getByText('Older message 2')).toBeInTheDocument();
-    expect(screen.queryByText('No new context for this call.')).not.toBeInTheDocument();
+    expect(screen.queryByText('No new context items are marked for this call.')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
   });
 
@@ -127,7 +127,7 @@ describe('RunEventDetails context pagination', () => {
         configurable: true,
       });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+      fireEvent.click(screen.getByRole('button', { name: 'View context history' }));
 
       currentScrollHeight = 600;
 

--- a/packages/platform-ui/__tests__/components/RunEventDetails.context.test.tsx
+++ b/packages/platform-ui/__tests__/components/RunEventDetails.context.test.tsx
@@ -10,7 +10,7 @@ type ContextRecord = Record<string, unknown> & {
   __agynIsNew?: boolean;
 };
 
-const buildEvent = (context: ContextRecord[]): RunEvent => ({
+const buildEvent = (context: ContextRecord[], contextDeltaStatus?: 'empty' | 'unknown'): RunEvent => ({
   id: 'event-1',
   type: 'llm',
   timestamp: '2024-01-01T00:00:00.000Z',
@@ -19,6 +19,7 @@ const buildEvent = (context: ContextRecord[]): RunEvent => ({
     assistantContext: [],
     response: '',
     toolCalls: [],
+    contextDeltaStatus,
   },
 });
 
@@ -69,17 +70,17 @@ describe('RunEventDetails context pagination', () => {
     const event = buildEvent([
       { id: 'ctx-old-1', role: 'user', content: 'Older message 1' },
       { id: 'ctx-old-2', role: 'user', content: 'Older message 2' },
-    ]);
+    ], 'empty');
 
     render(<RunEventDetails event={event} />);
 
-    expect(screen.getByText('No new context items are marked for this call.')).toBeInTheDocument();
+    expect(screen.getByText('No new context added for this call.')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'View context history' }));
 
     await waitFor(() => expect(screen.getByText('Older message 1')).toBeInTheDocument());
     expect(screen.getByText('Older message 2')).toBeInTheDocument();
-    expect(screen.queryByText('No new context items are marked for this call.')).not.toBeInTheDocument();
+    expect(screen.queryByText('No new context added for this call.')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
   });
 

--- a/packages/platform-ui/src/api/modules/runs.ts
+++ b/packages/platform-ui/src/api/modules/runs.ts
@@ -2,6 +2,8 @@ import { http, asData } from '@/api/http';
 import type {
   RunMessageItem,
   RunMeta,
+  LlmContextPage,
+  LlmContextPageCursor,
   RunTimelineEventsResponse,
   RunTimelineSummary,
   RunTimelineTotalsResponse,
@@ -63,6 +65,23 @@ export const runs = {
             order: params?.order ?? 'asc',
             ...(params?.sinceSeq !== undefined ? { sinceSeq: params.sinceSeq } : {}),
             ...(params?.limit !== undefined ? { limit: params.limit } : {}),
+          },
+        },
+      ),
+    ),
+  llmContext: (
+    runId: string,
+    eventId: string,
+    params?: { limit?: number; cursor?: LlmContextPageCursor | null },
+  ) =>
+    asData<LlmContextPage>(
+      http.get<LlmContextPage>(
+        `/api/agents/runs/${encodeURIComponent(runId)}/events/${encodeURIComponent(eventId)}/llm-context`,
+        {
+          params: {
+            ...(params?.limit !== undefined ? { limit: params.limit } : {}),
+            ...(params?.cursor?.idx !== undefined ? { cursorIdx: params.cursor.idx } : {}),
+            ...(params?.cursor?.rowId !== undefined ? { cursorRowId: params.cursor.rowId } : {}),
           },
         },
       ),

--- a/packages/platform-ui/src/api/types/agents.ts
+++ b/packages/platform-ui/src/api/types/agents.ts
@@ -74,6 +74,8 @@ export type LlmContextPage = {
   nextCursor: LlmContextPageCursor | null;
 };
 
+export type LlmContextDeltaStatus = 'available' | 'empty' | 'unavailable' | 'redacted' | 'first_call' | 'unknown';
+
 export type RunEventType = 'invocation_message' | 'injection' | 'llm_call' | 'tool_execution' | 'summarization';
 export type RunEventStatus = 'pending' | 'running' | 'success' | 'error' | 'cancelled';
 export type EventSourceKind = 'internal' | 'tracing';
@@ -123,6 +125,7 @@ export type RunTimelineEvent = {
       createdAt: string;
       isNew?: boolean;
     }>;
+    contextDeltaStatus: LlmContextDeltaStatus;
     responseText: string | null;
     rawResponse: unknown;
     toolCalls: Array<{ callId: string; name: string; arguments: unknown }>;

--- a/packages/platform-ui/src/api/types/agents.ts
+++ b/packages/platform-ui/src/api/types/agents.ts
@@ -57,6 +57,23 @@ export type ContextItem = {
   createdAt: string;
 };
 
+export type LlmContextPageCursor = {
+  idx: number;
+  rowId: string;
+};
+
+export type LlmContextPageItem = {
+  rowId: string;
+  idx: number;
+  isNew: boolean;
+  contextItem: ContextItem;
+};
+
+export type LlmContextPage = {
+  items: LlmContextPageItem[];
+  nextCursor: LlmContextPageCursor | null;
+};
+
 export type RunEventType = 'invocation_message' | 'injection' | 'llm_call' | 'tool_execution' | 'summarization';
 export type RunEventStatus = 'pending' | 'running' | 'success' | 'error' | 'cancelled';
 export type EventSourceKind = 'internal' | 'tracing';

--- a/packages/platform-ui/src/components/RunEventDetails.tsx
+++ b/packages/platform-ui/src/components/RunEventDetails.tsx
@@ -216,12 +216,17 @@ export interface RunEventData extends Record<string, unknown> {
   oldContext?: unknown;
   newContext?: unknown;
   summary?: string;
+  contextDelta?: {
+    status?: ContextDeltaStatus;
+  };
+  contextDeltaStatus?: ContextDeltaStatus;
 }
 
 export type EventType = 'message' | 'llm' | 'tool' | 'summarization';
 export type ToolSubtype = 'generic' | 'shell' | 'manage' | string;
 export type MessageSubtype = 'source' | 'intermediate' | 'result';
 export type OutputViewMode = 'text' | 'terminal' | 'markdown' | 'json' | 'yaml';
+export type ContextDeltaStatus = 'available' | 'empty' | 'unavailable' | 'redacted' | 'first_call' | 'unknown';
 
 export interface RunEventDetailsProps {
   event: RunEvent;
@@ -532,6 +537,12 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
     const toolCalls = Array.isArray(event.data.toolCalls)
       ? event.data.toolCalls.filter(isRecord)
       : [];
+    const contextDeltaStatus = event.data.contextDelta?.status ?? event.data.contextDeltaStatus ?? 'unknown';
+    const emptyContextMessage = contextDeltaStatus === 'empty'
+      ? 'No new context added for this call.'
+      : contextDeltaStatus === 'first_call'
+        ? 'This is the first call in the run.'
+        : 'Context delta is not available for this call.';
     const showEmptyContext = context.length === 0;
     const showHistoryButton = !contextOlderError && (contextOlderVisibleCount === 0 || hasOlderContextRemaining);
     const historyButtonLabel = contextOlderVisibleCount > 0 ? 'Load more' : 'View context history';
@@ -608,7 +619,7 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
                   </button>
                 )}
                 {showEmptyContext ? (
-                  <div className="text-sm text-[var(--agyn-gray)]">No new context items are marked for this call.</div>
+                  <div className="text-sm text-[var(--agyn-gray)]">{emptyContextMessage}</div>
                 ) : (
                   <div className="flex flex-col">
                     {renderContextMessages(context)}

--- a/packages/platform-ui/src/components/RunEventDetails.tsx
+++ b/packages/platform-ui/src/components/RunEventDetails.tsx
@@ -243,6 +243,7 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
   const [contextOlderVisibleCount, setContextOlderVisibleCount] = useState(0);
   const [contextOlderLoading, setContextOlderLoading] = useState(false);
   const [contextOlderError, setContextOlderError] = useState<string | null>(null);
+  const [contextHistoryNotice, setContextHistoryNotice] = useState<string | null>(null);
   const loadMoreResetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const contextScrollRef = useRef<HTMLDivElement | null>(null);
   const pendingScrollAnchor = useRef<{ previousHeight: number; previousScrollTop: number } | null>(null);
@@ -291,6 +292,7 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
     setContextOlderVisibleCount(0);
     setContextOlderLoading(false);
     setContextOlderError(null);
+    setContextHistoryNotice(null);
     if (loadMoreResetTimeout.current !== null) {
       clearTimeout(loadMoreResetTimeout.current);
       loadMoreResetTimeout.current = null;
@@ -312,10 +314,6 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
 
   const handleLoadMoreContext = useCallback(() => {
     if (contextOlderLoading) return;
-    if (olderContextEntries.length === 0) {
-      setContextOlderError('Failed to load older context.');
-      return;
-    }
     const container = contextScrollRef.current;
     if (container) {
       pendingScrollAnchor.current = {
@@ -379,6 +377,16 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
     setContextOlderError(null);
     handleLoadMoreContext();
   }, [contextOlderLoading, handleLoadMoreContext]);
+
+  const handleViewContextHistory = useCallback(() => {
+    if (contextOlderLoading) return;
+    setContextHistoryNotice(null);
+    if (olderContextEntries.length === 0) {
+      setContextHistoryNotice('No context history available for this call.');
+      return;
+    }
+    handleLoadMoreContext();
+  }, [contextOlderLoading, olderContextEntries.length, handleLoadMoreContext]);
 
   const isShellToolEvent =
     event.type === 'tool' &&
@@ -525,7 +533,8 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
       ? event.data.toolCalls.filter(isRecord)
       : [];
     const showEmptyContext = context.length === 0;
-    const showLoadMoreButton = hasOlderContextRemaining && !contextOlderError;
+    const showHistoryButton = !contextOlderError && (contextOlderVisibleCount === 0 || hasOlderContextRemaining);
+    const historyButtonLabel = contextOlderVisibleCount > 0 ? 'Load more' : 'View context history';
 
     return (
       <div className="space-y-6 h-full flex flex-col">
@@ -588,22 +597,25 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
                 ref={contextScrollRef}
                 data-testid="context-scroll-container"
               >
-                {showLoadMoreButton && (
+                {showHistoryButton && (
                   <button
                     type="button"
-                    onClick={handleLoadMoreContext}
+                    onClick={handleViewContextHistory}
                     disabled={contextOlderLoading}
                     className="mb-4 w-full text-sm text-[var(--agyn-blue)] hover:text-[var(--agyn-blue)]/80 py-2 border border-[var(--agyn-border-subtle)] rounded-[6px] transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
                   >
-                    {contextOlderLoading ? 'Loading…' : 'Load more'}
+                    {contextOlderLoading ? 'Loading…' : historyButtonLabel}
                   </button>
                 )}
                 {showEmptyContext ? (
-                  <div className="text-sm text-[var(--agyn-gray)]">No new context for this call.</div>
+                  <div className="text-sm text-[var(--agyn-gray)]">No new context items are marked for this call.</div>
                 ) : (
                   <div className="flex flex-col">
                     {renderContextMessages(context)}
                   </div>
+                )}
+                {contextHistoryNotice && (
+                  <div className="mt-3 text-sm text-[var(--agyn-gray)]">{contextHistoryNotice}</div>
                 )}
                 {contextOlderError && (
                   <div className="mt-4 border border-[var(--agyn-border-subtle)] rounded-[6px] p-3 bg-[var(--agyn-bg-light)]">

--- a/packages/platform-ui/src/components/RunEventDetails.tsx
+++ b/packages/platform-ui/src/components/RunEventDetails.tsx
@@ -228,9 +228,17 @@ export type MessageSubtype = 'source' | 'intermediate' | 'result';
 export type OutputViewMode = 'text' | 'terminal' | 'markdown' | 'json' | 'yaml';
 export type ContextDeltaStatus = 'available' | 'empty' | 'unavailable' | 'redacted' | 'first_call' | 'unknown';
 
+export type ContextPaginationState = {
+  hasMore: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
 export interface RunEventDetailsProps {
   event: RunEvent;
   runId?: string;
+  contextPagination?: ContextPaginationState;
+  onLoadOlderContext?: (eventId: string) => Promise<{ addedCount: number; hasMore: boolean }>;
 }
 
 export interface RunEvent {
@@ -242,16 +250,18 @@ export interface RunEvent {
   data: RunEventData;
 }
 
-export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
+export function RunEventDetails({ event, runId, contextPagination, onLoadOlderContext }: RunEventDetailsProps) {
   const [outputViewMode, setOutputViewMode] = useState<OutputViewMode>('text');
   const [expandedToolCalls, setExpandedToolCalls] = useState<Set<string>>(new Set());
   const [contextOlderVisibleCount, setContextOlderVisibleCount] = useState(0);
   const [contextOlderLoading, setContextOlderLoading] = useState(false);
   const [contextOlderError, setContextOlderError] = useState<string | null>(null);
   const [contextHistoryNotice, setContextHistoryNotice] = useState<string | null>(null);
-  const loadMoreResetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const contextScrollRef = useRef<HTMLDivElement | null>(null);
   const pendingScrollAnchor = useRef<{ previousHeight: number; previousScrollTop: number } | null>(null);
+  const pendingContextLoadRef = useRef(false);
+  const contextPaginationLoading = contextPagination?.isLoading ?? false;
+  const contextPaginationHasMore = contextPagination?.hasMore ?? false;
 
   const contextRecordsOrdered = useMemo(() => {
     if (event.type !== 'llm') return [] as Record<string, unknown>[];
@@ -298,11 +308,8 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
     setContextOlderLoading(false);
     setContextOlderError(null);
     setContextHistoryNotice(null);
-    if (loadMoreResetTimeout.current !== null) {
-      clearTimeout(loadMoreResetTimeout.current);
-      loadMoreResetTimeout.current = null;
-    }
     pendingScrollAnchor.current = null;
+    pendingContextLoadRef.current = false;
   }, [event.id]);
 
   useEffect(() => {
@@ -310,15 +317,14 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
   }, [olderContextEntries.length]);
 
   useEffect(() => {
-    return () => {
-      if (loadMoreResetTimeout.current !== null) {
-        clearTimeout(loadMoreResetTimeout.current);
-      }
-    };
-  }, []);
+    if (!contextPagination?.error) return;
+    setContextOlderError('Failed to load older context.');
+    setContextOlderLoading(false);
+    pendingContextLoadRef.current = false;
+  }, [contextPagination?.error]);
 
-  const handleLoadMoreContext = useCallback(() => {
-    if (contextOlderLoading) return;
+  const handleLoadMoreContext = useCallback(async () => {
+    if (contextOlderLoading || contextPaginationLoading) return;
     const container = contextScrollRef.current;
     if (container) {
       pendingScrollAnchor.current = {
@@ -330,32 +336,59 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
     }
     setContextOlderLoading(true);
     setContextOlderError(null);
-    try {
-      const nextCount = Math.min(contextOlderVisibleCount + CONTEXT_PAGINATION_PAGE_SIZE, olderContextEntries.length);
-      if (nextCount <= contextOlderVisibleCount) {
-        throw new Error('No additional context available');
-      }
+    setContextHistoryNotice(null);
+
+    const nextCount = Math.min(contextOlderVisibleCount + CONTEXT_PAGINATION_PAGE_SIZE, olderContextEntries.length);
+    if (nextCount > contextOlderVisibleCount) {
       setContextOlderVisibleCount(nextCount);
-      if (loadMoreResetTimeout.current !== null) {
-        clearTimeout(loadMoreResetTimeout.current);
-      }
-      loadMoreResetTimeout.current = setTimeout(() => {
-        setContextOlderLoading(false);
-        loadMoreResetTimeout.current = null;
-      }, 0);
+      setContextOlderLoading(false);
+      return;
+    }
+
+    if (!onLoadOlderContext || !contextPaginationHasMore) {
+      setContextHistoryNotice('No context history available for this call.');
+      setContextOlderLoading(false);
+      pendingScrollAnchor.current = null;
+      return;
+    }
+
+    try {
+      pendingContextLoadRef.current = true;
+      await onLoadOlderContext(event.id);
     } catch (error) {
       console.error('Failed to load older context', error);
       setContextOlderError('Failed to load older context.');
+      pendingContextLoadRef.current = false;
+      setContextOlderLoading(false);
       pendingScrollAnchor.current = null;
-      if (loadMoreResetTimeout.current !== null) {
-        clearTimeout(loadMoreResetTimeout.current);
-      }
-      loadMoreResetTimeout.current = setTimeout(() => {
-        setContextOlderLoading(false);
-        loadMoreResetTimeout.current = null;
-      }, 0);
     }
-  }, [contextOlderLoading, olderContextEntries.length, contextOlderVisibleCount]);
+  }, [
+    contextOlderLoading,
+    contextPaginationLoading,
+    contextOlderVisibleCount,
+    olderContextEntries.length,
+    onLoadOlderContext,
+    contextPaginationHasMore,
+    event.id,
+  ]);
+
+  useEffect(() => {
+    if (!pendingContextLoadRef.current) return;
+    if (contextPaginationLoading) return;
+    const nextCount = Math.min(contextOlderVisibleCount + CONTEXT_PAGINATION_PAGE_SIZE, olderContextEntries.length);
+    if (nextCount > contextOlderVisibleCount) {
+      setContextOlderVisibleCount(nextCount);
+    } else if (!contextPaginationHasMore) {
+      setContextHistoryNotice('No context history available for this call.');
+    }
+    setContextOlderLoading(false);
+    pendingContextLoadRef.current = false;
+  }, [
+    contextOlderVisibleCount,
+    olderContextEntries.length,
+    contextPaginationLoading,
+    contextPaginationHasMore,
+  ]);
 
   useLayoutEffect(() => {
     const container = contextScrollRef.current;
@@ -378,20 +411,26 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
   }, [visibleContextRecords]);
 
   const handleRetryLoadMore = useCallback(() => {
-    if (contextOlderLoading) return;
+    if (contextOlderLoading || contextPaginationLoading) return;
     setContextOlderError(null);
     handleLoadMoreContext();
-  }, [contextOlderLoading, handleLoadMoreContext]);
+  }, [contextOlderLoading, contextPaginationLoading, handleLoadMoreContext]);
 
   const handleViewContextHistory = useCallback(() => {
-    if (contextOlderLoading) return;
+    if (contextOlderLoading || contextPaginationLoading) return;
     setContextHistoryNotice(null);
-    if (olderContextEntries.length === 0) {
+    if (olderContextEntries.length === 0 && !contextPaginationHasMore) {
       setContextHistoryNotice('No context history available for this call.');
       return;
     }
     handleLoadMoreContext();
-  }, [contextOlderLoading, olderContextEntries.length, handleLoadMoreContext]);
+  }, [
+    contextOlderLoading,
+    contextPaginationLoading,
+    olderContextEntries.length,
+    contextPaginationHasMore,
+    handleLoadMoreContext,
+  ]);
 
   const isShellToolEvent =
     event.type === 'tool' &&
@@ -544,7 +583,8 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
         ? 'This is the first call in the run.'
         : 'Context delta is not available for this call.';
     const showEmptyContext = context.length === 0;
-    const showHistoryButton = !contextOlderError && (contextOlderVisibleCount === 0 || hasOlderContextRemaining);
+    const contextLoadInProgress = contextOlderLoading || contextPaginationLoading;
+    const showHistoryButton = !contextOlderError && (contextOlderVisibleCount === 0 || hasOlderContextRemaining || contextPaginationHasMore);
     const historyButtonLabel = contextOlderVisibleCount > 0 ? 'Load more' : 'View context history';
 
     return (
@@ -612,10 +652,10 @@ export function RunEventDetails({ event, runId }: RunEventDetailsProps) {
                   <button
                     type="button"
                     onClick={handleViewContextHistory}
-                    disabled={contextOlderLoading}
+                    disabled={contextLoadInProgress}
                     className="mb-4 w-full text-sm text-[var(--agyn-blue)] hover:text-[var(--agyn-blue)]/80 py-2 border border-[var(--agyn-border-subtle)] rounded-[6px] transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
                   >
-                    {contextOlderLoading ? 'Loading…' : historyButtonLabel}
+                    {contextLoadInProgress ? 'Loading…' : historyButtonLabel}
                   </button>
                 )}
                 {showEmptyContext ? (

--- a/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
@@ -46,9 +46,9 @@ describe('RunEventDetails – LLM outputs', () => {
     const assistantPanel = screen.getByTestId('assistant-context-panel');
     expect(within(assistantPanel).getByText('Persisted assistant output')).toBeInTheDocument();
     expect(within(assistantPanel).getByText('Reasoning tokens: 88')).toBeInTheDocument();
-    expect(screen.getByText('No new context for this call.')).toBeInTheDocument();
+    expect(screen.getByText('No new context items are marked for this call.')).toBeInTheDocument();
 
-    const loadMoreButton = screen.getByRole('button', { name: 'Load more' });
+    const loadMoreButton = screen.getByRole('button', { name: 'View context history' });
     fireEvent.click(loadMoreButton);
 
     await waitFor(() => {

--- a/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
+++ b/packages/platform-ui/src/components/__tests__/RunEventDetails.llmOutputs.test.tsx
@@ -46,7 +46,7 @@ describe('RunEventDetails – LLM outputs', () => {
     const assistantPanel = screen.getByTestId('assistant-context-panel');
     expect(within(assistantPanel).getByText('Persisted assistant output')).toBeInTheDocument();
     expect(within(assistantPanel).getByText('Reasoning tokens: 88')).toBeInTheDocument();
-    expect(screen.getByText('No new context items are marked for this call.')).toBeInTheDocument();
+    expect(screen.getByText('Context delta is not available for this call.')).toBeInTheDocument();
 
     const loadMoreButton = screen.getByRole('button', { name: 'View context history' });
     fireEvent.click(loadMoreButton);

--- a/packages/platform-ui/src/components/screens/RunScreen.tsx
+++ b/packages/platform-ui/src/components/screens/RunScreen.tsx
@@ -16,7 +16,7 @@ import {
 import type { ReactNode } from 'react';
 import { Button } from '../Button';
 import { IconButton } from '../IconButton';
-import { RunEventDetails } from '../RunEventDetails';
+import { RunEventDetails, type ContextPaginationState } from '../RunEventDetails';
 import { type RunEvent, RunEventsList } from '../RunEventsList';
 import { type Status, StatusIndicator } from '../StatusIndicator';
 import {
@@ -53,6 +53,7 @@ interface RunScreenProps {
   };
   events: RunEvent[];
   selectedEventId: string | null;
+  contextPagination?: ContextPaginationState;
   isFollowing: boolean;
   eventFilters: EventFilter[];
   statusFilters: StatusFilter[];
@@ -70,6 +71,7 @@ interface RunScreenProps {
   onTokensPopoverOpenChange: (open: boolean) => void;
   onRunsPopoverOpenChange: (open: boolean) => void;
   onLoadMoreEvents?: () => void;
+  onLoadOlderContext?: (eventId: string) => Promise<{ addedCount: number; hasMore: boolean }>;
   onTerminate?: () => void;
   onBack?: () => void;
   className?: string;
@@ -84,6 +86,7 @@ export default function RunScreen({
   tokens,
   events,
   selectedEventId,
+  contextPagination,
   isFollowing,
   eventFilters,
   statusFilters,
@@ -101,6 +104,7 @@ export default function RunScreen({
   onTokensPopoverOpenChange,
   onRunsPopoverOpenChange,
   onLoadMoreEvents,
+  onLoadOlderContext,
   onTerminate,
   onBack,
   className = '',
@@ -240,7 +244,14 @@ export default function RunScreen({
       );
     }
 
-    return <RunEventDetails event={selectedEvent} runId={runId} />;
+    return (
+      <RunEventDetails
+        event={selectedEvent}
+        runId={runId}
+        contextPagination={contextPagination}
+        onLoadOlderContext={onLoadOlderContext}
+      />
+    );
   };
 
   return (

--- a/packages/platform-ui/src/lib/llmContext.ts
+++ b/packages/platform-ui/src/lib/llmContext.ts
@@ -1,0 +1,237 @@
+import type { ContextItem } from '@/api/types/agents';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export function coerceRecord(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
+
+export function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch (_error) {
+    return value;
+  }
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export function toRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  const result: Record<string, unknown>[] = [];
+  for (const item of value) {
+    const record = coerceRecord(item);
+    if (record) result.push(record);
+  }
+  return result;
+}
+
+export function normalizeMetadata(value: unknown): Record<string, unknown> | null {
+  const parsed = parseMaybeJson(value);
+  return coerceRecord(parsed);
+}
+
+export function parseContextItemContent(item: ContextItem): {
+  parsed: unknown;
+  record: Record<string, unknown> | null;
+  text: string | null;
+} {
+  const parsedContent = item.contentJson ?? (isNonEmptyString(item.contentText) ? parseMaybeJson(item.contentText) : undefined);
+  const record = coerceRecord(parsedContent);
+
+  const stringCandidates: Array<string | null> = [];
+  if (record && typeof record.content === 'string' && record.content.length > 0) stringCandidates.push(record.content);
+  if (record && typeof record.response === 'string' && record.response.length > 0) stringCandidates.push(record.response);
+  if (typeof parsedContent === 'string' && parsedContent.length > 0) stringCandidates.push(parsedContent);
+  if (isNonEmptyString(item.contentText)) stringCandidates.push(item.contentText);
+
+  const text = stringCandidates.find((candidate): candidate is string => typeof candidate === 'string' && candidate.trim().length > 0) ?? null;
+
+  return { parsed: parsedContent, record, text };
+}
+
+export function collectToolCalls(
+  primary: Record<string, unknown> | null,
+  primaryAdditionalKwargs: Record<string, unknown> | null,
+  metadata: Record<string, unknown> | null,
+  metadataAdditionalKwargs: Record<string, unknown> | null,
+): Record<string, unknown>[] {
+  const seen = new Set<string>();
+  const result: Record<string, unknown>[] = [];
+
+  const addRecords = (value: unknown) => {
+    if (value === undefined || value === null) return;
+    const normalized = typeof value === 'string' ? parseMaybeJson(value) : value;
+    for (const record of toRecordArray(normalized)) {
+      const key = (() => {
+        try {
+          return JSON.stringify(record);
+        } catch (_err) {
+          return undefined;
+        }
+      })();
+      if (key && seen.has(key)) continue;
+      if (key) seen.add(key);
+      result.push(record);
+    }
+  };
+
+  if (primary) {
+    addRecords(primary.tool_calls);
+    addRecords(primary.toolCalls);
+  }
+  if (primaryAdditionalKwargs) {
+    addRecords(primaryAdditionalKwargs.tool_calls);
+    addRecords(primaryAdditionalKwargs.toolCalls);
+  }
+  if (metadata) {
+    addRecords(metadata.tool_calls);
+    addRecords(metadata.toolCalls);
+  }
+  if (metadataAdditionalKwargs) {
+    addRecords(metadataAdditionalKwargs.tool_calls);
+    addRecords(metadataAdditionalKwargs.toolCalls);
+  }
+
+  const synthesizeFromOutput = (container?: Record<string, unknown> | null) => {
+    if (!container) return;
+    const outputEntries = Array.isArray(container.output) ? (container.output as unknown[]) : [];
+    for (const entry of outputEntries) {
+      const rec = coerceRecord(entry);
+      if (!rec) continue;
+      if (rec.type !== 'function_call') continue;
+
+      const funcRec = coerceRecord(rec.function);
+      const rawArgs = rec.arguments ?? funcRec?.arguments;
+      const normArgs = typeof rawArgs === 'string' ? parseMaybeJson(rawArgs) : rawArgs;
+
+      const synthesized: Record<string, unknown> = {
+        callId: isNonEmptyString(rec.call_id)
+          ? rec.call_id
+          : isNonEmptyString(rec.id)
+            ? rec.id
+            : undefined,
+        name: isNonEmptyString(rec.name)
+          ? rec.name
+          : isNonEmptyString(funcRec?.name)
+            ? funcRec.name
+            : undefined,
+        arguments: normArgs,
+      };
+
+      const key = (() => {
+        try {
+          return JSON.stringify(synthesized);
+        } catch (_err) {
+          return undefined;
+        }
+      })();
+      if (key && seen.has(key)) continue;
+      if (key) seen.add(key);
+      result.push(synthesized);
+    }
+  };
+
+  synthesizeFromOutput(primary);
+  synthesizeFromOutput(primaryAdditionalKwargs);
+  synthesizeFromOutput(metadata);
+  synthesizeFromOutput(metadataAdditionalKwargs);
+
+  return result;
+}
+
+export function extractReasoning(
+  primary: Record<string, unknown> | null,
+  primaryAdditionalKwargs: Record<string, unknown> | null,
+  metadata: Record<string, unknown> | null,
+  metadataAdditionalKwargs: Record<string, unknown> | null,
+): unknown {
+  const candidates: unknown[] = [];
+  if (primary) candidates.push(primary.reasoning);
+  if (primaryAdditionalKwargs) candidates.push(primaryAdditionalKwargs.reasoning);
+  if (metadata) candidates.push(metadata.reasoning);
+  if (metadataAdditionalKwargs) candidates.push(metadataAdditionalKwargs.reasoning);
+
+  for (const candidate of candidates) {
+    if (candidate === undefined) continue;
+    if (candidate === null) return null;
+    if (typeof candidate === 'string') {
+      const parsed = parseMaybeJson(candidate);
+      return parsed;
+    }
+    return candidate;
+  }
+
+  return undefined;
+}
+
+export function toContextRecord(item: ContextItem): Record<string, unknown> {
+  const metadataRecord = normalizeMetadata(item.metadata);
+  const metadataAdditionalKwargs = metadataRecord ? coerceRecord(metadataRecord.additional_kwargs) : null;
+  const { parsed: parsedContent, record: parsedRecord, text: textContent } = parseContextItemContent(item);
+  const contentAdditionalKwargs = parsedRecord ? coerceRecord(parsedRecord.additional_kwargs) : null;
+
+  const result: Record<string, unknown> = parsedRecord ? { ...parsedRecord } : {};
+
+  if (!isNonEmptyString(result.id)) {
+    result.id = item.id;
+  }
+  result.role = typeof result.role === 'string' && result.role.length > 0 ? result.role : item.role;
+  result.timestamp = result.timestamp ?? item.createdAt;
+  result.sizeBytes = item.sizeBytes;
+  result.contentJson = parsedContent;
+  result.metadata = metadataRecord ?? item.metadata;
+
+  const normalizedText = typeof textContent === 'string' && textContent.length > 0
+    ? textContent
+    : isNonEmptyString(item.contentText)
+      ? item.contentText
+      : null;
+
+  if (normalizedText !== null) {
+    result.contentText = normalizedText;
+  } else if ('contentText' in result && typeof result.contentText !== 'string') {
+    delete result.contentText;
+  }
+
+  const hasStringContent = typeof normalizedText === 'string' && normalizedText.length > 0;
+
+  if (result.role === 'assistant') {
+    if (hasStringContent) {
+      result.content = normalizedText;
+      if (typeof result.response !== 'string' || result.response.length === 0) {
+        result.response = normalizedText;
+      }
+    } else {
+      if (typeof result.content !== 'string') delete result.content;
+      if (typeof result.response !== 'string') delete result.response;
+    }
+  } else if (hasStringContent) {
+    if (typeof result.content !== 'string' || result.content.length === 0) {
+      result.content = normalizedText;
+    }
+  }
+
+  const mergedAdditionalKwargs = contentAdditionalKwargs ?? metadataAdditionalKwargs;
+  if (mergedAdditionalKwargs) {
+    result.additional_kwargs = mergedAdditionalKwargs;
+  }
+
+  const toolCalls = collectToolCalls(parsedRecord, contentAdditionalKwargs, metadataRecord, metadataAdditionalKwargs);
+
+  if (toolCalls.length > 0) {
+    result.tool_calls = toolCalls;
+    result.toolCalls = toolCalls;
+  }
+
+  const reasoning = extractReasoning(parsedRecord, contentAdditionalKwargs, metadataRecord, metadataAdditionalKwargs);
+  if (reasoning !== undefined) {
+    result.reasoning = reasoning;
+  }
+
+  return result;
+}

--- a/packages/platform-ui/src/pages/AgentsRunScreen.tsx
+++ b/packages/platform-ui/src/pages/AgentsRunScreen.tsx
@@ -575,6 +575,7 @@ function createUiEvent(event: RunTimelineEvent, options?: CreateUiEventOptions):
         response,
         assistantContext,
         model: event.llmCall?.model ?? undefined,
+        contextDeltaStatus: event.llmCall?.contextDeltaStatus,
         tokens: usage
           ? {
               input: usage.inputTokens ?? undefined,
@@ -712,6 +713,7 @@ export function AgentsRunScreen() {
     },
     [setSearchParams],
   );
+  const selectedEventId = searchParams.get('eventId');
 
   const isMdUp = useMediaQuery('(min-width: 768px)');
   const [liveMessage, setLiveMessage] = useState('');
@@ -987,17 +989,6 @@ export function AgentsRunScreen() {
   );
 
   useEffect(() => {
-    if (!runId) return;
-    if (allEvents.length === 0) return;
-    for (const event of allEvents) {
-      if (event.type !== 'llm_call') continue;
-      const state = contextStateRef.current.get(event.id);
-      if (state?.hasFetched || state?.isLoading) continue;
-      void loadContextPage(event.id, null);
-    }
-  }, [allEvents, runId, loadContextPage]);
-
-  useEffect(() => {
     setEvents((prev) => {
       const next = allEvents.filter((event) => matchesFilters(event, selectedTypes, selectedStatuses));
       if (areEventListsEqual(prev, next)) return prev;
@@ -1080,6 +1071,18 @@ export function AgentsRunScreen() {
       });
     }
   }, [eventsQuery.data, updateEventsState, updateCursor, updateOlderCursor]);
+
+  useEffect(() => {
+    if (!runId) return;
+    if (!selectedEventId) return;
+    const selectedEvent =
+      allEvents.find((event) => event.id === selectedEventId) ??
+      eventsQuery.data?.items?.find((event) => event.id === selectedEventId);
+    if (!selectedEvent || selectedEvent.type !== 'llm_call') return;
+    const state = contextStateRef.current.get(selectedEvent.id);
+    if (state?.hasFetched || state?.isLoading) return;
+    void loadContextPage(selectedEvent.id, null);
+  }, [allEvents, runId, selectedEventId, loadContextPage, eventsQuery.data]);
 
   const fetchSinceCursor = useCallback(() => {
     if (!runId) return Promise.resolve();
@@ -1259,13 +1262,18 @@ export function AgentsRunScreen() {
     };
   }, [runId, summaryQuery, updateEventsState, updateCursor, fetchSinceCursor, scheduleTotalsRefetch]);
 
-  const selectedEventId = searchParams.get('eventId');
-
   useEffect(() => {
     if (!events.length) return;
-    if (!followRef.current) return;
     const latest = events[events.length - 1];
-    if (latest && latest.id !== selectedEventId) {
+    if (!latest) return;
+    if (!selectedEventId) {
+      updateSearchParams((params) => {
+        params.set('eventId', latest.id);
+      });
+      return;
+    }
+    if (!followRef.current) return;
+    if (latest.id !== selectedEventId) {
       updateSearchParams((params) => {
         params.set('eventId', latest.id);
       });
@@ -1275,13 +1283,17 @@ export function AgentsRunScreen() {
 
   useEffect(() => {
     if (!selectedEventId) return;
+    if (!eventsQuery.data) return;
+    if (events.length === 0) {
+      if ((eventsQuery.data.items ?? []).length > 0) return;
+    }
     const exists = events.some((event) => event.id === selectedEventId);
     if (!exists) {
       updateSearchParams((params) => {
         params.delete('eventId');
       });
     }
-  }, [events, selectedEventId, updateSearchParams]);
+  }, [events, selectedEventId, updateSearchParams, eventsQuery.data]);
 
   const selectEvent = useCallback(
     (eventId: string) => {

--- a/packages/platform-ui/src/pages/AgentsRunScreen.tsx
+++ b/packages/platform-ui/src/pages/AgentsRunScreen.tsx
@@ -4,10 +4,10 @@ import RunScreen, { type EventFilter, type StatusFilter } from '@/components/scr
 import type { RunEvent as UiRunEvent } from '@/components/RunEventsList';
 import type { Status } from '@/components/StatusIndicator';
 import { useRunTimelineEventTotals, useRunTimelineEvents, useRunTimelineSummary } from '@/api/hooks/runs';
-import { contextItems } from '@/api/modules/contextItems';
 import { runs } from '@/api/modules/runs';
 import type {
-  ContextItem,
+  LlmContextPageCursor,
+  LlmContextPageItem,
   RunEventStatus,
   RunEventType,
   RunTimelineEvent,
@@ -15,6 +15,7 @@ import type {
   RunTimelineEventsResponse,
 } from '@/api/types/agents';
 import { graphSocket } from '@/lib/graph/socket';
+import { coerceRecord, isNonEmptyString, parseMaybeJson, toContextRecord, toRecordArray } from '@/lib/llmContext';
 import { notifyError, notifySuccess } from '@/lib/notify';
 import { formatDuration } from '@/components/agents/runTimelineFormatting';
 
@@ -22,6 +23,15 @@ const EVENT_FILTER_OPTIONS: EventFilter[] = ['message', 'llm', 'tool', 'summary'
 const STATUS_FILTER_OPTIONS: StatusFilter[] = ['running', 'finished', 'failed', 'terminated'];
 const API_EVENT_TYPES: RunEventType[] = ['invocation_message', 'injection', 'llm_call', 'tool_execution', 'summarization'];
 const API_EVENT_STATUSES: RunEventStatus[] = ['pending', 'running', 'success', 'error', 'cancelled'];
+const LLM_CONTEXT_PAGE_LIMIT = 100;
+
+type LlmContextState = {
+  items: LlmContextPageItem[];
+  nextCursor: LlmContextPageCursor | null;
+  isLoading: boolean;
+  error: string | null;
+  hasFetched: boolean;
+};
 
 const EVENT_FILTER_TO_TYPES: Record<EventFilter, RunEventType[]> = {
   message: ['invocation_message', 'injection'],
@@ -206,63 +216,6 @@ function inferToolSubtype(toolName: string | undefined, input: unknown): 'shell'
   return 'generic';
 }
 
-function coerceRecord(value: unknown): Record<string, unknown> | null {
-  if (typeof value === 'object' && value !== null && !Array.isArray(value)) return value as Record<string, unknown>;
-  return null;
-}
-
-function parseMaybeJson(value: unknown): unknown {
-  if (typeof value !== 'string') return value;
-  try {
-    return JSON.parse(value);
-  } catch (_error) {
-    return value;
-  }
-}
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0;
-}
-
-type ContextSource = {
-  ids: string[];
-  highlightIds: string[];
-};
-
-const EMPTY_CONTEXT_SOURCE: ContextSource = {
-  ids: [],
-  highlightIds: [],
-};
-
-function buildContextSource(llmCall?: RunTimelineEvent['llmCall']): ContextSource {
-  if (!llmCall) return EMPTY_CONTEXT_SOURCE;
-  const rows = Array.isArray(llmCall.inputContextItems) ? llmCall.inputContextItems : [];
-  if (rows.length === 0) return EMPTY_CONTEXT_SOURCE;
-  const sorted = [...rows].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-  const highlightCandidates = new Set<string>();
-  for (const row of sorted) {
-    const id = row.contextItemId;
-    if (!isNonEmptyString(id)) continue;
-    if (row.isNew === true) {
-      highlightCandidates.add(id);
-    }
-  }
-  const ids: string[] = [];
-  const highlightIds: string[] = [];
-  const seen = new Set<string>();
-  for (const row of sorted) {
-    const id = row.contextItemId;
-    if (!isNonEmptyString(id)) continue;
-    if (seen.has(id)) continue;
-    seen.add(id);
-    ids.push(id);
-    if (highlightCandidates.has(id)) {
-      highlightIds.push(id);
-    }
-  }
-  return { ids, highlightIds };
-}
-
 type LinkTargets = {
   threadId?: string;
   subthreadId?: string;
@@ -384,143 +337,8 @@ function normalizeRecordWithTargets(record: Record<string, unknown> | null, targ
   return changed ? next : record;
 }
 
-function parseContextItemContent(item: ContextItem): {
-  parsed: unknown;
-  record: Record<string, unknown> | null;
-  text: string | null;
-} {
-  const parsedContent = item.contentJson ?? (isNonEmptyString(item.contentText) ? parseMaybeJson(item.contentText) : undefined);
-  const record = coerceRecord(parsedContent);
 
-  const stringCandidates: Array<string | null> = [];
-  if (record && typeof record.content === 'string' && record.content.length > 0) stringCandidates.push(record.content);
-  if (record && typeof record.response === 'string' && record.response.length > 0) stringCandidates.push(record.response);
-  if (typeof parsedContent === 'string' && parsedContent.length > 0) stringCandidates.push(parsedContent);
-  if (isNonEmptyString(item.contentText)) stringCandidates.push(item.contentText);
 
-  const text = stringCandidates.find((candidate): candidate is string => typeof candidate === 'string' && candidate.trim().length > 0) ?? null;
-
-  return { parsed: parsedContent, record, text };
-}
-
-function normalizeMetadata(value: unknown): Record<string, unknown> | null {
-  const parsed = parseMaybeJson(value);
-  return coerceRecord(parsed);
-}
-
-function collectToolCalls(
-  primary: Record<string, unknown> | null,
-  primaryAdditionalKwargs: Record<string, unknown> | null,
-  metadata: Record<string, unknown> | null,
-  metadataAdditionalKwargs: Record<string, unknown> | null,
-): Record<string, unknown>[] {
-  const seen = new Set<string>();
-  const result: Record<string, unknown>[] = [];
-
-  const addRecords = (value: unknown) => {
-    if (value === undefined || value === null) return;
-    const normalized = typeof value === 'string' ? parseMaybeJson(value) : value;
-    for (const record of toRecordArray(normalized)) {
-      const key = (() => {
-        try {
-          return JSON.stringify(record);
-        } catch (_err) {
-          return undefined;
-        }
-      })();
-      if (key && seen.has(key)) continue;
-      if (key) seen.add(key);
-      result.push(record);
-    }
-  };
-
-  if (primary) {
-    addRecords(primary.tool_calls);
-    addRecords(primary.toolCalls);
-  }
-  if (primaryAdditionalKwargs) {
-    addRecords(primaryAdditionalKwargs.tool_calls);
-    addRecords(primaryAdditionalKwargs.toolCalls);
-  }
-  if (metadata) {
-    addRecords(metadata.tool_calls);
-    addRecords(metadata.toolCalls);
-  }
-  if (metadataAdditionalKwargs) {
-    addRecords(metadataAdditionalKwargs.tool_calls);
-    addRecords(metadataAdditionalKwargs.toolCalls);
-  }
-
-  const synthesizeFromOutput = (container?: Record<string, unknown> | null) => {
-    if (!container) return;
-    const outputEntries = Array.isArray(container.output) ? (container.output as unknown[]) : [];
-    for (const entry of outputEntries) {
-      const rec = coerceRecord(entry);
-      if (!rec) continue;
-      if (rec.type !== 'function_call') continue;
-
-      const funcRec = coerceRecord(rec.function);
-      const rawArgs = rec.arguments ?? funcRec?.arguments;
-      const normArgs = typeof rawArgs === 'string' ? parseMaybeJson(rawArgs) : rawArgs;
-
-      const synthesized: Record<string, unknown> = {
-        callId: isNonEmptyString(rec.call_id)
-          ? rec.call_id
-          : isNonEmptyString(rec.id)
-            ? rec.id
-            : undefined,
-        name: isNonEmptyString(rec.name)
-          ? rec.name
-          : isNonEmptyString(funcRec?.name)
-            ? funcRec.name
-            : undefined,
-        arguments: normArgs,
-      };
-
-      const key = (() => {
-        try {
-          return JSON.stringify(synthesized);
-        } catch (_err) {
-          return undefined;
-        }
-      })();
-      if (key && seen.has(key)) continue;
-      if (key) seen.add(key);
-      result.push(synthesized);
-    }
-  };
-
-  synthesizeFromOutput(primary);
-  synthesizeFromOutput(primaryAdditionalKwargs);
-  synthesizeFromOutput(metadata);
-  synthesizeFromOutput(metadataAdditionalKwargs);
-
-  return result;
-}
-
-function extractReasoning(
-  primary: Record<string, unknown> | null,
-  primaryAdditionalKwargs: Record<string, unknown> | null,
-  metadata: Record<string, unknown> | null,
-  metadataAdditionalKwargs: Record<string, unknown> | null,
-): unknown {
-  const candidates: unknown[] = [];
-  if (primary) candidates.push(primary.reasoning);
-  if (primaryAdditionalKwargs) candidates.push(primaryAdditionalKwargs.reasoning);
-  if (metadata) candidates.push(metadata.reasoning);
-  if (metadataAdditionalKwargs) candidates.push(metadataAdditionalKwargs.reasoning);
-
-  for (const candidate of candidates) {
-    if (candidate === undefined) continue;
-    if (candidate === null) return null;
-    if (typeof candidate === 'string') {
-      const parsed = parseMaybeJson(candidate);
-      return parsed;
-    }
-    return candidate;
-  }
-  return undefined;
-}
 
 function extractTextFromRawResponse(raw: unknown): string | null {
   const visited = new WeakSet<object>();
@@ -642,82 +460,6 @@ function extractLlmResponse(event: RunTimelineEvent): string {
   return '';
 }
 
-function toContextRecord(item: ContextItem): Record<string, unknown> {
-  const metadataRecord = normalizeMetadata(item.metadata);
-  const metadataAdditionalKwargs = metadataRecord ? coerceRecord(metadataRecord.additional_kwargs) : null;
-  const { parsed: parsedContent, record: parsedRecord, text: textContent } = parseContextItemContent(item);
-  const contentAdditionalKwargs = parsedRecord ? coerceRecord(parsedRecord.additional_kwargs) : null;
-
-  const result: Record<string, unknown> = parsedRecord ? { ...parsedRecord } : {};
-
-  if (!isNonEmptyString(result.id)) {
-    result.id = item.id;
-  }
-  result.role = typeof result.role === 'string' && result.role.length > 0 ? result.role : item.role;
-  result.timestamp = result.timestamp ?? item.createdAt;
-  result.sizeBytes = item.sizeBytes;
-  result.contentJson = parsedContent;
-  result.metadata = metadataRecord ?? item.metadata;
-
-  const normalizedText = typeof textContent === 'string' && textContent.length > 0
-    ? textContent
-    : isNonEmptyString(item.contentText)
-      ? item.contentText
-      : null;
-
-  if (normalizedText !== null) {
-    result.contentText = normalizedText;
-  } else if ('contentText' in result && typeof result.contentText !== 'string') {
-    delete result.contentText;
-  }
-
-  const hasStringContent = typeof normalizedText === 'string' && normalizedText.length > 0;
-
-  if (result.role === 'assistant') {
-    if (hasStringContent) {
-      result.content = normalizedText;
-      if (typeof result.response !== 'string' || result.response.length === 0) {
-        result.response = normalizedText;
-      }
-    } else {
-      if (typeof result.content !== 'string') delete result.content;
-      if (typeof result.response !== 'string') delete result.response;
-    }
-  } else if (hasStringContent) {
-    if (typeof result.content !== 'string' || result.content.length === 0) {
-      result.content = normalizedText;
-    }
-  }
-
-  const mergedAdditionalKwargs = contentAdditionalKwargs ?? metadataAdditionalKwargs;
-  if (mergedAdditionalKwargs) {
-    result.additional_kwargs = mergedAdditionalKwargs;
-  }
-
-  const toolCalls = collectToolCalls(parsedRecord, contentAdditionalKwargs, metadataRecord, metadataAdditionalKwargs);
-
-  if (toolCalls.length > 0) {
-    result.tool_calls = toolCalls;
-    result.toolCalls = toolCalls;
-  }
-
-  const reasoning = extractReasoning(parsedRecord, contentAdditionalKwargs, metadataRecord, metadataAdditionalKwargs);
-  if (reasoning !== undefined) {
-    result.reasoning = reasoning;
-  }
-
-  return result;
-}
-
-function toRecordArray(value: unknown): Record<string, unknown>[] {
-  if (!Array.isArray(value)) return [];
-  const result: Record<string, unknown>[] = [];
-  for (const item of value) {
-    const record = coerceRecord(item);
-    if (record) result.push(record);
-  }
-  return result;
-}
 
 function buildToolLinkData(event: RunTimelineEvent): ToolLinkData | undefined {
   const execution = event.toolExecution;
@@ -760,43 +502,15 @@ function buildToolLinkData(event: RunTimelineEvent): ToolLinkData | undefined {
   };
 }
 
-type ResolveContextRecordsOptions = {
-  highlightIds?: readonly string[];
-  includeAssistant?: boolean;
-};
-
-function resolveContextRecords(
-  ids: readonly string[],
-  lookup: Map<string, ContextItem>,
-  options?: ResolveContextRecordsOptions,
-): Record<string, unknown>[] {
-  if (!Array.isArray(ids) || ids.length === 0) return [];
-  const includeAssistant = options?.includeAssistant ?? false;
-  const highlightIds = Array.isArray(options?.highlightIds) ? options?.highlightIds.filter(isNonEmptyString) : [];
-  const highlightSet = highlightIds.length > 0 ? new Set(highlightIds) : null;
-  const records: Record<string, unknown>[] = [];
-  const seen = new Set<string>();
-  for (const id of ids) {
-    if (!isNonEmptyString(id)) continue;
-    if (seen.has(id)) continue;
-    seen.add(id);
-    const item = lookup.get(id);
-    if (!item) continue;
-    const record = toContextRecord(item);
-    const role = typeof record.role === 'string' ? record.role : item.role;
-    if (!includeAssistant && role === 'assistant') {
-      continue;
+function buildContextRecords(items: LlmContextPageItem[]): Record<string, unknown>[] {
+  if (!Array.isArray(items) || items.length === 0) return [];
+  return items.map((item) => {
+    const record = toContextRecord(item.contextItem);
+    if (item.isNew) {
+      (record as Record<string, unknown> & { __agynIsNew?: boolean }).__agynIsNew = true;
     }
-    const recordId = typeof record.id === 'string' && record.id.length > 0 ? record.id : item.id;
-    if (isNonEmptyString(recordId)) {
-      record.id = recordId;
-      if (highlightSet?.has(recordId)) {
-        (record as Record<string, unknown> & { __agynIsNew?: boolean }).__agynIsNew = true;
-      }
-    }
-    records.push(record);
-  }
-  return records;
+    return record;
+  });
 }
 
 type CreateUiEventOptions = {
@@ -1011,9 +725,8 @@ export function AgentsRunScreen() {
   const [nextCursor, setNextCursor] = useState<RunTimelineEventsCursor | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [loadOlderError, setLoadOlderError] = useState<string | null>(null);
-  const contextItemsRef = useRef<Map<string, ContextItem>>(new Map());
-  const pendingContextIdsRef = useRef<Set<string>>(new Set());
-  const [contextItemsVersion, setContextItemsVersion] = useState(0);
+  const contextStateRef = useRef<Map<string, LlmContextState>>(new Map());
+  const [contextStateVersion, setContextStateVersion] = useState(0);
 
   const followDefault = useMemo(() => {
     const paramValue = parseFollowValue(searchParams.get('follow'));
@@ -1199,63 +912,90 @@ export function AgentsRunScreen() {
     [],
   );
 
-  const fetchContextItems = useCallback(async (ids: readonly string[]) => {
-    if (!Array.isArray(ids) || ids.length === 0) return;
-    const lookup = contextItemsRef.current;
-    const pending = pendingContextIdsRef.current;
-    const candidates: string[] = [];
-
-    for (const id of ids) {
-      if (!isNonEmptyString(id)) continue;
-      if (lookup.has(id) || pending.has(id)) continue;
-      pending.add(id);
-      candidates.push(id);
-    }
-
-    if (candidates.length === 0) return;
-
-    let fetched: ContextItem[] | null = null;
-    try {
-      fetched = await contextItems.getMany(candidates);
-    } catch (error) {
-      console.error('Failed to load context items', error);
-    } finally {
-      for (const id of candidates) {
-        pending.delete(id);
+  const updateContextState = useCallback(
+    (eventId: string, updater: (state: LlmContextState) => LlmContextState) => {
+      const map = contextStateRef.current;
+      const current: LlmContextState = map.get(eventId) ?? {
+        items: [],
+        nextCursor: null,
+        isLoading: false,
+        error: null,
+        hasFetched: false,
+      };
+      const next = updater(current);
+      if (next !== current) {
+        map.set(eventId, next);
+        setContextStateVersion((version) => version + 1);
       }
-    }
+      return next;
+    },
+    [],
+  );
 
-    if (!fetched || fetched.length === 0) return;
+  const loadContextPage = useCallback(
+    async (eventId: string, cursor: LlmContextPageCursor | null): Promise<{ addedCount: number; hasMore: boolean }> => {
+      if (!runId) return { addedCount: 0, hasMore: false };
+      const current = contextStateRef.current.get(eventId);
+      if (current?.isLoading) return { addedCount: 0, hasMore: current.nextCursor !== null };
 
-    let updated = false;
-    for (const item of fetched) {
-      if (isNonEmptyString(item.id) && !lookup.has(item.id)) {
-        lookup.set(item.id, item);
-        updated = true;
+      updateContextState(eventId, (state) => ({
+        ...state,
+        isLoading: true,
+        error: null,
+      }));
+
+      try {
+        const page = await runs.llmContext(runId, eventId, {
+          limit: LLM_CONTEXT_PAGE_LIMIT,
+          cursor,
+        });
+        const newestFirstItems = Array.isArray(page.items) ? page.items : [];
+        const reversedItems = [...newestFirstItems].reverse();
+        let addedCount = 0;
+
+        updateContextState(eventId, (state) => {
+          const existing = state.items ?? [];
+          const existingIds = new Set(existing.map((item) => item.rowId));
+          const deduped: LlmContextPageItem[] = [];
+          for (const item of reversedItems) {
+            if (existingIds.has(item.rowId)) continue;
+            existingIds.add(item.rowId);
+            deduped.push(item);
+          }
+          addedCount = deduped.length;
+          const merged = cursor ? [...deduped, ...existing] : deduped;
+          return {
+            items: merged,
+            nextCursor: page.nextCursor ?? null,
+            isLoading: false,
+            error: null,
+            hasFetched: true,
+          };
+        });
+
+        return { addedCount, hasMore: page.nextCursor !== null };
+      } catch (error) {
+        updateContextState(eventId, (state) => ({
+          ...state,
+          isLoading: false,
+          error: 'Failed to load context.',
+        }));
+        throw error;
       }
-    }
-
-    if (updated) {
-      setContextItemsVersion((version) => version + 1);
-    }
-  }, []);
+    },
+    [runId, updateContextState],
+  );
 
   useEffect(() => {
+    if (!runId) return;
     if (allEvents.length === 0) return;
-    const lookup = contextItemsRef.current;
-    const ids = new Set<string>();
     for (const event of allEvents) {
       if (event.type !== 'llm_call') continue;
-      const { ids: inputIds } = buildContextSource(event.llmCall);
-      for (const id of inputIds) {
-        if (!isNonEmptyString(id)) continue;
-        if (lookup.has(id)) continue;
-        ids.add(id);
-      }
+      const state = contextStateRef.current.get(event.id);
+      if (state?.hasFetched || state?.isLoading) continue;
+      void loadContextPage(event.id, null);
     }
-    if (ids.size === 0) return;
-    void fetchContextItems(Array.from(ids));
-  }, [allEvents, fetchContextItems]);
+  }, [allEvents, runId, loadContextPage]);
 
   useEffect(() => {
     setEvents((prev) => {
@@ -1290,6 +1030,8 @@ export function AgentsRunScreen() {
       catchUpRef.current = null;
       setAllEvents([]);
       setEvents([]);
+      contextStateRef.current.clear();
+      setContextStateVersion((version) => version + 1);
       cursorRef.current = null;
       updateOlderCursor(null);
       updateCursor(null, { force: true });
@@ -1696,6 +1438,19 @@ export function AgentsRunScreen() {
     }
   }, [runId, isTerminating, summaryQuery]);
 
+  const handleLoadOlderContext = useCallback(
+    async (eventId: string) => {
+      const state = contextStateRef.current.get(eventId);
+      if (state?.isLoading) return { addedCount: 0, hasMore: state.nextCursor !== null };
+      if (!state || !state.hasFetched) {
+        return await loadContextPage(eventId, null);
+      }
+      if (!state.nextCursor) return { addedCount: 0, hasMore: false };
+      return await loadContextPage(eventId, state.nextCursor);
+    },
+    [loadContextPage],
+  );
+
   const runSummary = summaryQuery.data;
   const runStatus = mapRunStatus(runSummary?.status);
   const runDuration = useRunDuration(runSummary?.createdAt, runSummary?.status, runSummary?.lastEventAt ?? runSummary?.updatedAt);
@@ -1724,26 +1479,29 @@ export function AgentsRunScreen() {
     };
   }, [filteredEventCount, runSummary]);
 
+  const selectedContextState = useMemo(() => {
+    const currentVersion = contextStateVersion;
+    if (currentVersion < 0) return undefined;
+    if (!selectedEventId) return undefined;
+    const state = contextStateRef.current.get(selectedEventId);
+    if (!state) return undefined;
+    return {
+      hasMore: state.nextCursor !== null,
+      isLoading: state.isLoading,
+      error: state.error,
+    };
+  }, [selectedEventId, contextStateVersion]);
+
   const uiEvents = useMemo<UiRunEvent[]>(() => {
-    const lookup = contextItemsRef.current;
-    void contextItemsVersion;
-    return events.map((event) => {
-      const contextSource = event.type === 'llm_call' ? buildContextSource(event.llmCall) : EMPTY_CONTEXT_SOURCE;
-      const inputRecords =
-        event.type === 'llm_call'
-          ? resolveContextRecords(contextSource.ids, lookup, {
-              highlightIds: contextSource.highlightIds,
-              includeAssistant: true,
-            })
-          : [];
-      const contextRecords =
-        event.type === 'llm_call'
-          ? inputRecords
-          : [];
+    const contextStates = contextStateRef.current;
+    const resolvedEvents = contextStateVersion >= 0 ? events : [];
+    return resolvedEvents.map((event) => {
+      const contextState = event.type === 'llm_call' ? contextStates.get(event.id) : undefined;
+      const contextRecords = contextState?.hasFetched ? buildContextRecords(contextState.items) : undefined;
       const toolLinks = event.type === 'tool_execution' ? buildToolLinkData(event) : undefined;
       return createUiEvent(event, { context: contextRecords, assistant: [], tool: toolLinks });
     });
-  }, [events, contextItemsVersion]);
+  }, [events, contextStateVersion]);
 
   const isLoading = eventsQuery.isLoading || summaryQuery.isLoading;
   const hasMoreEvents = Boolean(nextCursor);
@@ -1771,6 +1529,8 @@ export function AgentsRunScreen() {
         tokens={tokens}
         events={uiEvents}
         selectedEventId={selectedEventId ?? null}
+        contextPagination={selectedContextState}
+        onLoadOlderContext={handleLoadOlderContext}
         isFollowing={isFollowing}
         eventFilters={eventFilters}
         statusFilters={statusFilters}

--- a/packages/platform-ui/src/pages/__tests__/AgentsRunScreen.test.tsx
+++ b/packages/platform-ui/src/pages/__tests__/AgentsRunScreen.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AgentsRunScreen } from '../AgentsRunScreen';
 import type {
   ContextItem,
+  LlmContextPage,
   RunEventStatus,
   RunEventType,
   RunTimelineEvent,
@@ -60,19 +61,13 @@ vi.mock('@/api/hooks/runs', () => ({
 const runsModuleMocks = vi.hoisted(() => ({
   terminate: vi.fn(),
   timelineEvents: vi.fn(),
+  llmContext: vi.fn<Promise<LlmContextPage>, [string, string, { cursor?: { idx: number; rowId: string } | null; limit?: number }]>(),
 }));
 
 vi.mock('@/api/modules/runs', () => ({
   runs: runsModuleMocks,
 }));
 
-const contextItemsMocks = vi.hoisted(() => ({
-  getMany: vi.fn(async () => [] as never[]),
-}));
-
-vi.mock('@/api/modules/contextItems', () => ({
-  contextItems: contextItemsMocks,
-}));
 
 const notifyMocks = vi.hoisted(() => ({
   success: vi.fn(),
@@ -130,8 +125,8 @@ beforeEach(() => {
   runsHookMocks.events.mockReset();
   runsHookMocks.totals.mockReset();
   runsHookMocks.totals.mockReturnValue(buildTotalsResponse());
-  contextItemsMocks.getMany.mockReset();
-  contextItemsMocks.getMany.mockResolvedValue([]);
+  runsModuleMocks.llmContext.mockReset();
+  runsModuleMocks.llmContext.mockResolvedValue({ items: [], nextCursor: null });
 });
 
 afterEach(() => {
@@ -239,6 +234,25 @@ function buildContextItems(rows: ContextRowInput[], prefix = 'rel'): LlmCallCont
     order: row.order ?? idx,
     createdAt: row.createdAt,
   }));
+}
+
+type ContextPageRowInput = {
+  contextItem: ContextItem;
+  isNew?: boolean;
+  idx?: number;
+  rowId?: string;
+};
+
+function buildLlmContextPage(items: ContextPageRowInput[], nextCursor: LlmContextPage['nextCursor'] = null): LlmContextPage {
+  return {
+    items: items.map((item, index) => ({
+      rowId: item.rowId ?? `row-${index + 1}`,
+      idx: item.idx ?? index,
+      isNew: item.isNew ?? false,
+      contextItem: item.contextItem,
+    })),
+    nextCursor,
+  };
 }
 
 type AgentsRunScreenWithTesting = typeof AgentsRunScreen & {
@@ -608,7 +622,7 @@ describe('AgentsRunScreen', () => {
       totalEvents: 1,
     });
     runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
-    contextItemsMocks.getMany.mockResolvedValue([anthropicAssistant]);
+    runsModuleMocks.llmContext.mockResolvedValue(buildLlmContextPage([{ contextItem: anthropicAssistant }]));
 
     const queryClient = new QueryClient();
 
@@ -622,7 +636,13 @@ describe('AgentsRunScreen', () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(contextItemsMocks.getMany).toHaveBeenCalledWith([anthropicAssistant.id]));
+    await waitFor(() =>
+      expect(runsModuleMocks.llmContext).toHaveBeenCalledWith(
+        event.runId,
+        event.id,
+        expect.objectContaining({ limit: 100 }),
+      ),
+    );
     await waitFor(() => expect(runScreenMocks.props).toHaveBeenCalled());
 
     const capturedProps = runScreenMocks.props.mock.calls.at(-1)?.[0] as { events: Array<{ data: Record<string, unknown> }> } | undefined;
@@ -774,7 +794,7 @@ describe('AgentsRunScreen', () => {
       totalEvents: 1,
     });
     runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
-    contextItemsMocks.getMany.mockImplementation(async () => [userContext]);
+    runsModuleMocks.llmContext.mockResolvedValue(buildLlmContextPage([{ contextItem: userContext }]));
 
     const queryClient = new QueryClient();
 
@@ -788,7 +808,13 @@ describe('AgentsRunScreen', () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(contextItemsMocks.getMany).toHaveBeenCalledWith([userContext.id]));
+    await waitFor(() =>
+      expect(runsModuleMocks.llmContext).toHaveBeenCalledWith(
+        event.runId,
+        event.id,
+        expect.objectContaining({ limit: 100 }),
+      ),
+    );
 
     await waitFor(() => expect(runScreenMocks.props).toHaveBeenCalled());
     const lastCall = runScreenMocks.props.mock.calls.at(-1);
@@ -884,7 +910,12 @@ describe('AgentsRunScreen', () => {
       totalEvents: 1,
     });
     runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
-    contextItemsMocks.getMany.mockImplementation(async () => [assistantContext, userContext]);
+    runsModuleMocks.llmContext.mockResolvedValue(
+      buildLlmContextPage([
+        { contextItem: assistantContext, isNew: false },
+        { contextItem: userContext, isNew: true },
+      ]),
+    );
 
     const queryClient = new QueryClient();
 
@@ -898,8 +929,7 @@ describe('AgentsRunScreen', () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(contextItemsMocks.getMany).toHaveBeenCalled());
-    expect(contextItemsMocks.getMany).toHaveBeenCalledWith(expect.arrayContaining([assistantContext.id, userContext.id]));
+    await waitFor(() => expect(runsModuleMocks.llmContext).toHaveBeenCalled());
 
     await waitFor(() => expect(runScreenMocks.props).toHaveBeenCalled());
     const lastCall = runScreenMocks.props.mock.calls.at(-1);
@@ -983,7 +1013,7 @@ describe('AgentsRunScreen', () => {
       totalEvents: 1,
     });
     runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
-    contextItemsMocks.getMany.mockResolvedValue([userContext]);
+    runsModuleMocks.llmContext.mockResolvedValue(buildLlmContextPage([{ contextItem: userContext, isNew: true }]));
 
     const queryClient = new QueryClient();
 
@@ -997,7 +1027,13 @@ describe('AgentsRunScreen', () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(contextItemsMocks.getMany).toHaveBeenCalledWith([userContext.id]));
+    await waitFor(() =>
+      expect(runsModuleMocks.llmContext).toHaveBeenCalledWith(
+        event.runId,
+        event.id,
+        expect.objectContaining({ limit: 100 }),
+      ),
+    );
 
     await waitFor(() => expect(runScreenMocks.props).toHaveBeenCalled());
     const lastCall = runScreenMocks.props.mock.calls.at(-1);
@@ -1086,7 +1122,12 @@ describe('AgentsRunScreen', () => {
       totalEvents: 1,
     });
     runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
-    contextItemsMocks.getMany.mockImplementation(async () => [assistantInput, toolInput]);
+    runsModuleMocks.llmContext.mockResolvedValue(
+      buildLlmContextPage([
+        { contextItem: assistantInput, isNew: true },
+        { contextItem: toolInput, isNew: true },
+      ]),
+    );
 
     const queryClient = new QueryClient();
 
@@ -1100,7 +1141,13 @@ describe('AgentsRunScreen', () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(contextItemsMocks.getMany).toHaveBeenCalledWith(expect.arrayContaining([assistantInput.id, toolInput.id])));
+    await waitFor(() =>
+      expect(runsModuleMocks.llmContext).toHaveBeenCalledWith(
+        event.runId,
+        event.id,
+        expect.objectContaining({ limit: 100 }),
+      ),
+    );
 
     await waitFor(() => expect(runScreenMocks.props).toHaveBeenCalled());
     const lastCall = runScreenMocks.props.mock.calls.at(-1);
@@ -1189,7 +1236,7 @@ describe('AgentsRunScreen', () => {
       totalEvents: 1,
     });
     runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
-    contextItemsMocks.getMany.mockImplementation(async () => [assistantContext]);
+    runsModuleMocks.llmContext.mockResolvedValue(buildLlmContextPage([{ contextItem: assistantContext }]));
 
     const queryClient = new QueryClient();
 
@@ -1203,7 +1250,13 @@ describe('AgentsRunScreen', () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(contextItemsMocks.getMany).toHaveBeenCalledWith([assistantContext.id]));
+    await waitFor(() =>
+      expect(runsModuleMocks.llmContext).toHaveBeenCalledWith(
+        event.runId,
+        event.id,
+        expect.objectContaining({ limit: 100 }),
+      ),
+    );
 
     await waitFor(() => expect(runScreenMocks.props).toHaveBeenCalled());
     const lastCall = runScreenMocks.props.mock.calls.at(-1);
@@ -1307,7 +1360,12 @@ describe('AgentsRunScreen', () => {
       totalEvents: 1,
     });
     runsHookMocks.events.mockReturnValue({ items: [event], nextCursor: null });
-    contextItemsMocks.getMany.mockImplementation(async () => [assistantWithTool, assistantWithoutTool]);
+    runsModuleMocks.llmContext.mockResolvedValue(
+      buildLlmContextPage([
+        { contextItem: assistantWithTool },
+        { contextItem: assistantWithoutTool },
+      ]),
+    );
 
     const queryClient = new QueryClient();
 
@@ -1322,7 +1380,11 @@ describe('AgentsRunScreen', () => {
     );
 
     await waitFor(() =>
-      expect(contextItemsMocks.getMany).toHaveBeenCalledWith(expect.arrayContaining([assistantWithTool.id, assistantWithoutTool.id])),
+      expect(runsModuleMocks.llmContext).toHaveBeenCalledWith(
+        event.runId,
+        event.id,
+        expect.objectContaining({ limit: 100 }),
+      ),
     );
 
     await waitFor(() => expect(runScreenMocks.props).toHaveBeenCalled());

--- a/packages/platform-ui/src/pages/__tests__/AgentsRunScreen.test.tsx
+++ b/packages/platform-ui/src/pages/__tests__/AgentsRunScreen.test.tsx
@@ -366,7 +366,7 @@ describe('AgentsRunScreen', () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}?eventId=${event.id}`]}>
           <Routes>
             <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
           </Routes>
@@ -402,7 +402,7 @@ describe('AgentsRunScreen', () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}?eventId=${event.id}`]}>
           <Routes>
             <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
           </Routes>
@@ -441,7 +441,7 @@ describe('AgentsRunScreen', () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}?eventId=${event.id}`]}>
           <Routes>
             <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
           </Routes>
@@ -480,7 +480,7 @@ describe('AgentsRunScreen', () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}?eventId=${event.id}`]}>
           <Routes>
             <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
           </Routes>
@@ -520,7 +520,7 @@ describe('AgentsRunScreen', () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}?eventId=${event.id}`]}>
           <Routes>
             <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
           </Routes>
@@ -594,6 +594,7 @@ describe('AgentsRunScreen', () => {
           ],
           'ctx-anthropic-tool-call',
         ),
+        contextDeltaStatus: 'empty',
         responseText: 'Done with delegate message.',
         rawResponse: null,
         toolCalls: [],
@@ -628,7 +629,7 @@ describe('AgentsRunScreen', () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}?eventId=${event.id}`]}>
           <Routes>
             <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
           </Routes>
@@ -643,10 +644,15 @@ describe('AgentsRunScreen', () => {
         expect.objectContaining({ limit: 100 }),
       ),
     );
-    await waitFor(() => expect(runScreenMocks.props).toHaveBeenCalled());
-
-    const capturedProps = runScreenMocks.props.mock.calls.at(-1)?.[0] as { events: Array<{ data: Record<string, unknown> }> } | undefined;
-    if (!capturedProps) throw new Error('RunScreen props were not captured.');
+    const capturedProps = await waitFor(() => {
+      const lastCall = runScreenMocks.props.mock.calls.at(-1)?.[0] as { events: Array<{ data: Record<string, unknown> }> } | undefined;
+      if (!lastCall) throw new Error('RunScreen props were not captured.');
+      const [capturedEvent] = lastCall.events;
+      const context = (capturedEvent.data.context as Record<string, unknown>[] | undefined) ?? [];
+      const assistantRecord = context.find((entry) => entry.role === 'assistant');
+      if (!assistantRecord) throw new Error('Context not loaded yet.');
+      return lastCall;
+    });
 
     const [capturedEvent] = capturedProps.events;
     const context = (capturedEvent.data.context as Record<string, unknown>[] | undefined) ?? [];
@@ -761,6 +767,7 @@ describe('AgentsRunScreen', () => {
           ],
           'ctx-llm-separated',
         ),
+        contextDeltaStatus: 'empty',
         responseText: 'I am fine, thanks!',
         rawResponse: null,
         toolCalls: [
@@ -800,7 +807,7 @@ describe('AgentsRunScreen', () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}`]}>
+        <MemoryRouter initialEntries={[`/threads/${event.threadId}/runs/${event.runId}?eventId=${event.id}`]}>
           <Routes>
             <Route path="/threads/:threadId/runs/:runId" element={<AgentsRunScreen />} />
           </Routes>
@@ -816,10 +823,15 @@ describe('AgentsRunScreen', () => {
       ),
     );
 
-    await waitFor(() => expect(runScreenMocks.props).toHaveBeenCalled());
-    const lastCall = runScreenMocks.props.mock.calls.at(-1);
-    const capturedProps = lastCall?.[0] as { events: Array<{ data: Record<string, unknown> }> } | undefined;
-    if (!capturedProps) throw new Error('RunScreen props were not captured.');
+    const capturedProps = await waitFor(() => {
+      const lastCall = runScreenMocks.props.mock.calls.at(-1);
+      const props = lastCall?.[0] as { events: Array<{ data: Record<string, unknown> }> } | undefined;
+      if (!props) throw new Error('RunScreen props were not captured.');
+      const [capturedEvent] = props.events;
+      const context = (capturedEvent.data.context as Record<string, unknown>[] | undefined) ?? [];
+      if (context.length === 0) throw new Error('Context not loaded yet.');
+      return props;
+    });
 
     const [capturedEvent] = capturedProps.events;
     const context = (capturedEvent.data.context as Record<string, unknown>[] | undefined) ?? [];
@@ -883,6 +895,7 @@ describe('AgentsRunScreen', () => {
           ],
           'ctx-highlight',
         ),
+        contextDeltaStatus: 'available',
         responseText: 'Working on it.',
         rawResponse: null,
         toolCalls: [],
@@ -986,6 +999,7 @@ describe('AgentsRunScreen', () => {
           ],
           'ctx-llm-duplicate-new',
         ),
+        contextDeltaStatus: 'available',
         responseText: 'Report acknowledged.',
         rawResponse: null,
         toolCalls: [],
@@ -1095,6 +1109,7 @@ describe('AgentsRunScreen', () => {
           ],
           'ctx-assistant-tool',
         ),
+        contextDeltaStatus: 'available',
         responseText: null,
         rawResponse: null,
         toolCalls: [],
@@ -1208,6 +1223,7 @@ describe('AgentsRunScreen', () => {
           ],
           'ctx-structured',
         ),
+        contextDeltaStatus: 'empty',
         responseText: null,
         rawResponse: null,
         toolCalls: [],
@@ -1327,6 +1343,7 @@ describe('AgentsRunScreen', () => {
           ],
           'ctx-per-item-tool-calls',
         ),
+        contextDeltaStatus: 'empty',
         responseText: 'All set.',
         rawResponse: null,
         toolCalls: [
@@ -1454,6 +1471,7 @@ describe('extractLlmResponse', () => {
         topP: null,
         stopReason: null,
         inputContextItems: [],
+        contextDeltaStatus: 'unavailable',
         responseText: null,
         rawResponse: null,
         toolCalls: [],


### PR DESCRIPTION
## Summary
- show a context history action for LLM calls even when no new context is marked
- keep the action consistent with existing paging and add a history notice when no older context exists
- update LLM context empty-state copy and tests

## Testing
- pnpm --filter @agyn/platform-ui lint
- pnpm --filter @agyn/platform-ui test

Refs #1322