### PR TITLE
fix: sanitize MCP tool error responses

### DIFF
--- a/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
+++ b/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
@@ -10,6 +10,7 @@ import { CallAgentLinkingService } from '../src/agents/call-agent-linking.servic
 import { ShellCommandTool } from '../src/nodes/tools/shell_command/shell_command.tool';
 import { ManageFunctionTool } from '../src/nodes/tools/manage/manage.tool';
 import type { ManageToolNode } from '../src/nodes/tools/manage/manage.node';
+import { McpError } from '../src/nodes/mcp/types';
 
 const buildState = (name: string, callId: string, args: string) => {
   const response = new ResponseMessage({
@@ -109,7 +110,40 @@ describe('CallToolsLLMReducer error isolation', () => {
     const payload = parseErrorPayload(result);
     expect(payload.message).toContain('execution failed');
     expect(payload.error_code).toBe('TOOL_EXECUTION_ERROR');
-    expect(payload.details?.message).toBe('boom');
+    expect(payload.details).toMatchObject({
+      errorId: expect.any(String),
+      name: 'Error',
+    });
+    expect(payload.details.message).toBeUndefined();
+    expect(payload.details.stack).toBeUndefined();
+    expect(typeof payload.details.errorId).toBe('string');
+    expect(payload.details.errorId.length).toBeGreaterThan(0);
+  });
+
+  it('sanitizes MCP errors while preserving code and errorId', async () => {
+    const tool = {
+      name: 'mcp-failing',
+      description: 'throws McpError',
+      schema: z.object({}),
+      async execute() {
+        throw new McpError('Tool broke', 'TOOL_CALL_ERROR');
+      },
+    } as any;
+
+    const runEvents = createRunEventsStub();
+    const eventsBus = createEventsBusStub();
+    const reducer = new CallToolsLLMReducer(runEvents as any, eventsBus as any).init({ tools: [tool] });
+    const result = await reducer.invoke(buildState('mcp-failing', 'call-mcp-fail', JSON.stringify({})), ctx);
+
+    const payload = parseErrorPayload(result);
+    expect(payload.error_code).toBe('MCP_CALL_ERROR');
+    expect(payload.details).toMatchObject({
+      errorId: expect.any(String),
+      name: 'McpError',
+      code: 'TOOL_CALL_ERROR',
+    });
+    expect(payload.details.stack).toBeUndefined();
+    expect(payload.details.message).toBeUndefined();
   });
 
   it('enforces TOOL_OUTPUT_TOO_LARGE limit', async () => {

--- a/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
+++ b/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
@@ -144,12 +144,13 @@ describe('CallToolsLLMReducer error isolation', () => {
     expect(last).toBeInstanceOf(ToolCallOutputMessage);
     const text = last.text;
     expect(typeof text).toBe('string');
-    expect(text.startsWith('[exit code 17]')).toBe(true);
+    expect(text.startsWith('[exit code 17] Process exited with code 17')).toBe(true);
     expect(text).toContain('\n---\n');
     expect(text).toContain('Process exited with code 17');
     expect(text).toContain('fatal: something bad');
     expect(text).toContain('line one');
     expect(text).toContain('line two');
+    expect(text).not.toContain('Tool broke');
     expect(() => JSON.parse(text)).toThrow();
   });
 
@@ -172,9 +173,33 @@ describe('CallToolsLLMReducer error isolation', () => {
     expect(last).toBeInstanceOf(ToolCallOutputMessage);
     const text = last.text;
     expect(typeof text).toBe('string');
-    expect(text).toBe('[TOOL_CALL_ERROR] Tool broke\n---\nTool broke');
+    expect(text).toBe('[mcp_error] mcp-minimal failed\n---\nTool broke');
     expect(text).toContain('\n---\n');
     expect(() => JSON.parse(text)).toThrow();
+  });
+
+  it('deduplicates identical MCP streams in body', async () => {
+    const tool = {
+      name: 'mcp-dup',
+      description: 'throws identical streams',
+      schema: z.object({}),
+      async execute() {
+        throw new McpError('Tool duplicate', {
+          stderr: 'same output\n',
+          stdout: 'same output\n',
+        });
+      },
+    } as any;
+
+    const runEvents = createRunEventsStub();
+    const eventsBus = createEventsBusStub();
+    const reducer = new CallToolsLLMReducer(runEvents as any, eventsBus as any).init({ tools: [tool] });
+    const result = await reducer.invoke(buildState('mcp-dup', 'call-dup', JSON.stringify({})), ctx);
+
+    const last = result.messages.at(-1) as ToolCallOutputMessage;
+    expect(last).toBeInstanceOf(ToolCallOutputMessage);
+    const text = last.text;
+    expect(text).toBe('[mcp_error] mcp-dup failed\n---\nsame output');
   });
 
   it('enforces TOOL_OUTPUT_TOO_LARGE limit', async () => {

--- a/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
+++ b/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
@@ -140,21 +140,17 @@ describe('CallToolsLLMReducer error isolation', () => {
     const reducer = new CallToolsLLMReducer(runEvents as any, eventsBus as any).init({ tools: [tool] });
     const result = await reducer.invoke(buildState('mcp-failing', 'call-mcp-fail', JSON.stringify({})), ctx);
 
-    const payload = parseErrorPayload(result);
-    expect(payload.error_code).toBe('MCP_CALL_ERROR');
-    expect(payload.details).toMatchObject({
-      errorId: expect.any(String),
-      name: 'McpError',
-      code: 'TOOL_CALL_ERROR',
-      exitCode: 17,
-    });
-    expect(payload.details.stack).toBeUndefined();
-    expect(payload.details.message).toBeUndefined();
-    expect(payload.message).toBe(
-      '[exit code 17] Process exited with code 17\n' +
-        '---\n' +
-        'fatal: something bad\nretry suggestion\nline one\nline two',
-    );
+    const last = result.messages.at(-1) as ToolCallOutputMessage;
+    expect(last).toBeInstanceOf(ToolCallOutputMessage);
+    const text = last.text;
+    expect(typeof text).toBe('string');
+    expect(text.startsWith('[exit code 17]')).toBe(true);
+    expect(text).toContain('\n---\n');
+    expect(text).toContain('Process exited with code 17');
+    expect(text).toContain('fatal: something bad');
+    expect(text).toContain('line one');
+    expect(text).toContain('line two');
+    expect(() => JSON.parse(text)).toThrow();
   });
 
   it('sanitizes MCP errors without exec output data', async () => {
@@ -172,15 +168,13 @@ describe('CallToolsLLMReducer error isolation', () => {
     const reducer = new CallToolsLLMReducer(runEvents as any, eventsBus as any).init({ tools: [tool] });
     const result = await reducer.invoke(buildState('mcp-minimal', 'call-mcp-min', JSON.stringify({})), ctx);
 
-    const payload = parseErrorPayload(result);
-    expect(payload.error_code).toBe('MCP_CALL_ERROR');
-    expect(payload.message).toBe(`[TOOL_CALL_ERROR] MCP tool failed\n---\n(no output)`);
-    expect(payload.details).toMatchObject({
-      errorId: expect.any(String),
-      name: 'McpError',
-      code: 'TOOL_CALL_ERROR',
-    });
-    expect(payload.details.exitCode).toBeUndefined();
+    const last = result.messages.at(-1) as ToolCallOutputMessage;
+    expect(last).toBeInstanceOf(ToolCallOutputMessage);
+    const text = last.text;
+    expect(typeof text).toBe('string');
+    expect(text).toBe('[TOOL_CALL_ERROR] Tool broke\n---\nTool broke');
+    expect(text).toContain('\n---\n');
+    expect(() => JSON.parse(text)).toThrow();
   });
 
   it('enforces TOOL_OUTPUT_TOO_LARGE limit', async () => {

--- a/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
+++ b/packages/platform-server/__tests__/callTools.reducer.errorHandling.test.ts
@@ -120,13 +120,18 @@ describe('CallToolsLLMReducer error isolation', () => {
     expect(payload.details.errorId.length).toBeGreaterThan(0);
   });
 
-  it('sanitizes MCP errors while preserving code and errorId', async () => {
+  it('formats MCP error message with exit code and captured output', async () => {
     const tool = {
       name: 'mcp-failing',
       description: 'throws McpError',
       schema: z.object({}),
       async execute() {
-        throw new McpError('Tool broke', 'TOOL_CALL_ERROR');
+        throw new McpError('Tool broke', {
+          code: 'TOOL_CALL_ERROR',
+          exitCode: 17,
+          stderr: 'fatal: something bad\nretry suggestion\n',
+          stdout: 'line one\nline two\n',
+        });
       },
     } as any;
 
@@ -141,9 +146,41 @@ describe('CallToolsLLMReducer error isolation', () => {
       errorId: expect.any(String),
       name: 'McpError',
       code: 'TOOL_CALL_ERROR',
+      exitCode: 17,
     });
     expect(payload.details.stack).toBeUndefined();
     expect(payload.details.message).toBeUndefined();
+    expect(payload.message).toBe(
+      '[exit code 17] Process exited with code 17\n' +
+        '---\n' +
+        'fatal: something bad\nretry suggestion\nline one\nline two',
+    );
+  });
+
+  it('sanitizes MCP errors without exec output data', async () => {
+    const tool = {
+      name: 'mcp-minimal',
+      description: 'throws McpError without metadata',
+      schema: z.object({}),
+      async execute() {
+        throw new McpError('Tool broke', 'TOOL_CALL_ERROR');
+      },
+    } as any;
+
+    const runEvents = createRunEventsStub();
+    const eventsBus = createEventsBusStub();
+    const reducer = new CallToolsLLMReducer(runEvents as any, eventsBus as any).init({ tools: [tool] });
+    const result = await reducer.invoke(buildState('mcp-minimal', 'call-mcp-min', JSON.stringify({})), ctx);
+
+    const payload = parseErrorPayload(result);
+    expect(payload.error_code).toBe('MCP_CALL_ERROR');
+    expect(payload.message).toBe(`[TOOL_CALL_ERROR] MCP tool failed\n---\n(no output)`);
+    expect(payload.details).toMatchObject({
+      errorId: expect.any(String),
+      name: 'McpError',
+      code: 'TOOL_CALL_ERROR',
+    });
+    expect(payload.details.exitCode).toBeUndefined();
   });
 
   it('enforces TOOL_OUTPUT_TOO_LARGE limit', async () => {

--- a/packages/platform-server/__tests__/mcp.error.mapping.test.ts
+++ b/packages/platform-server/__tests__/mcp.error.mapping.test.ts
@@ -60,19 +60,17 @@ describe('CallToolsLLMReducer MCP error mapping', () => {
     expect(runEvents.completeToolExecution).toHaveBeenCalledTimes(1);
     const [completionPayload] = runEvents.completeToolExecution.mock.calls[0];
     expect(completionPayload.status).toBe('error');
-    expect(completionPayload.errorMessage).toBe('[mcp_error] MCP tool failed\n---\n(no output)');
+    expect(completionPayload.errorMessage).toBe(
+      '[mcp_error] apply_patch failed (code=PATCH_FAIL retriable=false)\n---\napply_patch failed (code=PATCH_FAIL retriable=false)',
+    );
 
     const lastMessage = result.messages.at(-1) as ToolCallOutputMessage;
     expect(lastMessage).toBeInstanceOf(ToolCallOutputMessage);
-    const payload = JSON.parse(lastMessage.text);
-    expect(payload.status).toBe('error');
-    expect(payload.error_code).toBe('MCP_CALL_ERROR');
-    expect(payload.message).toBe('[mcp_error] MCP tool failed\n---\n(no output)');
-    expect(payload.details).toMatchObject({
-      errorId: expect.any(String),
-      name: 'McpError',
-    });
-    expect(payload.details.code).toBeUndefined();
-    expect(payload.details.stack).toBeUndefined();
+    const text = lastMessage.text;
+    expect(typeof text).toBe('string');
+    expect(text.startsWith('[mcp_error]')).toBe(true);
+    expect(text).toContain('\n---\n');
+    expect(text).toContain('apply_patch failed (code=PATCH_FAIL retriable=false)');
+    expect(() => JSON.parse(text)).toThrow();
   });
 });

--- a/packages/platform-server/__tests__/mcp.error.mapping.test.ts
+++ b/packages/platform-server/__tests__/mcp.error.mapping.test.ts
@@ -60,16 +60,14 @@ describe('CallToolsLLMReducer MCP error mapping', () => {
     expect(runEvents.completeToolExecution).toHaveBeenCalledTimes(1);
     const [completionPayload] = runEvents.completeToolExecution.mock.calls[0];
     expect(completionPayload.status).toBe('error');
-    expect(completionPayload.errorMessage).toContain('apply_patch failed (code=PATCH_FAIL retriable=false)');
+    expect(completionPayload.errorMessage).toBe('[mcp_error] MCP tool failed\n---\n(no output)');
 
     const lastMessage = result.messages.at(-1) as ToolCallOutputMessage;
     expect(lastMessage).toBeInstanceOf(ToolCallOutputMessage);
     const payload = JSON.parse(lastMessage.text);
     expect(payload.status).toBe('error');
     expect(payload.error_code).toBe('MCP_CALL_ERROR');
-    expect(payload.message).toContain(
-      `Tool ${tool.name} execution failed: apply_patch failed (code=PATCH_FAIL retriable=false)`,
-    );
+    expect(payload.message).toBe('[mcp_error] MCP tool failed\n---\n(no output)');
     expect(payload.details).toMatchObject({
       errorId: expect.any(String),
       name: 'McpError',

--- a/packages/platform-server/__tests__/mcp.error.mapping.test.ts
+++ b/packages/platform-server/__tests__/mcp.error.mapping.test.ts
@@ -70,5 +70,11 @@ describe('CallToolsLLMReducer MCP error mapping', () => {
     expect(payload.message).toContain(
       `Tool ${tool.name} execution failed: apply_patch failed (code=PATCH_FAIL retriable=false)`,
     );
+    expect(payload.details).toMatchObject({
+      errorId: expect.any(String),
+      name: 'McpError',
+    });
+    expect(payload.details.code).toBeUndefined();
+    expect(payload.details.stack).toBeUndefined();
   });
 });

--- a/packages/platform-server/__tests__/mcp.error.mapping.test.ts
+++ b/packages/platform-server/__tests__/mcp.error.mapping.test.ts
@@ -61,14 +61,14 @@ describe('CallToolsLLMReducer MCP error mapping', () => {
     const [completionPayload] = runEvents.completeToolExecution.mock.calls[0];
     expect(completionPayload.status).toBe('error');
     expect(completionPayload.errorMessage).toBe(
-      '[mcp_error] apply_patch failed (code=PATCH_FAIL retriable=false)\n---\napply_patch failed (code=PATCH_FAIL retriable=false)',
+      '[mcp_error] demo_codex_apply_patch failed\n---\napply_patch failed (code=PATCH_FAIL retriable=false)',
     );
 
     const lastMessage = result.messages.at(-1) as ToolCallOutputMessage;
     expect(lastMessage).toBeInstanceOf(ToolCallOutputMessage);
     const text = lastMessage.text;
     expect(typeof text).toBe('string');
-    expect(text.startsWith('[mcp_error]')).toBe(true);
+    expect(text.startsWith('[mcp_error] demo_codex_apply_patch failed')).toBe(true);
     expect(text).toContain('\n---\n');
     expect(text).toContain('apply_patch failed (code=PATCH_FAIL retriable=false)');
     expect(() => JSON.parse(text)).toThrow();

--- a/packages/platform-server/src/llm/reducers/callTools.llm.reducer.ts
+++ b/packages/platform-server/src/llm/reducers/callTools.llm.reducer.ts
@@ -80,6 +80,7 @@ export class CallToolsLLMReducer extends Reducer<LLMState, LLMContext> {
         errorId,
         name: error.name,
         ...(error.code ? { code: error.code } : {}),
+        ...(typeof error.exitCode === 'number' && Number.isFinite(error.exitCode) ? { exitCode: error.exitCode } : {}),
       };
     }
 
@@ -95,6 +96,31 @@ export class CallToolsLLMReducer extends Reducer<LLMState, LLMContext> {
       name: 'UnknownError',
       ...(errorCode ? { code: errorCode } : {}),
     };
+  }
+
+  private normalizeExecOutput(output?: string | null): string {
+    if (typeof output !== 'string') return '';
+    return output.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd();
+  }
+
+  private buildMcpFailureMessage(error: McpError): string {
+    const exitCode = typeof error.exitCode === 'number' && Number.isFinite(error.exitCode) ? error.exitCode : undefined;
+    const errorCode = typeof error.code === 'string' && error.code.trim().length > 0 ? error.code.trim() : undefined;
+
+    const header = exitCode !== undefined
+      ? `[exit code ${exitCode}] Process exited with code ${exitCode}`
+      : errorCode
+        ? `[${errorCode}] MCP tool failed`
+        : '[mcp_error] MCP tool failed';
+
+    const stderr = this.normalizeExecOutput(error.stderr ?? null);
+    const stdout = this.normalizeExecOutput(error.stdout ?? null);
+    const bodyParts: string[] = [];
+    if (stderr) bodyParts.push(stderr);
+    if (stdout) bodyParts.push(stdout);
+    const body = bodyParts.length > 0 ? bodyParts.join('\n') : '(no output)';
+
+    return `${header}\n---\n${body}`;
   }
 
   private tools?: FunctionTool[];
@@ -359,12 +385,16 @@ export class CallToolsLLMReducer extends Reducer<LLMState, LLMContext> {
             error: this.errorInfo(err),
           })}`,
         );
-        const message = err instanceof Error && err.message ? err.message : 'Unknown error';
         const code = err instanceof McpError ? 'MCP_CALL_ERROR' : 'TOOL_EXECUTION_ERROR';
+        const baseMessage = err instanceof Error && err.message ? err.message : 'Unknown error';
+        const message =
+          code === 'MCP_CALL_ERROR' && err instanceof McpError
+            ? this.buildMcpFailureMessage(err)
+            : `Tool ${toolCall.name} execution failed: ${baseMessage}`;
         const details = this.buildToolErrorDetails(err, code, errorId);
         response = createErrorResponse({
           code,
-          message: `Tool ${toolCall.name} execution failed: ${message}`,
+          message,
           originalArgs: input,
           details,
         });

--- a/packages/platform-server/src/llm/reducers/callTools.llm.reducer.ts
+++ b/packages/platform-server/src/llm/reducers/callTools.llm.reducer.ts
@@ -104,23 +104,35 @@ export class CallToolsLLMReducer extends Reducer<LLMState, LLMContext> {
   }
 
   private buildMcpFailureMessage(error: McpError): string {
-    const exitCode = typeof error.exitCode === 'number' && Number.isFinite(error.exitCode) ? error.exitCode : undefined;
-    const errorCode = typeof error.code === 'string' && error.code.trim().length > 0 ? error.code.trim() : undefined;
+    const exitCode = typeof error.exitCode === 'number' && Number.isFinite(error.exitCode)
+      ? Number(error.exitCode)
+      : null;
+    const codeLabel = exitCode !== null
+      ? `exit code ${exitCode}`
+      : typeof error.code === 'string' && error.code.trim().length > 0
+        ? error.code.trim()
+        : 'mcp_error';
 
-    const header = exitCode !== undefined
-      ? `[exit code ${exitCode}] Process exited with code ${exitCode}`
-      : errorCode
-        ? `[${errorCode}] MCP tool failed`
-        : '[mcp_error] MCP tool failed';
+    const message = typeof error.message === 'string' && error.message.length > 0 ? error.message : 'MCP tool failed';
+    const shortDescription = exitCode !== null
+      ? `Process exited with code ${exitCode}`
+      : message.split(/\r?\n/, 1)[0]?.trim() || 'MCP tool failed';
 
     const stderr = this.normalizeExecOutput(error.stderr ?? null);
     const stdout = this.normalizeExecOutput(error.stdout ?? null);
-    const bodyParts: string[] = [];
-    if (stderr) bodyParts.push(stderr);
-    if (stdout) bodyParts.push(stdout);
-    const body = bodyParts.length > 0 ? bodyParts.join('\n') : '(no output)';
 
-    return `${header}\n---\n${body}`;
+    const segments: string[] = [message];
+    const streamSegments: string[] = [];
+    if (stderr) streamSegments.push(stderr);
+    if (stdout) streamSegments.push(stdout);
+    if (streamSegments.length > 0) {
+      segments.push('');
+      segments.push(streamSegments.join('\n'));
+    }
+
+    const body = segments.join('\n');
+
+    return `[${codeLabel}] ${shortDescription}\n---\n${body}`;
   }
 
   private tools?: FunctionTool[];
@@ -386,18 +398,24 @@ export class CallToolsLLMReducer extends Reducer<LLMState, LLMContext> {
           })}`,
         );
         const code = err instanceof McpError ? 'MCP_CALL_ERROR' : 'TOOL_EXECUTION_ERROR';
-        const baseMessage = err instanceof Error && err.message ? err.message : 'Unknown error';
-        const message =
-          code === 'MCP_CALL_ERROR' && err instanceof McpError
-            ? this.buildMcpFailureMessage(err)
-            : `Tool ${toolCall.name} execution failed: ${baseMessage}`;
-        const details = this.buildToolErrorDetails(err, code, errorId);
-        response = createErrorResponse({
-          code,
-          message,
-          originalArgs: input,
-          details,
-        });
+        if (err instanceof McpError) {
+          const formatted = this.buildMcpFailureMessage(err);
+          response = {
+            status: 'error',
+            raw: formatted,
+            output: formatted,
+          };
+        } else {
+          const baseMessage = err instanceof Error && err.message ? err.message : 'Unknown error';
+          const message = `Tool ${toolCall.name} execution failed: ${baseMessage}`;
+          const details = this.buildToolErrorDetails(err, code, errorId);
+          response = createErrorResponse({
+            code,
+            message,
+            originalArgs: input,
+            details,
+          });
+        }
       }
 
       if (!response) {

--- a/packages/platform-server/src/llm/reducers/callTools.llm.reducer.ts
+++ b/packages/platform-server/src/llm/reducers/callTools.llm.reducer.ts
@@ -1,6 +1,7 @@
 import { LLMContext, LLMContextState, LLMMessage, LLMState } from '../types';
 import { FunctionTool, Reducer, ResponseMessage, ToolCallMessage, ToolCallOutputMessage } from '@agyn/llm';
 import { Inject, Injectable, Logger, Scope } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
 import { McpError } from '../../nodes/mcp/types';
 import { RunEventsService } from '../../events/run-events.service';
 import { EventsBusService } from '../../events/events-bus.service';
@@ -71,6 +72,29 @@ export class CallToolsLLMReducer extends Reducer<LLMState, LLMContext> {
       return { name: error.name, message: error.message, stack: error.stack };
     }
     return { message: String(error) };
+  }
+
+  private buildToolErrorDetails(error: unknown, errorCode: ToolCallErrorCode, errorId: string): Record<string, unknown> {
+    if (error instanceof McpError) {
+      return {
+        errorId,
+        name: error.name,
+        ...(error.code ? { code: error.code } : {}),
+      };
+    }
+
+    if (error instanceof Error) {
+      return {
+        errorId,
+        name: error.name,
+      };
+    }
+
+    return {
+      errorId,
+      name: 'UnknownError',
+      ...(errorCode ? { code: errorCode } : {}),
+    };
   }
 
   private tools?: FunctionTool[];
@@ -326,17 +350,18 @@ export class CallToolsLLMReducer extends Reducer<LLMState, LLMContext> {
           };
         }
       } catch (err) {
+        const errorId = uuidv4();
         this.logger.error(
           `Error occurred while executing tool${this.format({
             tool: tool?.name ?? toolCall.name,
             callId: toolCall.callId,
+            errorId,
             error: this.errorInfo(err),
           })}`,
         );
         const message = err instanceof Error && err.message ? err.message : 'Unknown error';
-        const details =
-          err instanceof Error ? { message: err.message, name: err.name, stack: err.stack } : { error: err };
         const code = err instanceof McpError ? 'MCP_CALL_ERROR' : 'TOOL_EXECUTION_ERROR';
+        const details = this.buildToolErrorDetails(err, code, errorId);
         response = createErrorResponse({
           code,
           message: `Tool ${toolCall.name} execution failed: ${message}`,

--- a/packages/platform-server/src/llm/reducers/callTools.llm.reducer.ts
+++ b/packages/platform-server/src/llm/reducers/callTools.llm.reducer.ts
@@ -103,36 +103,43 @@ export class CallToolsLLMReducer extends Reducer<LLMState, LLMContext> {
     return output.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd();
   }
 
-  private buildMcpFailureMessage(error: McpError): string {
+  private buildMcpFailureMessage(error: McpError, toolName: string): string {
     const exitCode = typeof error.exitCode === 'number' && Number.isFinite(error.exitCode)
       ? Number(error.exitCode)
       : null;
-    const codeLabel = exitCode !== null
-      ? `exit code ${exitCode}`
-      : typeof error.code === 'string' && error.code.trim().length > 0
-        ? error.code.trim()
-        : 'mcp_error';
-
-    const message = typeof error.message === 'string' && error.message.length > 0 ? error.message : 'MCP tool failed';
-    const shortDescription = exitCode !== null
-      ? `Process exited with code ${exitCode}`
-      : message.split(/\r?\n/, 1)[0]?.trim() || 'MCP tool failed';
+    const toolLabel = typeof toolName === 'string' && toolName.trim().length > 0 ? toolName.trim() : 'tool';
+    const header = exitCode !== null
+      ? `[exit code ${exitCode}] Process exited with code ${exitCode}`
+      : `[mcp_error] ${toolLabel} failed`;
 
     const stderr = this.normalizeExecOutput(error.stderr ?? null);
     const stdout = this.normalizeExecOutput(error.stdout ?? null);
 
-    const segments: string[] = [message];
-    const streamSegments: string[] = [];
-    if (stderr) streamSegments.push(stderr);
-    if (stdout) streamSegments.push(stdout);
-    if (streamSegments.length > 0) {
-      segments.push('');
-      segments.push(streamSegments.join('\n'));
+    let bodySegments: string[] = [];
+    const hasStderr = typeof stderr === 'string' && stderr.length > 0;
+    const hasStdout = typeof stdout === 'string' && stdout.length > 0;
+
+    if (hasStderr && hasStdout) {
+      if (stderr === stdout) {
+        bodySegments = [stderr];
+      } else {
+        bodySegments = [stderr, stdout];
+      }
+    } else if (hasStderr) {
+      bodySegments = [stderr];
+    } else if (hasStdout) {
+      bodySegments = [stdout];
     }
 
-    const body = segments.join('\n');
+    if (bodySegments.length === 0) {
+      const fallbackLine = typeof error.message === 'string' && error.message.length > 0
+        ? error.message.split(/\r?\n/, 1)[0]?.trim()
+        : undefined;
+      bodySegments = [fallbackLine && fallbackLine.length > 0 ? fallbackLine : 'MCP tool failed'];
+    }
 
-    return `[${codeLabel}] ${shortDescription}\n---\n${body}`;
+    const body = bodySegments.join('\n');
+    return `${header}\n---\n${body}`;
   }
 
   private tools?: FunctionTool[];
@@ -399,7 +406,7 @@ export class CallToolsLLMReducer extends Reducer<LLMState, LLMContext> {
         );
         const code = err instanceof McpError ? 'MCP_CALL_ERROR' : 'TOOL_EXECUTION_ERROR';
         if (err instanceof McpError) {
-          const formatted = this.buildMcpFailureMessage(err);
+          const formatted = this.buildMcpFailureMessage(err, tool?.name ?? toolCall.name);
           response = {
             status: 'error',
             raw: formatted,

--- a/packages/platform-server/src/nodes/mcp/localMcpServer.node.ts
+++ b/packages/platform-server/src/nodes/mcp/localMcpServer.node.ts
@@ -450,6 +450,23 @@ export class LocalMCPServerNode extends Node<z.infer<typeof LocalMcpServerStatic
         raw: result,
       };
     } catch (e: unknown) {
+      let exitCode: number | undefined;
+      let stdout = '';
+      let stderr = '';
+      if (transport) {
+        try {
+          await transport.close();
+        } catch (closeErr) {
+          this.logger.error(
+            `[MCP:${this.config.namespace}] Error closing transport after tool failure error=${this.formatError(closeErr)}`,
+          );
+        }
+        const execResult = transport.getExecResult();
+        exitCode = execResult.exitCode;
+        stdout = execResult.stdout;
+        stderr = execResult.stderr;
+        transport = undefined;
+      }
       const errObj = e as { code?: string } | unknown;
       const emsg =
         e && typeof e === 'object' && 'message' in e ? String((e as { message?: unknown }).message) : String(e);
@@ -458,7 +475,13 @@ export class LocalMCPServerNode extends Node<z.infer<typeof LocalMcpServerStatic
         errObj && typeof errObj === 'object' && 'code' in errObj
           ? String((errObj as { code?: unknown }).code)
           : 'TOOL_CALL_ERROR';
-      throw new McpError(`Tool '${name}' failed: ${ename}: ${emsg}`.trim(), code);
+      throw new McpError(`Tool '${name}' failed: ${ename}: ${emsg}`.trim(), {
+        code,
+        cause: e,
+        exitCode,
+        stdout,
+        stderr,
+      });
     } finally {
       // Clean up after tool call
       if (client) {

--- a/packages/platform-server/src/nodes/mcp/types.ts
+++ b/packages/platform-server/src/nodes/mcp/types.ts
@@ -58,14 +58,37 @@ export interface JsonRpcTransport {
   sessionId?: string; // optional for reconnect semantics (unused for now)
 }
 
+export type McpErrorOptions = {
+  code?: string;
+  cause?: unknown;
+  exitCode?: number | null;
+  stdout?: string;
+  stderr?: string;
+};
+
 export class McpError extends Error {
   public code?: string;
+  public exitCode?: number;
+  public stdout?: string;
+  public stderr?: string;
 
-  constructor(message: string, codeOrOptions?: string | { code?: string; cause?: unknown }) {
+  constructor(message: string, codeOrOptions?: string | McpErrorOptions) {
     const hasOptionsObject = typeof codeOrOptions === 'object' && codeOrOptions !== null;
-    const cause = hasOptionsObject ? (codeOrOptions as { cause?: unknown }).cause : undefined;
+    const options = hasOptionsObject ? (codeOrOptions as McpErrorOptions) : undefined;
+    const cause = options?.cause;
     super(message, cause !== undefined ? { cause } : undefined);
-    this.code = hasOptionsObject ? (codeOrOptions as { code?: string }).code : codeOrOptions;
+    this.code = hasOptionsObject ? options?.code : (codeOrOptions as string | undefined);
+    if (options) {
+      if (typeof options.exitCode === 'number' && Number.isFinite(options.exitCode)) {
+        this.exitCode = options.exitCode;
+      }
+      if (typeof options.stdout === 'string') {
+        this.stdout = options.stdout;
+      }
+      if (typeof options.stderr === 'string') {
+        this.stderr = options.stderr;
+      }
+    }
     this.name = 'McpError';
   }
 }

--- a/packages/platform-server/src/nodes/mcp/workspaceExecTransport.ts
+++ b/packages/platform-server/src/nodes/mcp/workspaceExecTransport.ts
@@ -42,6 +42,10 @@ export class WorkspaceExecTransport {
   private stdin?: NodeJS.WritableStream;
   private stdout = new PassThrough();
   private stderr = new PassThrough();
+  private stdoutText = '';
+  private stderrText = '';
+  private execResult: { exitCode?: number; stdout: string; stderr: string } | null = null;
+  private sessionClosePromise?: Promise<void>;
   private closed = false;
   private static seq = 0;
   private readonly id = ++WorkspaceExecTransport.seq;
@@ -73,14 +77,17 @@ export class WorkspaceExecTransport {
     }
 
     this.stdout.on('data', (chunk: Buffer) => {
-      this.logger.debug(`[WorkspaceExecTransport#${this.id} stdout] ${chunk.toString().trim()}`);
+      const text = chunk.toString('utf8');
+      this.stdoutText += text;
+      this.logger.debug(`[WorkspaceExecTransport#${this.id} stdout] ${text.trim()}`);
       this.readBuffer.append(chunk);
       this.processReadBuffer();
     });
     this.stdout.on('error', (err) => this.onerror?.(err));
 
     this.stderr.on('data', (chunk: Buffer) => {
-      const text = chunk.toString();
+      const text = chunk.toString('utf8');
+      this.stderrText += text;
       if (text.trim().length > 0) {
         this.logger.error(`[WorkspaceExecTransport#${this.id} stderr] ${text.trim()}`);
       }
@@ -131,7 +138,7 @@ export class WorkspaceExecTransport {
       // ignore errors closing stdin
     }
     try {
-      await this.session?.close().catch(() => undefined);
+      await this.ensureSessionClosed();
     } catch {
       // ignore close errors
     }
@@ -142,7 +149,57 @@ export class WorkspaceExecTransport {
   private handleClose(): void {
     if (this.closed) return;
     this.closed = true;
-    this.logger.log(`[WorkspaceExecTransport#${this.id}] STREAM CLOSED`);
-    this.onclose?.();
+    this.ensureSessionClosed()
+      .catch((err) => {
+        this.logger.warn(`[WorkspaceExecTransport#${this.id}] Failed to finalize session error=${(err as Error).message}`);
+      })
+      .finally(() => {
+        this.logger.log(`[WorkspaceExecTransport#${this.id}] STREAM CLOSED`);
+        this.onclose?.();
+      });
+  }
+
+  private async ensureSessionClosed(): Promise<void> {
+    if (!this.session) {
+      this.setExecResult();
+      return;
+    }
+    if (!this.sessionClosePromise) {
+      this.sessionClosePromise = this.session
+        .close()
+        .then((result) => {
+          this.setExecResult(result ?? undefined);
+        })
+        .catch((err) => {
+          this.logger.warn(
+            `[WorkspaceExecTransport#${this.id}] session.close() failed error=${err instanceof Error ? err.message : String(err)}`,
+          );
+          this.setExecResult();
+        });
+    }
+    await this.sessionClosePromise;
+  }
+
+  private setExecResult(result?: { exitCode: number; stdout: string; stderr: string }): void {
+    if (this.execResult) return;
+    const normalizedExit = result && Number.isFinite(result.exitCode) ? result.exitCode : undefined;
+    const stdout = result?.stdout ?? this.stdoutText;
+    const stderr = result?.stderr ?? this.stderrText;
+    this.execResult = {
+      exitCode: normalizedExit,
+      stdout,
+      stderr,
+    };
+  }
+
+  getExecResult(): { exitCode?: number; stdout: string; stderr: string } {
+    if (this.execResult) {
+      return { ...this.execResult };
+    }
+    return {
+      exitCode: undefined,
+      stdout: this.stdoutText,
+      stderr: this.stderrText,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- ensure CallToolsLLMReducer omits stacks from error payloads and emits correlation errorId
- log full stack with errorId context for diagnostics and sanitize MCP error details
- update error handling tests for generic tools and MCP-specific flows

## Testing
- /root/.nix-profile/bin/pnpm --filter @agyn/platform-server exec eslint src/llm/reducers/callTools.llm.reducer.ts __tests__/callTools.reducer.errorHandling.test.ts __tests__/mcp.error.mapping.test.ts
- /root/.nix-profile/bin/pnpm exec vitest run __tests__/callTools.reducer.errorHandling.test.ts __tests__/mcp.error.mapping.test.ts

Closes #1362