### PR TITLE
fix: align runner exec timeout handling

### DIFF
--- a/docs/config/env-overlays.md
+++ b/docs/config/env-overlays.md
@@ -16,7 +16,7 @@ Shell tool
   - `cwd?: string` — optional per-call working directory override for the executed command.
 - Behavior:
   - Pass `env`, `workdir`, `executionTimeoutMs`, `idleTimeoutMs` to container.exec (per exec only).
-  - On timeout and when killOnTimeout=true, the container is stopped with a 10s grace period.
+  - Execution and idle timeouts terminate only the exec process group (SIGTERM, short grace, then SIGKILL) without stopping the container.
   - Empty string sets a variable to empty (does not unset).
 
 MCP server

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -69,7 +69,7 @@ Behaviors and failure modes
   - VERSION_CONFLICT (409), LOCK_TIMEOUT (409), PERSIST_FAILED (500).
   - Schema validation errors trigger key stripping and up to 3 retries.
 - Container exec
-  - executionTimeout and idleTimeout produce structured timeouts with captured tail output; optional killOnTimeout stops container. Benign stop/remove errors swallowed (304/404/409).
+  - executionTimeout and idleTimeout produce structured timeouts with captured tail output; runner terminates the exec process group (SIGTERM then SIGKILL) without stopping the container. Benign stop/remove errors swallowed (304/404/409).
 - MCP
   - Tool call failures normalized with message/code/retriable; transport disconnect to be handled by restart/backoff (planned).
 - Slack

--- a/packages/docker-runner/__tests__/exec.shell.command.test.ts
+++ b/packages/docker-runner/__tests__/exec.shell.command.test.ts
@@ -52,4 +52,38 @@ describe('ContainerService execContainer', () => {
     expect(result.stderr).toBe('');
     expect(containerInspect).toHaveBeenCalledTimes(1);
   });
+
+  it('sends signals to exec process group when terminating after timeout', async () => {
+    const service = new ContainerService();
+    const killSpy = vi
+      .spyOn(process, 'kill')
+      .mockImplementation(() => true as unknown as ReturnType<typeof process.kill>);
+    try {
+      const exec = {
+        inspect: vi.fn(async () => ({ ID: 'exec-xyz', Pid: 4321 })),
+      } as unknown as { inspect: () => Promise<{ ID: string; Pid: number }> };
+
+      Reflect.set(service as unknown as object, 'delay', vi.fn(async () => undefined));
+      Reflect.set(service as unknown as object, 'isProcessAlive', vi.fn(() => true));
+
+      type TerminateExecProcessFn = (
+        execLike: { inspect: () => Promise<{ ID: string; Pid: number }> },
+        context: { containerId: string; reason: 'timeout' | 'idle_timeout'; timeoutMs?: number; idleTimeoutMs?: number },
+      ) => Promise<void>;
+      const terminateExecProcess = Reflect.get(service as unknown as object, 'terminateExecProcess') as TerminateExecProcessFn;
+
+      await terminateExecProcess.call(service, exec, {
+        containerId: 'cid-xyz',
+        reason: 'timeout',
+        timeoutMs: 500,
+      });
+
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGTERM');
+      expect(killSpy).toHaveBeenCalledWith(4321, 'SIGTERM');
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGKILL');
+      expect(killSpy).toHaveBeenCalledWith(4321, 'SIGKILL');
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
 });

--- a/packages/docker-runner/src/lib/container.service.ts
+++ b/packages/docker-runner/src/lib/container.service.ts
@@ -277,23 +277,17 @@ export class ContainerService implements DockerClientPort {
       );
       return { stdout, stderr, exitCode };
     } catch (err: unknown) {
-      const isTimeout = isExecTimeoutError(err) || isExecIdleTimeoutError(err);
-      if (isTimeout && options?.killOnTimeout) {
-        // Gracefully stop the container to ensure process-tree cleanup.
-        try {
-          this.warn('Exec timeout detected; stopping container', {
-            containerId,
-            timeoutMs: options?.timeoutMs,
-            idleTimeoutMs: options?.idleTimeoutMs,
-          });
-          await this.stopContainer(containerId, 10);
-        } catch (stopErr) {
-          // Log but do not swallow original timeout error
-          this.error('Failed to stop container after exec timeout', {
-            containerId,
-            error: this.errorContext(stopErr),
-          });
-        }
+      const isHardTimeout = isExecTimeoutError(err);
+      const isIdleTimeout = isExecIdleTimeoutError(err);
+      if (isHardTimeout || isIdleTimeout) {
+        const reason = isIdleTimeout ? 'idle_timeout' : 'timeout';
+        const timeoutValue = (err as ExecTimeoutError | ExecIdleTimeoutError).timeoutMs;
+        await this.terminateExecProcess(exec, {
+          containerId,
+          reason,
+          timeoutMs: isHardTimeout ? options?.timeoutMs ?? timeoutValue : options?.timeoutMs,
+          idleTimeoutMs: isIdleTimeout ? options?.idleTimeoutMs ?? timeoutValue : options?.idleTimeoutMs,
+        });
       }
       throw err;
     }
@@ -421,6 +415,10 @@ export class ContainerService implements DockerClientPort {
     const execDetails = await exec.inspect();
     const execId = execDetails.ID ?? 'unknown';
 
+    const terminateProcessGroup = async (reason: 'timeout' | 'idle_timeout'): Promise<void> => {
+      await this.terminateExecProcess(exec, { containerId: inspectData.Id, reason });
+    };
+
     const close = async (): Promise<{ exitCode: number; stdout: string; stderr: string }> => {
       try {
         hijackStream.end();
@@ -449,6 +447,7 @@ export class ContainerService implements DockerClientPort {
       stderr: demux ? stderrStream : undefined,
       close,
       execId,
+      terminateProcessGroup,
     };
   }
 
@@ -806,6 +805,82 @@ export class ContainerService implements DockerClientPort {
         });
       });
     });
