### PR TITLE
feat: add platform-ui helm chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
       contents: read
       packages: write
     env:
-      CHARTS: "charts/platform-server charts/platform-ui"
+      CHARTS: "charts/platform-server charts/docker-runner charts/platform-ui"
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,10 @@ jobs:
             image: ghcr.io/agynio/platform-server
             dockerfile: packages/platform-server/Dockerfile
             context: .
+          - name: platform-ui
+            image: ghcr.io/agynio/platform-ui
+            dockerfile: packages/platform-ui/Dockerfile
+            context: .
           - name: docker-runner
             image: ghcr.io/agynio/docker-runner
             dockerfile: packages/docker-runner/Dockerfile
@@ -82,7 +86,7 @@ jobs:
       contents: read
       packages: write
     env:
-      CHARTS: "charts/platform-server charts/docker-runner"
+      CHARTS: "charts/platform-server charts/platform-ui"
 
     steps:
       - name: Checkout

--- a/charts/platform-ui/Chart.lock
+++ b/charts/platform-ui/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: service-base
+  repository: oci://ghcr.io/agynio/charts
+  version: 0.1.4
+digest: sha256:570721ceec7cbe765e88c4719adea845a291a5ea697fecfb41ec63e47036694d
+generated: "2026-02-24T02:32:28.204562749Z"

--- a/charts/platform-ui/Chart.yaml
+++ b/charts/platform-ui/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: platform-ui
+description: Helm chart for deploying the agyn platform UI.
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+home: https://github.com/agynio/platform
+sources:
+  - https://github.com/agynio/platform
+dependencies:
+  - name: service-base
+    version: ">=0.1.4 <1.0.0"
+    repository: oci://ghcr.io/agynio/charts

--- a/charts/platform-ui/templates/_helpers.tpl
+++ b/charts/platform-ui/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{- define "platform-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "platform-ui.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "platform-ui.name" . -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "platform-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "platform-ui.labels" -}}
+helm.sh/chart: {{ include "platform-ui.chart" . }}
+{{ include "platform-ui.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "platform-ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "platform-ui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "platform-ui.nginxConfigName" -}}
+{{- printf "%s-nginx" (include "service-base.fullname" .) -}}
+{{- end -}}
+
+{{- define "platform-ui.render" -}}
+{{- $template := .template -}}
+{{- $root := .context -}}
+{{- $values := deepCopy $root.Values -}}
+{{- $nginx := $values.nginx | default (dict) -}}
+{{- $config := $nginx.config | default (dict) -}}
+{{- if ($config.enabled | default false) -}}
+  {{- $mount := dict "name" "nginx-template" "sourceName" (include "platform-ui.nginxConfigName" $root) "type" "configMap" "mountPath" "/etc/nginx/templates/default.conf.template" "subPath" "default.conf.template" "readOnly" true -}}
+  {{- $mounts := $values.configMounts | default (list) -}}
+  {{- $mounts = append $mounts $mount -}}
+  {{- $values = set $values "configMounts" $mounts -}}
+{{- end -}}
+{{- $ctx := dict "Values" $values "Chart" $root.Chart "Capabilities" $root.Capabilities "Release" $root.Release "Files" $root.Files "Template" $root.Template -}}
+{{- include $template $ctx -}}
+{{- end -}}

--- a/charts/platform-ui/templates/configmap-nginx.yaml
+++ b/charts/platform-ui/templates/configmap-nginx.yaml
@@ -1,0 +1,78 @@
+{{- $nginx := .Values.nginx | default (dict) -}}
+{{- $config := $nginx.config | default (dict) -}}
+{{- if ($config.enabled | default false) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "platform-ui.nginxConfigName" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+data:
+  default.conf.template: |-
+    server {
+        listen {{ $nginx.port }};
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        gzip on;
+        gzip_comp_level 6;
+        gzip_min_length 256;
+        gzip_vary on;
+        gzip_types
+            text/plain
+            text/css
+            text/javascript
+            application/javascript
+            application/json
+            application/xml
+            application/xml+rss
+            image/svg+xml
+            font/woff2;
+
+        location /socket.io/ {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
+            proxy_pass ${API_UPSTREAM};
+        }
+
+        location /api/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection "";
+            proxy_read_timeout 60s;
+            proxy_pass ${API_UPSTREAM};
+        }
+
+        location {{ $nginx.healthzPath }} {
+            access_log off;
+            default_type text/plain;
+            return 200 "ok";
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        location ~* \.(?:js|css|png|jpg|jpeg|gif|svg|ico|webp|woff2?)$ {
+            expires 30d;
+            access_log off;
+            add_header Cache-Control "public, max-age=2592000, immutable";
+            try_files $uri =404;
+        }
+
+        location = /index.html {
+            add_header Cache-Control "no-cache" always;
+        }
+    }
+{{- end }}

--- a/charts/platform-ui/templates/deployment.yaml
+++ b/charts/platform-ui/templates/deployment.yaml
@@ -1,0 +1,1 @@
+{{- include "platform-ui.render" (dict "template" "service-base.deployment" "context" .) -}}

--- a/charts/platform-ui/templates/hpa.yaml
+++ b/charts/platform-ui/templates/hpa.yaml
@@ -1,0 +1,1 @@
+{{- include "platform-ui.render" (dict "template" "service-base.hpa" "context" .) -}}

--- a/charts/platform-ui/templates/ingress.yaml
+++ b/charts/platform-ui/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "platform-ui.render" (dict "template" "service-base.ingress" "context" .) -}}

--- a/charts/platform-ui/templates/pdb.yaml
+++ b/charts/platform-ui/templates/pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "platform-ui.render" (dict "template" "service-base.pdb" "context" .) -}}

--- a/charts/platform-ui/templates/rbac.yaml
+++ b/charts/platform-ui/templates/rbac.yaml
@@ -1,0 +1,1 @@
+{{- include "platform-ui.render" (dict "template" "service-base.rbac" "context" .) -}}

--- a/charts/platform-ui/templates/service.yaml
+++ b/charts/platform-ui/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "platform-ui.render" (dict "template" "service-base.service" "context" .) -}}

