### PR TITLE
Fix: ensure tool call outputs include role 'tool'

### DIFF
--- a/packages/llm/__tests__/toolCallOutputMessage.role.test.ts
+++ b/packages/llm/__tests__/toolCallOutputMessage.role.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { ToolCallOutputMessage } from '../src/messages/toolCallOutputMessage';
+
+describe('ToolCallOutputMessage', () => {
+  it('includes role "tool" when serialized', () => {
+    const message = ToolCallOutputMessage.fromResponse('call-123', 'output value');
+
+    expect(message.toPlain()).toEqual({
+      type: 'function_call_output',
+      call_id: 'call-123',
+      output: 'output value',
+      role: 'tool',
+    });
+  });
+});

--- a/packages/llm/src/messages/toolCallOutputMessage.ts
+++ b/packages/llm/src/messages/toolCallOutputMessage.ts
@@ -27,6 +27,9 @@ export class ToolCallOutputMessage {
   }
 
   toPlain(): ResponseInputItem.FunctionCallOutput {
-    return this._source;
+    return {
+      ...this._source,
+      role: 'tool',
+    } as ResponseInputItem.FunctionCallOutput;
   }
 }

--- a/packages/platform-server/__tests__/context-items.utils.test.ts
+++ b/packages/platform-server/__tests__/context-items.utils.test.ts
@@ -243,6 +243,7 @@ describe('contextItemInputFromMessage', () => {
       outputBytes: Buffer.byteLength(binary, 'utf8'),
     });
     expect(result.contentJson).toEqual({
+      role: 'tool',
       type: 'function_call_output',
       call_id: 'call-bin',
       output: {
@@ -261,6 +262,7 @@ describe('contextItemInputFromMessage', () => {
     expect(result.contentText).toBe('plain output');
     expect(result.metadata).toEqual({ type: 'function_call_output', callId: 'call-text' });
     expect(result.contentJson).toEqual({
+      role: 'tool',
       type: 'function_call_output',
       call_id: 'call-text',
       output: 'plain output',


### PR DESCRIPTION
## Summary
- ensure tool call outputs serialize with role `tool`
- add regression test for ToolCallOutputMessage serialization

## Testing
- pnpm install --frozen-lockfile
- pnpm lint *(fails: existing @agyn/platform-server lint violations)*
- pnpm test *(fails: docker-runner tests require buf-generated protos)*
- node ../../node_modules/.bin/vitest run (packages/llm)