+  }
+
+  private async terminateExecProcess(
+    exec: Exec,
+    context: { containerId: string; reason: 'timeout' | 'idle_timeout'; timeoutMs?: number; idleTimeoutMs?: number },
+  ): Promise<void> {
+    try {
+      const details = await exec.inspect();
+      const execId = typeof details.ID === 'string' ? details.ID : undefined;
+      const pid = typeof details.Pid === 'number' ? details.Pid : undefined;
+      if (!pid || pid <= 0) {
+        this.warn('Exec timeout detected but PID unavailable; skipping process termination', {
+          containerId: context.containerId,
+          execId,
+          reason: context.reason,
+        });
+        return;
+      }
+
+      const baseLog: Record<string, unknown> = {
+        containerId: context.containerId,
+        execId,
+        pid,
+        reason: context.reason,
+        timeoutMs: context.timeoutMs,
+        idleTimeoutMs: context.idleTimeoutMs,
+      };
+
+      this.warn('Exec timeout detected; terminating process group', baseLog);
+      this.signalExecProcess(pid, 'SIGTERM', baseLog);
+      await this.delay(750);
+      if (!this.isProcessAlive(pid)) return;
+      this.warn('Exec process group still running after SIGTERM; sending SIGKILL', baseLog);
+      this.signalExecProcess(pid, 'SIGKILL', baseLog);
+      await this.delay(150);
+    } catch (error) {
+      this.warn('Failed to terminate exec process group after timeout', {
+        containerId: context.containerId,
+        reason: context.reason,
+        error: this.errorContext(error),
+      });
+    }
+  }
+
+  private signalExecProcess(pid: number, signal: NodeJS.Signals, context: Record<string, unknown>): void {
+    const targets = [-Math.abs(pid), pid];
+    for (const target of targets) {
+      try {
+        process.kill(target, signal);
+        this.debug('Sent signal to exec process target', { ...context, signal, target });
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err?.code === 'ESRCH') continue;
+        this.warn('Failed to signal exec process target', {
+          ...context,
+          signal,
+          target,
+          error: this.errorContext(err),
+        });
+      }
+    }
+  }
+
+  private async delay(ms: number): Promise<void> {
+    if (ms <= 0) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+
+  private isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      return err?.code !== 'ESRCH';
+    }
   }
 
   // Demultiplex docker multiplexed stream if modem.demuxStream is available; otherwise fall back to manual demux

