### PR TITLE
Enable WS upgrade for terminal endpoint in platform-ui nginx

### DIFF
--- a/packages/platform-ui/docker/nginx.conf.template
+++ b/packages/platform-ui/docker/nginx.conf.template
@@ -32,6 +32,20 @@ server {
         proxy_pass ${API_UPSTREAM};
     }
 
+    # Enable WebSocket upgrade for the terminal stream endpoint under /api
+    # This must be defined before the generic /api/ location to ensure matching
+    location ~ ^/api/containers/[^/]+/terminal/ws$ {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+        proxy_pass ${API_UPSTREAM};
+    }
+
     location /api/ {
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
This PR implements the fix for terminal WebSocket handshake failure when running via prebuilt images.

Related issue: https://github.com/agynio/platform/issues/1337

Problem
- Creating a terminal session (HTTP) succeeds: `POST /api/containers/{id}/terminal/sessions`.
- WebSocket handshake to `/api/containers/{id}/terminal/ws?...` fails when traffic is proxied through the prebuilt `platform-ui` nginx.

Root cause
- The `platform-ui` nginx config forwarded WS upgrade headers for `/socket.io/` but not for `/api/` routes. The terminal WS endpoint lives under `/api`, so the handshake was treated like plain HTTP and failed.

Change
- Add a dedicated nginx `location` before the generic `/api/` block to enable WS upgrade for the terminal stream endpoint:

```nginx
location ~ ^/api/containers/[^/]+/terminal/ws$ {
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_read_timeout 60s;
    proxy_pass ${API_UPSTREAM};
}
```

Validation plan (post‑merge / CI image publish)
- Build/publish the updated `platform-ui` image.
- Run the platform stack and:
  1) Create a terminal session.
  2) Confirm the WS handshake returns `101 Switching Protocols` for `/api/containers/{id}/terminal/ws?...`.
  3) Interact with the shell to verify end‑to‑end.

Notes
- This change is narrowly scoped to the terminal WS path and should not affect other `/api` routes.
- After publish, we will open a PR in `agynio/bootstrap` to bump the `platform-ui` image tag so prebuilt deployments receive the fix.