### PR TITLE
Prepare release v0.14.4 (changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Version v0.14.4 — 2026-02-26
+
+Summary
+
+- `shell_command`: set a default `outputLimitChars` and spill oversized output to `/tmp` (#1326)
+- UI: add LLM context history action (#1323)


### PR DESCRIPTION
## Summary
- add root `CHANGELOG.md` with `v0.14.4` release notes
- document #1326 (`shell_command` default `outputLimitChars` + oversized spill to `/tmp`)
- document #1323 (UI LLM context history action)

## Verification
- ran `rg -n \"image:|tag:|appVersion|Chart.yaml\" charts -S`
- confirmed no pinned app image tags in `platform-server`/`platform-ui` values (`tag: \"\"`), so image tag resolves via chart appVersion wiring
- noted current `appVersion` fields in `charts/platform-server/Chart.yaml` and `charts/platform-ui/Chart.yaml` are `0.1.0` and should be bumped by the release/versioning flow if required

Closes #1335