### PR TITLE
feat(ops): configure litellm prompt logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,11 +220,16 @@ services:
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-dev-master-1234}
       LITELLM_SALT_KEY: ${LITELLM_SALT_KEY:-sk-dev-salt-1234}
       DATABASE_URL: postgresql://litellm:change-me@litellm-db:5432/litellm
-      STORE_MODEL_IN_DB: "True"
       UI_USERNAME: ${LITELLM_UI_USERNAME:-admin}
       UI_PASSWORD: ${LITELLM_UI_PASSWORD:-admin}
       PORT: "4000"
       HOST: "0.0.0.0"
+    volumes:
+      - type: bind
+        source: ./ops/litellm/proxy_config.yaml
+        target: /tmp/proxy_config.yaml
+        read_only: true
+    command: ["--config", "/tmp/proxy_config.yaml"]
     depends_on:
       litellm-db:
         condition: service_healthy
@@ -246,7 +251,7 @@ services:
       start_period: 10s
     networks:
       - agents_net
-      
+
 volumes:
   vault-file:
     driver: local

--- a/ops/litellm/proxy_config.yaml
+++ b/ops/litellm/proxy_config.yaml
@@ -1,0 +1,6 @@
+general_settings:
+  store_model_in_db: true
+  store_prompts_in_spend_logs: true
+  # Optional retention settings to control DB growth:
+  # maximum_spend_logs_retention_period: "7d"
+  # maximum_spend_logs_retention_interval: "1d"


### PR DESCRIPTION
## Summary
- add LiteLLM proxy_config.yaml with prompt/model storage defaults
- mount the config into the litellm service and start it with --config
- drop the redundant STORE_MODEL_IN_DB env so YAML is the source of truth

## Testing
- docker compose up -d litellm-db litellm
- curl -sS http://127.0.0.1:4000/chat/completions -H 'Authorization: Bearer sk-dev-master-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"log-test: say hello"}]}'
- curl -sS http://127.0.0.1:4000/spend/logs -H 'Authorization: Bearer sk-dev-master-1234' (shows request content)
- /nix/var/nix/profiles/per-user/root/profile/bin/pnpm lint *(fails: existing @typescript-eslint/no-unsafe-assignment errors in packages/platform-server/src/infra/container/runnerGrpc.client.ts)*

Local LiteLLM verification: ✅ request/response now appears in spend logs (mirrors UI Logs)

Resolves #1360