--- a/charts/platform-ui/templates/serviceaccount.yaml
+++ b/charts/platform-ui/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{- include "platform-ui.render" (dict "template" "service-base.serviceAccount" "context" .) -}}

--- a/charts/platform-ui/templates/servicemonitor.yaml
+++ b/charts/platform-ui/templates/servicemonitor.yaml
@@ -1,0 +1,1 @@
+{{- include "platform-ui.render" (dict "template" "service-base.metrics" "context" .) -}}

--- a/charts/platform-ui/values.schema.json
+++ b/charts/platform-ui/values.schema.json
@@ -1,0 +1,1164 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "default": ""
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "default": ""
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "imageRegistry": {
+          "type": "string",
+          "default": ""
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "default": {
+        "imageRegistry": "",
+        "imagePullSecrets": []
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository"
+      ],
+      "properties": {
+        "registry": {
+          "type": "string",
+          "default": ""
+        },
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "default": "ghcr.io/agynio/platform-ui"
+        },
+        "tag": {
+          "type": "string",
+          "default": ""
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ],
+          "default": "IfNotPresent"
+        },
+        "pullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "default": {
+        "registry": "",
+        "repository": "ghcr.io/agynio/platform-ui",
+        "tag": "",
+        "pullPolicy": "IfNotPresent",
+        "pullSecrets": []
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 2
+    },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 10
+    },
+    "updateStrategy": {
+      "type": "object",
+      "default": {}
+    },
+    "deploymentAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "fsGroup": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "default": null
+        }
+      },
+      "default": {
+        "enabled": false,
+        "fsGroup": null
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "runAsNonRoot": {
+          "type": "boolean",
+          "default": true
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean",
+          "default": true
+        },
+        "allowPrivilegeEscalation": {
+          "type": "boolean",
+          "default": false
+        },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "ALL"
+              ]
+            }
+          },
+          "default": {
+            "drop": [
+              "ALL"
+            ]
+          }
+        },
+        "seccompProfile": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "RuntimeDefault"
+              ],
+              "default": "RuntimeDefault"
+            }
+          },
+          "default": {
+            "type": "RuntimeDefault"
+          }
+        },
+        "runAsUser": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 101
+        },
+        "runAsGroup": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 101
+        }
+      },
+      "default": {
+        "enabled": true,
+        "runAsNonRoot": true,
+        "readOnlyRootFilesystem": true,
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        },
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        },
+        "runAsUser": 101,
+        "runAsGroup": 101
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "type": "string",
+          "default": ""
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        }
+      },
+      "default": {
+        "create": true,
+        "name": "",
+        "annotations": {}
+      }
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean",
+      "default": false
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": false
+        },
+        "clusterWide": {
+          "type": "boolean",
+          "default": false
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "apiGroups": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "resources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "resourceNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "verbs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "nonResourceURLs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "verbs"
+            ]
+          },
+          "default": []
+        }
+      },
+      "default": {
+        "create": false,
+        "clusterWide": false,
+        "rules": []
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "default": "ClusterIP"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "ports": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "port": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "targetPort": {
+                "oneOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                ]
+              },
+              "protocol": {
+                "type": "string",
+                "default": "TCP"
+              }
+            },
+            "required": [
+              "name",
+              "port",
+              "targetPort"
+            ]
+          },
+          "default": [
+            {
+              "name": "http",
+              "port": 3000,
+              "targetPort": "http",
+              "protocol": "TCP"
+            }
+          ]
+        }
+      },
+      "default": {
+        "enabled": true,
+        "type": "ClusterIP",
+        "annotations": {},
+        "labels": {},
+        "ports": [
+          {
+            "name": "http",
+            "port": 3000,
+            "targetPort": "http",
+            "protocol": "TCP"
+          }
+        ]
+      }
+    },
+    "containerPorts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "containerPort": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "protocol": {
+            "type": "string",
+            "default": "TCP"
+          }
+        },
+        "required": [
+          "name",
+          "containerPort"
+        ]
+      },
+      "default": [
+        {
+          "name": "http",
+          "containerPort": 3000,
+          "protocol": "TCP"
+        }
+      ]
+    },
+    "resources": {
+      "type": "object",
+      "default": {
+        "requests": {
+          "cpu": "50m",
+          "memory": "128Mi"
+        },
+        "limits": {
+          "cpu": "200m",
+          "memory": "256Mi"
+        }
+      },
+      "additionalProperties": true
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "tolerations": {
+      "type": "array",
+      "default": []
+    },
+    "affinity": {
+      "type": "object",
+      "default": {}
+    },
+    "priorityClassName": {
+      "type": "string",
+      "default": ""
+    },
+    "terminationGracePeriodSeconds": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "default": null
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "initContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "extraContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "lifecycle": {
+      "type": "object",
+      "default": {}
+    },
+    "livenessProbe": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "default": {
+        "enabled": true,
+        "httpGet": {
+          "path": "/healthz",
+          "port": "http"
+        },
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "timeoutSeconds": 5,
+        "successThreshold": 1,
+        "failureThreshold": 3
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "default": {
+        "enabled": true,
+        "httpGet": {
+          "path": "/",
+          "port": "http"
+        },
+        "initialDelaySeconds": 5,
+        "periodSeconds": 10,
+        "timeoutSeconds": 5,
+        "successThreshold": 1,
+        "failureThreshold": 3
+      }
+    },
+    "startupProbe": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "default": {
+        "enabled": false
+      }
+    },
+    "command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "envFrom": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "extraEnvVars": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "extraEnvVarsCM": {
+      "type": "string",
+      "default": ""
+    },
+    "extraEnvVarsSecret": {
+      "type": "string",
+      "default": ""
+    },
+    "configMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sourceName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "configMap",
+              "secret"
+            ],
+            "default": "configMap"
+          },
+          "mountPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "subPath": {
+            "type": "string"
+          },
+          "readOnly": {
+            "type": "boolean",
+            "default": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "path"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "sourceName",
+          "mountPath"
+        ]
+      },
+      "default": []
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 2
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 5
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "maximum": 100,
+          "default": 70
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "maximum": 100,
+          "default": null
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "behavior": {
+          "type": "object",
+          "default": {}
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": [
+              "enabled"
+            ]
+          },
+          "then": {
+            "required": [
+              "minReplicas",
+              "maxReplicas"
+            ],
+            "anyOf": [
+              {
+                "required": [
+                  "targetCPUUtilizationPercentage"
+                ]
+              },
+              {
+                "required": [
+                  "targetMemoryUtilizationPercentage"
+                ]
+              },
+              {
+                "properties": {
+                  "metrics": {
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "metrics"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "default": {
+        "enabled": false,
+        "minReplicas": 2,
+        "maxReplicas": 5,
+        "targetCPUUtilizationPercentage": 70,
+        "targetMemoryUtilizationPercentage": null,
+        "metrics": [],
+        "behavior": {}
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "minAvailable": {
+          "type": [
+            "integer",
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "maxUnavailable": {
+          "type": [
+            "integer",
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": [
+              "enabled"
+            ]
+          },
+          "then": {
+            "oneOf": [
+              {
+                "required": [
+                  "minAvailable"
+                ],
+                "properties": {
+                  "minAvailable": {
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
+                  },
+                  "maxUnavailable": {
+                    "type": "null"
+                  }
+                }
+              },
+              {
+                "required": [
+                  "maxUnavailable"
+                ],
+                "properties": {
+                  "maxUnavailable": {
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
+                  },
+                  "minAvailable": {
+                    "type": "null"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "default": {
+        "enabled": false,
+        "minAvailable": 1,
+        "maxUnavailable": null
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "ingressClassName": {
+          "type": "string",
+          "default": ""
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "hosts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": [
+                        "Exact",
+                        "Prefix",
+                        "ImplementationSpecific"
+                      ]
+                    },
+                    "servicePort": {
+                      "oneOf": [
+                        {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 65535
+                        },
+                        {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      ],
+                      "default": "http"
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "pathType"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "host",
+              "paths"
+            ]
+          },
+          "default": [
+            {
+              "host": "platform-ui.example.com",
+              "paths": [
+                {
+                  "path": "/",
+                  "pathType": "Prefix",
+                  "servicePort": "http"
+                }
+              ]
+            }
+          ]
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        }
+      },
+      "default": {
+        "enabled": false,
+        "ingressClassName": "",
+        "annotations": {},
+        "hosts": [
+          {
+            "host": "platform-ui.example.com",
+            "paths": [
+              {
+                "path": "/",
+                "pathType": "Prefix",
+                "servicePort": "http"
+              }
+            ]
+          }
+        ],
+        "tls": []
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "namespace": {
+              "type": "string",
+              "default": ""
+            },
+            "interval": {
+              "type": "string",
+              "default": ""
+            },
+            "scrapeTimeout": {
+              "type": "string",
+              "default": ""
+            },
+            "honorLabels": {
+              "type": "boolean",
+              "default": false
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {}
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {}
+            },
+            "relabelings": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "default": []
+            },
+            "metricRelabelings": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "default": []
+            },
+            "endpoints": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "port": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "path": {
+                    "type": "string",
+                    "default": "/metrics"
+                  },
+                  "interval": {
+                    "type": "string",
+                    "default": ""
+                  },
+                  "scrapeTimeout": {
+                    "type": "string",
+                    "default": ""
+                  }
+                },
+                "required": [
+                  "port"
+                ]
+              },
+              "default": [
+                {
+                  "port": "http",
+                  "path": "/metrics",
+                  "interval": "",
+                  "scrapeTimeout": ""
+                }
+              ]
+            }
+          },
+          "default": {
+            "enabled": false,
+            "namespace": "",
+            "interval": "",
+            "scrapeTimeout": "",
+            "honorLabels": false,
+            "labels": {},
+            "annotations": {},
+            "relabelings": [],
+            "metricRelabelings": [],
+            "endpoints": [
+              {
+                "port": "http",
+                "path": "/metrics",
+                "interval": "",
+                "scrapeTimeout": ""
+              }
+            ]
+          }
+        }
+      },
+      "default": {
+        "enabled": false,
+        "serviceMonitor": {
+          "enabled": false,
+          "namespace": "",
+          "interval": "",
+          "scrapeTimeout": "",
+          "honorLabels": false,
+          "labels": {},
+          "annotations": {},
+          "relabelings": [],
+          "metricRelabelings": [],
+          "endpoints": [
+            {
+              "port": "http",
+              "path": "/metrics",
+              "interval": "",
+              "scrapeTimeout": ""
+            }
+          ]
+        }
+      }
+    },
+    "nginx": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 3000
+        },
+        "healthzPath": {
+          "type": "string",
+          "pattern": "^/.+",
+          "default": "/healthz"
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          "default": {
+            "enabled": true
+          }
+        }
+      },
+      "default": {
+        "port": 3000,
+        "healthzPath": "/healthz",
+        "config": {
+          "enabled": true
+        }
+      }
+    },
+    "service-base": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/charts/platform-ui/values.yaml
+++ b/charts/platform-ui/values.yaml
@@ -1,0 +1,176 @@
+nameOverride: ""
+fullnameOverride: ""
+
+commonAnnotations: {}
+
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+
+image:
+  registry: ""
+  repository: ghcr.io/agynio/platform-ui
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+replicaCount: 2
+revisionHistoryLimit: 10
+updateStrategy: {}
+deploymentAnnotations: {}
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+automountServiceAccountToken: false
+
+rbac:
+  create: false
+  clusterWide: false
+  rules: []
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  enabled: false
+  fsGroup: null
+
+securityContext:
+  enabled: true
+  runAsUser: 101
+  runAsGroup: 101
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+priorityClassName: ""
+terminationGracePeriodSeconds: null
+
+service:
+  enabled: true
+  type: ClusterIP
+  annotations: {}
+  labels: {}
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP
+
+containerPorts:
+  - name: http
+    containerPort: 3000
+    protocol: TCP
+
+command: []
+args: []
+env: []
+envFrom: []
+extraEnvVars: []
+extraEnvVarsCM: ""
+extraEnvVarsSecret: ""
+
+configMounts: []
+extraVolumeMounts: []
+extraVolumes: []
+
+initContainers: []
+extraContainers: []
+
+lifecycle: {}
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+startupProbe:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: null
+  metrics: []
+  behavior: {}
+
+pdb:
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: null
+
+ingress:
+  enabled: false
+  ingressClassName: ""
+  annotations: {}
+  hosts:
+    - host: platform-ui.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePort: http
+  tls: []
+
+metrics:
+  enabled: false
+  serviceMonitor:
+    enabled: false
+    namespace: ""
+    interval: ""
+    scrapeTimeout: ""
+    honorLabels: false
+    labels: {}
+    annotations: {}
+    relabelings: []
+    metricRelabelings: []
+    endpoints:
+      - port: http
+        path: /metrics
+        interval: ""
+        scrapeTimeout: ""
+
+nginx:
+  port: 3000
+  healthzPath: /healthz
+  config:
+    enabled: true


### PR DESCRIPTION
## Summary
- add platform-ui Helm chart using the service-base library
- wire nginx template config and schema validation for platform-ui values
- extend release workflow to publish the platform-ui image and chart alongside existing assets

## Testing
- pnpm lint
- pnpm --filter @agyn/platform-server test -- --reporter=json
- pnpm --filter @agyn/platform-ui test -- --reporter=json
- helm lint charts/platform-ui

#1333