### PR TITLE
WIP: Shell exec streaming

### DIFF
--- a/packages/docker-runner/src/contracts/execStreaming.ts
+++ b/packages/docker-runner/src/contracts/execStreaming.ts
@@ -1,0 +1,31 @@
+export type ExecRunStreamReadyFrame = {
+  type: 'ready';
+  execId: string;
+};
+
+export type ExecRunStreamChunkFrame = {
+  type: 'stdout' | 'stderr';
+  seq: number;
+  data: string;
+};
+
+export type ExecRunStreamTerminalFrame = {
+  type: 'terminal';
+  seq: number;
+  exitCode: number | null;
+  signal?: string | null;
+};
+
+export type ExecRunStreamErrorFrame = {
+  type: 'error';
+  seq: number;
+  code: string;
+  message: string;
+  retryable?: boolean;
+};
+
+export type ExecRunStreamFrame =
+  | ExecRunStreamReadyFrame
+  | ExecRunStreamChunkFrame
+  | ExecRunStreamTerminalFrame
+  | ExecRunStreamErrorFrame;

--- a/packages/docker-runner/src/index.ts
+++ b/packages/docker-runner/src/index.ts
@@ -9,3 +9,4 @@ export * from './lib/types';
 export * from './contracts/auth';
 export * from './contracts/json';
 export * from './contracts/api';
+export * from './contracts/execStreaming';


### PR DESCRIPTION
## Summary
- scaffold exec streaming frame contracts for docker-runner

## Testing
- baseline vitest suites run prior to implementation; platform-server tests currently blocked by missing local services

Closes #1339