--- a/packages/docker-runner/src/lib/types.ts
+++ b/packages/docker-runner/src/lib/types.ts
@@ -68,6 +68,7 @@ export type InteractiveExecSession = {
   stderr?: NodeJS.ReadableStream;
   close: () => Promise<ExecResult>;
   execId: string;
+  terminateProcessGroup: (reason: 'timeout' | 'idle_timeout') => Promise<void>;
 };
 
 export type LogsStreamOptions = {

--- a/packages/docker-runner/src/service/grpc/server.ts
+++ b/packages/docker-runner/src/service/grpc/server.ts
@@ -1164,20 +1164,21 @@ export function createRunnerGrpcServer(opts: RunnerGrpcOptions): Server {
             const handleTimeout = async (target: ExecutionContext, reason: ExecExitReason) => {
               if (target.finished || target.cancelRequested) return;
               target.reason = reason;
-              target.killed = target.killOnTimeout;
-              if (target.killOnTimeout) {
-                try {
-                  await opts.containers.stopContainer(target.targetId, CONTAINER_STOP_TIMEOUT_SEC);
-                } catch (stopErr) {
-                  console.warn('Failed to stop container on exec timeout', {
-                    containerId: target.targetId,
-                    error: stopErr instanceof Error ? stopErr.message : stopErr,
-                    reason,
-                  });
-                }
+              const terminationReason = reason === ExecExitReason.IDLE_TIMEOUT ? 'idle_timeout' : 'timeout';
+              try {
+                await target.session.terminateProcessGroup(terminationReason);
+                target.killed = true;
+              } catch (terminateErr) {
+                target.killed = false;
+                console.warn('Failed to terminate exec process group on timeout', {
+                  executionId: target.executionId,
+                  containerId: target.targetId,
+                  reason,
+                  error: terminateErr instanceof Error ? terminateErr.message : terminateErr,
+                });
               }
               try {
-                await target.finish?.(reason, target.killOnTimeout);
+                await target.finish?.(reason, target.killed);
               } catch {
                 // finish already emits structured error; swallow here
               }

--- a/packages/platform-server/__tests__/infra/runnerGrpc.client.test.ts
+++ b/packages/platform-server/__tests__/infra/runnerGrpc.client.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it, vi } from 'vitest';
 import { Metadata, status } from '@grpc/grpc-js';
 import { NonceCache, verifyAuthHeaders } from '@agyn/docker-runner';
 import { RUNNER_SERVICE_TOUCH_WORKLOAD_PATH } from '../../src/proto/grpc.js';
+import type { RunnerServiceGrpcClientInstance } from '../../src/proto/grpc.js';
 
 import {
   RunnerGrpcClient,
+  RunnerGrpcExecClient,
   DockerRunnerRequestError,
   EXEC_REQUEST_TIMEOUT_SLACK_MS,
 } from '../../src/infra/container/runnerGrpc.client';
+import { ExecTimeoutError } from '../../src/utils/execTimeout';
 
 describe('RunnerGrpcClient', () => {
   it('sends signed runner metadata on touchLastUsed calls', async () => {
@@ -47,11 +50,11 @@ describe('RunnerGrpcClient', () => {
     expect(verification.ok).toBe(true);
   });
 
-  it('maps gRPC errors to DockerRunnerRequestError', async () => {
+  it('sanitizes infra details from gRPC errors', async () => {
     const client = new RunnerGrpcClient({ address: 'grpc://runner', sharedSecret: 'secret' });
-    const error = Object.assign(new Error('runner missing workload'), {
-      code: status.NOT_FOUND,
-      details: 'runner missing workload',
+    const error = Object.assign(new Error('Deadline exceeded after 305.002s,LB pick: 0.001s,remote_addr=172.21.0.3:7071'), {
+      code: status.DEADLINE_EXCEEDED,
+      details: 'Deadline exceeded after 305.002s,LB pick: 0.001s,remote_addr=172.21.0.3:7071',
     });
 
     const translated = (client as unknown as {
@@ -60,11 +63,45 @@ describe('RunnerGrpcClient', () => {
 
     expect(translated).toBeInstanceOf(DockerRunnerRequestError);
     expect(translated).toMatchObject({
-      statusCode: 404,
-      errorCode: 'runner_not_found',
-      retryable: false,
-      message: 'runner missing workload',
+      statusCode: 504,
+      errorCode: 'runner_timeout',
+      retryable: true,
+      message: 'Deadline exceeded after 305.002s',
     });
+    expect(translated.message.includes('remote_addr')).toBe(false);
+    expect(translated.message.includes('LB pick')).toBe(false);
+  });
+});
+
+describe('RunnerGrpcExecClient', () => {
+  it('converts gRPC deadline exceeded errors to ExecTimeoutError', () => {
+    const execClient = new RunnerGrpcExecClient({
+      address: 'grpc://runner',
+      sharedSecret: 'secret',
+      client: {} as RunnerServiceGrpcClientInstance,
+    });
+    const mapper = (execClient as unknown as {
+      mapGrpcDeadlineToTimeout: (
+        error: Error,
+        context: { stdout: string; stderr: string; timeoutMs?: number; idleTimeoutMs?: number },
+      ) => ExecTimeoutError | undefined;
+    }).mapGrpcDeadlineToTimeout;
+
+    const error = Object.assign(new Error('Deadline exceeded after 1500ms,remote_addr=10.0.0.2:7071'), {
+      code: status.DEADLINE_EXCEEDED,
+      details: 'Deadline exceeded after 1500ms,remote_addr=10.0.0.2:7071',
+    });
+
+    const timeoutError = mapper.call(execClient, error, {
+      stdout: 'partial-out',
+      stderr: 'partial-err',
+      timeoutMs: 1500,
+    });
+
+    expect(timeoutError).toBeInstanceOf(ExecTimeoutError);
+    expect(timeoutError?.message).toBe('Exec timed out after 1500ms');
+    expect(timeoutError?.stdout).toBe('partial-out');
+    expect(timeoutError?.stderr).toBe('partial-err');
   });
 });
 

--- a/packages/platform-server/__tests__/infra/runnerGrpc.client.test.ts
+++ b/packages/platform-server/__tests__/infra/runnerGrpc.client.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { ClientDuplexStream } from '@grpc/grpc-js';
 import { Metadata, status } from '@grpc/grpc-js';
 import { NonceCache, verifyAuthHeaders } from '@agyn/docker-runner';
 import { RUNNER_SERVICE_TOUCH_WORKLOAD_PATH } from '../../src/proto/grpc.js';
@@ -11,6 +13,12 @@ import {
   EXEC_REQUEST_TIMEOUT_SLACK_MS,
 } from '../../src/infra/container/runnerGrpc.client';
 import { ExecTimeoutError } from '../../src/utils/execTimeout';
+
+class MockClientStream<Req = unknown> extends EventEmitter {
+  write = vi.fn((_chunk: Req) => true);
+  end = vi.fn(() => this);
+  cancel = vi.fn(() => undefined);
+}
 
 describe('RunnerGrpcClient', () => {
   it('sends signed runner metadata on touchLastUsed calls', async () => {
@@ -74,34 +82,43 @@ describe('RunnerGrpcClient', () => {
 });
 
 describe('RunnerGrpcExecClient', () => {
-  it('converts gRPC deadline exceeded errors to ExecTimeoutError', () => {
+  it('rejects exec calls with ExecTimeoutError when the stream exceeds its deadline', async () => {
+    const stream = new MockClientStream();
+    const execStub = vi.fn(
+      () => stream as unknown as ClientDuplexStream<unknown, unknown>,
+    );
     const execClient = new RunnerGrpcExecClient({
       address: 'grpc://runner',
       sharedSecret: 'secret',
-      client: {} as RunnerServiceGrpcClientInstance,
+      client: { exec: execStub } as unknown as RunnerServiceGrpcClientInstance,
     });
-    const mapper = (execClient as unknown as {
-      mapGrpcDeadlineToTimeout: (
-        error: Error,
-        context: { stdout: string; stderr: string; timeoutMs?: number; idleTimeoutMs?: number },
-      ) => ExecTimeoutError | undefined;
-    }).mapGrpcDeadlineToTimeout;
+
+    const execPromise = execClient.exec('container-1', ['echo', 'hi'], { timeoutMs: 1_500 });
 
     const error = Object.assign(new Error('Deadline exceeded after 1500ms,remote_addr=10.0.0.2:7071'), {
       code: status.DEADLINE_EXCEEDED,
       details: 'Deadline exceeded after 1500ms,remote_addr=10.0.0.2:7071',
     });
 
-    const timeoutError = mapper.call(execClient, error, {
-      stdout: 'partial-out',
-      stderr: 'partial-err',
-      timeoutMs: 1500,
+    queueMicrotask(() => {
+      stream.emit('error', error);
     });
 
-    expect(timeoutError).toBeInstanceOf(ExecTimeoutError);
-    expect(timeoutError?.message).toBe('Exec timed out after 1500ms');
-    expect(timeoutError?.stdout).toBe('partial-out');
-    expect(timeoutError?.stderr).toBe('partial-err');
+    const failure = await execPromise.catch((err) => err);
+
+    expect(execStub).toHaveBeenCalledTimes(1);
+    expect(stream.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: expect.objectContaining({ case: 'start' }),
+      }),
+    );
+    expect(failure).toBeInstanceOf(ExecTimeoutError);
+    expect(failure).toMatchObject({
+      timeoutMs: 1_500,
+      stdout: '',
+      stderr: '',
+      message: 'Exec timed out after 1500ms',
+    });
   });
 });
 

--- a/packages/platform-server/__tests__/tools/shell.idle.killOnTimeout.false.test.ts
+++ b/packages/platform-server/__tests__/tools/shell.idle.killOnTimeout.false.test.ts
@@ -25,13 +25,15 @@ describe('ContainerService idle timeout with killOnTimeout=false', () => {
         exec: vi.fn(async (_opts: any) => ({
           start: (_: any, cb: any) => cb(undefined, { on: () => {}, once: () => {}, pipe: () => {}, end: () => {} }),
           inspect: vi.fn(async () => ({})),
-        })),
+    })),
       })),
       modem: { demuxStream: () => {} },
     };
     (svc as any).docker = docker;
     const idleErr = new ExecIdleTimeoutError(123, '', '');
     vi.spyOn(svc as any, 'startAndCollectExec').mockRejectedValue(idleErr);
+    const terminateSpy = vi.fn(async () => undefined);
+    Reflect.set(svc as unknown as object, 'terminateExecProcess', terminateSpy);
 
     await expect(
       svc.execContainer('cid', 'echo', { idleTimeoutMs: 123, killOnTimeout: false }),
@@ -41,5 +43,7 @@ describe('ContainerService idle timeout with killOnTimeout=false', () => {
     expect(docker.getContainer).toHaveBeenCalledTimes(1);
     const stoppedCalled = docker.getContainer.mock.results.some((r: any) => r.value.stop.mock.calls.length > 0);
     expect(stoppedCalled).toBe(false);
+    expect(terminateSpy).toHaveBeenCalledTimes(1);
+    expect(terminateSpy.mock.calls[0][1]).toMatchObject({ reason: 'idle_timeout', idleTimeoutMs: 123 });
   });
 });

--- a/packages/platform-server/__tests__/tools/shell.timeout.behavior.test.ts
+++ b/packages/platform-server/__tests__/tools/shell.timeout.behavior.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ShellCommandNode } from '../../src/nodes/tools/shell_command/shell_command.node';
 import { ContainerService, ContainerHandle } from '@agyn/docker-runner';
+import type { ExecOptions } from '@agyn/docker-runner';
 import type { ContainerRegistry } from '../../src/infra/container/container.registry';
-import { ExecIdleTimeoutError } from '../../src/utils/execTimeout';
+import { ExecIdleTimeoutError, ExecTimeoutError } from '../../src/utils/execTimeout';
 import type { Mock } from 'vitest';
 import { RunEventsService } from '../../src/events/run-events.service';
 import { EventsBusService } from '../../src/events/events-bus.service';
@@ -47,6 +48,62 @@ const createShellNode = () => {
     prismaStub as any,
   );
 };
+
+describe('ShellTool killOnTimeout configuration', () => {
+  const baseCtx = {
+    threadId: 'thread-123',
+    finishSignal: { activate() {}, deactivate() {}, isActive: false },
+    callerAgent: {},
+  } as const;
+
+  it('disables killOnTimeout for buffered exec', async () => {
+    class RecordingContainer extends ContainerHandle {
+      lastExecOptions?: ExecOptions;
+      override async exec(_cmd: string | string[], options?: ExecOptions) {
+        this.lastExecOptions = options;
+        return { stdout: '', stderr: '', exitCode: 0 };
+      }
+    }
+
+    const container = new RecordingContainer(new ContainerService(makeRegistry()), 'fake-container');
+    const provider = { provide: async () => container };
+    const node = createShellNode();
+    node.setContainerProvider(provider as any);
+    await node.setConfig({});
+
+    const tool = node.getTool();
+    const result = await tool.execute({ command: 'echo buffered' } as any, baseCtx as any);
+
+    expect(typeof result).toBe('string');
+    expect(container.lastExecOptions?.killOnTimeout).toBe(false);
+  });
+
+  it('disables killOnTimeout for streaming exec', async () => {
+    class RecordingContainer extends ContainerHandle {
+      lastExecOptions?: ExecOptions;
+      override async exec(_cmd: string | string[], options?: ExecOptions) {
+        this.lastExecOptions = options;
+        return { stdout: '', stderr: '', exitCode: 0 };
+      }
+    }
+
+    const container = new RecordingContainer(new ContainerService(makeRegistry()), 'fake-container-stream');
+    const provider = { provide: async () => container };
+    const node = createShellNode();
+    node.setContainerProvider(provider as any);
+    await node.setConfig({});
+
+    const tool = node.getTool();
+    const message = await tool.executeStreaming(
+      { command: 'echo streaming' } as any,
+      baseCtx as any,
+      { runId: 'run-1', threadId: 'thread-123', eventId: 'event-1' },
+    );
+
+    expect(typeof message).toBe('string');
+    expect(container.lastExecOptions?.killOnTimeout).toBe(false);
+  });
+});
 
 describe('ShellTool timeout error message', () => {
   it('returns clear timeout message with tail header on exec timeout', async () => {
@@ -125,7 +182,7 @@ describe('ContainerService.execContainer killOnTimeout behavior', () => {
     svc = new ContainerService(makeRegistry());
   });
 
-  it('stops container on timeout when killOnTimeout=true', async () => {
+  it('terminates exec process group on hard timeout without stopping container', async () => {
     const docker = {
       getContainer: vi.fn((id: string) => ({
         inspect: vi.fn(async () => ({ Id: id, State: { Running: true } })),
@@ -140,22 +197,22 @@ describe('ContainerService.execContainer killOnTimeout behavior', () => {
 
     // Patch service docker instance without any: use Reflect.set
     Reflect.set(svc as unknown as object, 'docker', docker);
-    // Simulate timeout by throwing during exec.inspect() at end
-    // We'll patch exec.inspect via docker mock below
-    const timeoutErr = new Error('Exec timed out after 123ms');
-    // Patch startAndCollectExec behavior by providing a container.exec that yields a stream that errors
+    const terminateSpy = vi.fn(async () => undefined);
+    Reflect.set(svc as unknown as object, 'terminateExecProcess', terminateSpy);
+    const timeoutErr = new ExecTimeoutError(123, 'out', 'err');
     Reflect.set(svc as unknown as object, 'startAndCollectExec', vi.fn(async () => { throw timeoutErr; }));
 
     await expect(
       svc.execContainer('cid123', 'echo hi', { timeoutMs: 123, killOnTimeout: true }),
     ).rejects.toThrow(/timed out/);
-    // Ensure stop was called via stopContainer path (second getContainer call)
-    expect(docker.getContainer).toHaveBeenCalledTimes(2);
-    const stopped = docker.getContainer.mock.results[1].value;
-    expect(stopped.stop).toHaveBeenCalledTimes(1);
+    expect(terminateSpy).toHaveBeenCalledTimes(1);
+    const args = terminateSpy.mock.calls[0];
+    expect(args[1]).toMatchObject({ containerId: 'cid123', reason: 'timeout', timeoutMs: 123 });
+    const stoppedContainer = docker.getContainer.mock.results[0].value;
+    expect(stoppedContainer.stop).not.toHaveBeenCalled();
   });
 
-  it('does not stop container when killOnTimeout is false/omitted', async () => {
+  it('terminates exec process group on idle timeout without stopping container', async () => {
     const docker = {
       getContainer: vi.fn((id: string) => ({
         inspect: vi.fn(async () => ({ Id: id, State: { Running: true } })),
@@ -168,18 +225,18 @@ describe('ContainerService.execContainer killOnTimeout behavior', () => {
       modem: { demuxStream: () => {} },
     } as const;
     Reflect.set(svc as unknown as object, 'docker', docker);
-    const timeoutErr = new Error('Exec timed out after 456ms');
-    Reflect.set(svc as unknown as object, 'startAndCollectExec', vi.fn(async () => { throw timeoutErr; }));
+    const terminateSpy = vi.fn(async () => undefined);
+    Reflect.set(svc as unknown as object, 'terminateExecProcess', terminateSpy);
+    const idleTimeoutErr = new ExecIdleTimeoutError(456, 'partial-out', 'partial-err');
+    Reflect.set(svc as unknown as object, 'startAndCollectExec', vi.fn(async () => { throw idleTimeoutErr; }));
 
     await expect(
       svc.execContainer('cid999', 'echo nope', { timeoutMs: 456 }),
     ).rejects.toThrow(/timed out/);
-    // Ensure stop was not called on any container instance
-    const getContainerMock = docker.getContainer;
-    const anyStopped = getContainerMock.mock.results.some((r: any) => r.value.stop.mock.calls.length > 0);
-    expect(anyStopped).toBe(false);
-    // Optional: verify only one getContainer call (inspect only)
-    expect(docker.getContainer).toHaveBeenCalledTimes(1);
+    expect(terminateSpy).toHaveBeenCalledTimes(1);
+    expect(terminateSpy.mock.calls[0][1]).toMatchObject({ containerId: 'cid999', reason: 'idle_timeout', idleTimeoutMs: 456 });
+    const stoppedContainer = docker.getContainer.mock.results[0].value;
+    expect(stoppedContainer.stop).not.toHaveBeenCalled();
   });
 
   it('propagates non-timeout errors unchanged (service)', async () => {
@@ -195,6 +252,8 @@ describe('ContainerService.execContainer killOnTimeout behavior', () => {
       modem: { demuxStream: () => {} },
     } as const;
     Reflect.set(svc as unknown as object, 'docker', docker);
+    const terminateSpy = vi.fn(async () => undefined);
+    Reflect.set(svc as unknown as object, 'terminateExecProcess', terminateSpy);
     const genericErr = new Error('Some other failure');
     Reflect.set(svc as unknown as object, 'startAndCollectExec', vi.fn(async () => { throw genericErr; }));
 
@@ -204,9 +263,10 @@ describe('ContainerService.execContainer killOnTimeout behavior', () => {
     // Should not attempt stop as it is not a timeout
     const anyStopped = docker.getContainer.mock.results.some((r: any) => r.value.stop.mock.calls.length > 0);
     expect(anyStopped).toBe(false);
+    expect(terminateSpy).not.toHaveBeenCalled();
   });
 
-  it('stops container on idle timeout with killOnTimeout=true', async () => {
+  it('terminates exec process group on idle timeout with killOnTimeout=true', async () => {
     const docker = {
       getContainer: vi.fn((id: string) => ({
         inspect: vi.fn(async () => ({ Id: id, State: { Running: true } })),
@@ -219,15 +279,18 @@ describe('ContainerService.execContainer killOnTimeout behavior', () => {
       modem: { demuxStream: () => {} },
     } as const;
     Reflect.set(svc as unknown as object, 'docker', docker);
+    const terminateSpy = vi.fn(async () => undefined);
+    Reflect.set(svc as unknown as object, 'terminateExecProcess', terminateSpy);
     const idleErr = new ExecIdleTimeoutError(321, 'a', 'b');
     Reflect.set(svc as unknown as object, 'startAndCollectExec', vi.fn(async () => { throw idleErr; }));
 
     await expect(
       svc.execContainer('cidIdle', 'echo idle', { timeoutMs: 9999, idleTimeoutMs: 321, killOnTimeout: true }),
     ).rejects.toBe(idleErr);
-    expect(docker.getContainer).toHaveBeenCalledTimes(2);
-    const stopped = docker.getContainer.mock.results[1].value;
-    expect(stopped.stop).toHaveBeenCalledTimes(1);
+    expect(terminateSpy).toHaveBeenCalledTimes(1);
+    expect(terminateSpy.mock.calls[0][1]).toMatchObject({ containerId: 'cidIdle', reason: 'idle_timeout', idleTimeoutMs: 321 });
+    const stopped = docker.getContainer.mock.results[0].value;
+    expect(stopped.stop).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/platform-server/src/infra/container/runnerGrpc.client.ts
+++ b/packages/platform-server/src/infra/container/runnerGrpc.client.ts
@@ -916,6 +916,7 @@ export class RunnerGrpcExecClient {
     let finished = false;
     let finalResult: ExecResult | undefined;
     let cancelledLocally = false;
+    let forcedTerminationReason: 'timeout' | 'idle_timeout' | undefined;
     const start = this.createStartRequest({ containerId, command, interactiveOptions: options });
     const { timeoutMs: requestedTimeoutMs, idleTimeoutMs: requestedIdleTimeoutMs } = this.extractRequestedTimeouts(start);
     let readyResolve: (() => void) | undefined;
@@ -996,6 +997,23 @@ export class RunnerGrpcExecClient {
       if (event.case === 'exit') {
         const stdoutTail = Buffer.from(event.value.stdoutTail ?? new Uint8Array()).toString('utf8');
         const stderrTail = Buffer.from(event.value.stderrTail ?? new Uint8Array()).toString('utf8');
+        if (
+          forcedTerminationReason &&
+          (event.value.reason === ExecExitReason.CANCELLED || event.value.reason === ExecExitReason.COMPLETED)
+        ) {
+          const timeoutMs =
+            forcedTerminationReason === 'timeout'
+              ? this.resolveTimeoutValue(requestedTimeoutMs, requestedIdleTimeoutMs)
+              : this.resolveTimeoutValue(requestedIdleTimeoutMs, requestedTimeoutMs);
+          const forcedError =
+            forcedTerminationReason === 'timeout'
+              ? new ExecTimeoutError(timeoutMs, stdoutTail, stderrTail)
+              : new ExecIdleTimeoutError(timeoutMs, stdoutTail, stderrTail);
+          forcedTerminationReason = undefined;
+          fail(forcedError);
+          return;
+        }
+        forcedTerminationReason = undefined;
         const timeoutError = this.mapExitReasonToError(event.value.reason, {
           stdout: stdoutTail,
           stderr: stderrTail,
@@ -1131,7 +1149,34 @@ export class RunnerGrpcExecClient {
       return closePromise;
     };
 
-    return { stdin, stdout, stderr, close, execId: resolvedExecId };
+    const terminateProcessGroup = async (reason: 'timeout' | 'idle_timeout'): Promise<void> => {
+      const targetExecId = execId ?? resolvedExecId;
+      if (!targetExecId) {
+        throw new DockerRunnerRequestError(404, 'runner_exec_not_found', false, 'Execution not active');
+      }
+      this.logger?.warn('Requesting runner exec termination', {
+        execId: targetExecId,
+        reason,
+      });
+      forcedTerminationReason = reason;
+      try {
+        const cancelled = await this.cancelExecution(targetExecId, true);
+        if (cancelled) {
+          cancelledLocally = true;
+          return;
+        }
+        forcedTerminationReason = undefined;
+        this.logger?.warn('Runner exec termination request acknowledged, execution already finished', {
+          execId: targetExecId,
+          reason,
+        });
+      } catch (error) {
+        forcedTerminationReason = undefined;
+        throw error;
+      }
+    };
+
+    return { stdin, stdout, stderr, close, execId: resolvedExecId, terminateProcessGroup };
   }
 
   async resizeExec(execId: string, size: { cols: number; rows: number }): Promise<void> {

--- a/packages/platform-server/src/infra/container/runnerGrpc.client.ts
+++ b/packages/platform-server/src/infra/container/runnerGrpc.client.ts
@@ -98,6 +98,39 @@ import type { DockerClient } from './dockerClient.token';
 
 export const EXEC_REQUEST_TIMEOUT_SLACK_MS = 5_000;
 
+const RUNNER_ERROR_MESSAGE_FALLBACK = 'Runner request failed';
+
+const INFRA_DETAIL_PATTERNS = [
+  /remote_addr\s*=[^,]+/gi,
+  /\bLB pick:[^,]+/gi,
+  /\bresolver:[^,]+/gi,
+  /\bsubchannel:[^,]+/gi,
+  /\bendpoint_picker:[^,]+/gi,
+];
+
+const sanitizeInfraMessage = (message: string): string => {
+  if (!message) return '';
+  let sanitized = message;
+  for (const pattern of INFRA_DETAIL_PATTERNS) {
+    sanitized = sanitized.replace(pattern, ' ').trim();
+  }
+  sanitized = sanitized
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
+    .join(', ');
+  return sanitized.replace(/\s{2,}/g, ' ').trim();
+};
+
+const extractSanitizedServiceErrorMessage = (error: ServiceError): { sanitized: string; raw: string } => {
+  const rawDetails = typeof error.details === 'string' ? error.details : '';
+  const rawMessage = typeof error.message === 'string' ? error.message : '';
+  const raw = rawDetails || rawMessage || '';
+  const sanitizedText = sanitizeInfraMessage(raw);
+  const sanitized = sanitizedText.length > 0 ? sanitizedText : RUNNER_ERROR_MESSAGE_FALLBACK;
+  return { sanitized, raw };
+};
+
 export class DockerRunnerRequestError extends Error {
   readonly statusCode: number;
   readonly errorCode: string;
@@ -550,9 +583,9 @@ export class RunnerGrpcClient implements DockerClient {
 
   private translateServiceError(error: ServiceError, context?: { path?: string }): DockerRunnerRequestError {
     const grpcCode = typeof error.code === 'number' ? error.code : status.UNKNOWN;
-    const message = error.details || error.message || 'gRPC runner error';
+    const { sanitized: sanitizedMessage, raw: rawMessage } = extractSanitizedServiceErrorMessage(error);
     if (grpcCode === status.CANCELLED) {
-      return new DockerRunnerRequestError(499, 'runner_exec_cancelled', false, message);
+      return new DockerRunnerRequestError(499, 'runner_exec_cancelled', false, sanitizedMessage);
     }
     const statusCode = this.grpcStatusToHttpStatus(grpcCode);
     const errorCode = this.grpcStatusToErrorCode(grpcCode);
@@ -563,7 +596,8 @@ export class RunnerGrpcClient implements DockerClient {
         path,
         grpcStatus: statusName,
         grpcCode,
-        message,
+        message: sanitizedMessage,
+        rawMessage: rawMessage || undefined,
       });
     } else {
       this.logger.warn(`Runner gRPC call failed`, {
@@ -572,14 +606,15 @@ export class RunnerGrpcClient implements DockerClient {
         grpcCode,
         httpStatus: statusCode,
         errorCode,
-        message,
+        message: sanitizedMessage,
+        rawMessage: rawMessage || undefined,
       });
     }
     const retryable =
       grpcCode === status.UNAVAILABLE ||
       grpcCode === status.RESOURCE_EXHAUSTED ||
       grpcCode === status.DEADLINE_EXCEEDED;
-    return new DockerRunnerRequestError(statusCode, errorCode, retryable, message);
+    return new DockerRunnerRequestError(statusCode, errorCode, retryable, sanitizedMessage);
   }
 
   private grpcStatusToHttpStatus(grpcCode: status): number {
@@ -829,6 +864,16 @@ export class RunnerGrpcExecClient {
           fail(new DockerRunnerRequestError(499, 'runner_exec_cancelled', false, 'Execution aborted'));
           return;
         }
+        const timeoutError = this.mapGrpcDeadlineToTimeout(err, {
+          stdout: this.composeOutput(stdoutChunks),
+          stderr: this.composeOutput(stderrChunks),
+          timeoutMs: requestedTimeoutMs,
+          idleTimeoutMs: requestedIdleTimeoutMs,
+        });
+        if (timeoutError) {
+          fail(timeoutError);
+          return;
+        }
         fail(this.translateServiceError(err, { path: RUNNER_SERVICE_EXEC_PATH }));
       });
 
@@ -975,6 +1020,16 @@ export class RunnerGrpcExecClient {
 
     call.on('error', (err: ServiceError) => {
       if (finished) return;
+      const timeoutError = this.mapGrpcDeadlineToTimeout(err, {
+        stdout: finalResult?.stdout ?? '',
+        stderr: finalResult?.stderr ?? '',
+        timeoutMs: requestedTimeoutMs,
+        idleTimeoutMs: requestedIdleTimeoutMs,
+      });
+      if (timeoutError) {
+        fail(timeoutError);
+        return;
+      }
       const translated = this.translateServiceError(err, { path: RUNNER_SERVICE_EXEC_PATH });
       fail(translated);
     });
@@ -1233,6 +1288,16 @@ export class RunnerGrpcExecClient {
     return undefined;
   }
 
+  private mapGrpcDeadlineToTimeout(
+    error: ServiceError,
+    context: { stdout: string; stderr: string; timeoutMs?: number; idleTimeoutMs?: number },
+  ): ExecTimeoutError | undefined {
+    if (error.code !== status.DEADLINE_EXCEEDED) return undefined;
+    const resolved = this.resolveTimeoutValue(context.timeoutMs, context.idleTimeoutMs);
+    const effectiveTimeout = resolved > 0 ? resolved : this.defaultDeadlineMs ?? 0;
+    return new ExecTimeoutError(effectiveTimeout, context.stdout, context.stderr);
+  }
+
   private resolveTimeoutValue(primary?: number, fallback?: number): number {
     if (typeof primary === 'number' && primary > 0) return primary;
     if (typeof fallback === 'number' && fallback > 0) return fallback;
@@ -1241,9 +1306,9 @@ export class RunnerGrpcExecClient {
 
   private translateServiceError(error: ServiceError, context?: { path?: string }): DockerRunnerRequestError {
     const grpcCode = typeof error.code === 'number' ? error.code : status.UNKNOWN;
-    const message = error.details || error.message || 'gRPC runner error';
+    const { sanitized: sanitizedMessage, raw: rawMessage } = extractSanitizedServiceErrorMessage(error);
     if (grpcCode === status.CANCELLED) {
-      return new DockerRunnerRequestError(499, 'runner_exec_cancelled', false, message);
+      return new DockerRunnerRequestError(499, 'runner_exec_cancelled', false, sanitizedMessage);
     }
     const statusName = (status as unknown as Record<number, string>)[grpcCode] ?? 'UNKNOWN';
     const path = context?.path ?? RUNNER_SERVICE_EXEC_PATH;
@@ -1252,21 +1317,23 @@ export class RunnerGrpcExecClient {
         path,
         grpcStatus: statusName,
         grpcCode,
-        message,
+        message: sanitizedMessage,
+        rawMessage: rawMessage || undefined,
       });
     } else {
       this.logger?.warn(`Runner exec gRPC call failed`, {
         path,
         grpcStatus: statusName,
         grpcCode,
-        message,
+        message: sanitizedMessage,
+        rawMessage: rawMessage || undefined,
       });
     }
     const retryable =
       grpcCode === status.UNAVAILABLE ||
       grpcCode === status.RESOURCE_EXHAUSTED ||
       grpcCode === status.DEADLINE_EXCEEDED;
-    return new DockerRunnerRequestError(0, 'runner_grpc_error', retryable, message);
+    return new DockerRunnerRequestError(0, 'runner_grpc_error', retryable, sanitizedMessage);
   }
 
   private attachAbortSignal(

--- a/packages/platform-server/src/nodes/tools/shell_command/shell_command.tool.ts
+++ b/packages/platform-server/src/nodes/tools/shell_command/shell_command.tool.ts
@@ -454,7 +454,7 @@ export class ShellCommandTool extends FunctionTool<typeof bashCommandSchema> {
         workdir: cwd ?? cfg.workdir,
         timeoutMs,
         idleTimeoutMs,
-        killOnTimeout: true,
+        killOnTimeout: false,
         logToPid1: cfg.logToPid1,
         onOutput: (source, chunk) => handleChunk(source as OutputSource, chunk),
       });
@@ -772,7 +772,7 @@ export class ShellCommandTool extends FunctionTool<typeof bashCommandSchema> {
         workdir: cwd ?? cfg.workdir,
         timeoutMs: cfg.executionTimeoutMs,
         idleTimeoutMs: cfg.idleTimeoutMs,
-        killOnTimeout: true,
+        killOnTimeout: false,
         logToPid1: cfg.logToPid1,
         onOutput: (source, chunk) => {
           if (truncated && !allowNextChunkAfterTruncate) return;


### PR DESCRIPTION
## Summary
- sanitize runner gRPC deadline errors and protect exec deadline mapping
- ensure docker-runner terminates exec process groups on timeouts without killing containers
- update shell timeout docs/tests for new semantics and expose terminateProcessGroup control

## Testing
- PATH=/root/.nix-profile/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm lint
- PATH=/root/.nix-profile/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm --filter @agyn/docker-runner test
- PATH=/root/.nix-profile/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm exec vitest run __tests__/infra/runnerGrpc.client.test.ts
- PATH=/root/.nix-profile/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm exec vitest run __tests__/tools/shell.timeout.behavior.test.ts __tests__/tools/shell.idle.killOnTimeout.false.test.ts

Fixes #1347