### PR TITLE
feat(platform-server): use grpc notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ charts/platform-server/charts/
 # Generated protobuf outputs
 packages/**/src/proto/gen/
 packages/runner-proto/src/gen/
-
+.bufbuild/
 .devspace

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Intended use cases:
 - Operating a local development environment with supporting infra.
 
 ## Repository Structure
-- docker-compose.yml — Development infra: Postgres, agents-db, Vault (+ auto-init), NCPS, LiteLLM, cAdvisor, Prometheus, Grafana.
+  - docker-compose.yml — Development infra: Postgres, agents-db, Vault (+ auto-init), NCPS, LiteLLM, Redis, notifications, notifications-gateway, cAdvisor, Prometheus, Grafana.
 - .github/workflows/
   - ci.yml — Linting, tests (server/UI), Storybook build + smoke, type-check build steps.
   - docker-ghcr.yml — Build and publish platform-server and platform-ui images to GHCR.
@@ -122,7 +122,8 @@ pnpm install
 ```bash
 docker compose up -d
 # Starts postgres (5442), agents-db (5443), vault (8200), ncps (8501),
-# litellm (127.0.0.1:4000)
+# litellm (127.0.0.1:4000), redis (6379), notifications (9090),
+# notifications-gateway (3011), docker-runner (50051)
 # Optional monitoring (prometheus/grafana) lives in docker-compose.monitoring.yml.
 # Enable with: docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 ```
@@ -197,6 +198,8 @@ Key environment variables (server) from packages/platform-server/.env.example an
   - DOCKER_RUNNER_CONNECT_RETRY_JITTER_MS (default 250)
   - DOCKER_RUNNER_CONNECT_PROBE_INTERVAL_MS (default 30000 while runner is healthy)
   - DOCKER_RUNNER_CONNECT_MAX_RETRIES (default 0 → unlimited background retries)
+- Notifications:
+  - NOTIFICATIONS_GRPC_ADDR (optional; e.g. notifications:9090 or localhost:9090)
 - Volume GC:
   - VOLUME_GC_ENABLED (default true)
   - VOLUME_GC_INTERVAL_MS (default 60000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,54 @@ services:
       retries: 5
       start_period: 20s
 
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    networks:
+      - agents_net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  notifications:
+    image: ghcr.io/agynio/notifications:edge
+    container_name: notifications
+    restart: unless-stopped
+    environment:
+      GRPC_ADDR: 0.0.0.0:9090
+      REDIS_ADDR: redis:6379
+      REDIS_DB: "0"
+      REDIS_CHANNEL: notifications.v1
+    ports:
+      - "9090:9090"
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - agents_net
+
+  notifications-gateway:
+    image: ghcr.io/agynio/notifications-gateway:edge
+    container_name: notifications-gateway
+    restart: unless-stopped
+    environment:
+      HTTP_ADDR: 0.0.0.0:3011
+      REDIS_ADDR: redis:6379
+      REDIS_DB: "0"
+      REDIS_CHANNEL: notifications.v1
+    ports:
+      - "3011:3011"
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - agents_net
+
   # LiteLLM Postgres database
   litellm-db:
     image: postgres:16-alpine

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ How these docs are organized
 Index
 - Product Spec: [product-spec.md](product-spec.md)
 - API Reference: [api/index.md](api/index.md)
+  - Realtime notifications: socket payloads are published via the notifications service and served by notifications-gateway when running docker-compose.yml.
 - Graph
   - Filesystem Store: [graph/fs-store.md](graph/fs-store.md)
   - Status Updates: [graph/status-updates.md](graph/status-updates.md)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "pnpm -r --workspace-concurrency=1 run --if-present test",
     "convert-graphs": "pnpm --filter @agyn/graph-converter exec graph-converter",
     "postinstall": "pnpm -r --if-present run prepare",
-    "proto:generate": "buf generate buf.build/agynio/api",
+    "proto:generate": "buf export buf.build/agynio/api --output .bufbuild && buf generate .bufbuild --template buf.gen.yaml",
     "deps:up:podman": "podman compose up -d"
   },
   "keywords": [],

--- a/packages/platform-server/.env.example
+++ b/packages/platform-server/.env.example
@@ -48,6 +48,10 @@ DOCKER_RUNNER_SHARED_SECRET=dev-shared-secret
 # DOCKER_RUNNER_TIMEOUT_MS=30000
 # DOCKER_RUNNER_CONNECT_MAX_RETRIES=0
 
+# Notifications gRPC endpoint (optional; recommended with notifications service)
+# Example: notifications:9090
+# NOTIFICATIONS_GRPC_ADDR=notifications:9090
+
 # Nix cache proxy (ncps) endpoints
 # NCPS_URL_SERVER=http://localhost:8501
 # NCPS_URL_CONTAINER=http://ncps:8501

--- a/packages/platform-server/__e2e__/bootstrap.di.test.ts
+++ b/packages/platform-server/__e2e__/bootstrap.di.test.ts
@@ -22,7 +22,8 @@ const REQUIRED_ENV = {
   OPENAI_API_KEY: 'sk-test-openai',
   LITELLM_BASE_URL: `http://127.0.0.1:${LITELLM_PORT}`,
   LITELLM_MASTER_KEY: 'sk-test-master-key',
-  AGENTS_DATABASE_URL: 'postgresql://postgres:postgres@127.0.0.1:5432/agents_test?schema=public',
+  AGENTS_DATABASE_URL:
+    process.env.AGENTS_DATABASE_URL ?? 'postgresql://postgres:postgres@127.0.0.1:5432/agents_test?schema=public',
   DOCKER_RUNNER_GRPC_HOST: '127.0.0.1',
   DOCKER_RUNNER_PORT: '59999',
   DOCKER_RUNNER_SHARED_SECRET: 'dev-shared-secret',

--- a/packages/platform-server/__e2e__/graph.socket.gateway.e2e.test.ts
+++ b/packages/platform-server/__e2e__/graph.socket.gateway.e2e.test.ts
@@ -17,6 +17,7 @@ import { PrismaService } from '../src/core/services/prisma.service';
 import { ContainerTerminalGateway } from '../src/infra/container/terminal.gateway';
 import { TerminalSessionsService, type TerminalSessionRecord } from '../src/infra/container/terminal.sessions.service';
 import { DockerRunnerStatusService } from '../src/infra/container/dockerRunnerStatus.service';
+import { NotificationsPublisher } from '../src/notifications/notifications.publisher';
 import {
   WorkspaceProvider,
   type WorkspaceKey,
@@ -220,6 +221,12 @@ class TerminalSessionsServiceStub {
   }
 }
 
+class NotificationsPublisherStub {
+  async publish(): Promise<void> {
+    return;
+  }
+}
+
 type RunEventRecordStub = {
   id: string;
   runId: string;
@@ -323,6 +330,7 @@ describe('Socket gateway real server handshakes', () => {
         { provide: TerminalSessionsService, useClass: TerminalSessionsServiceStub },
         { provide: WorkspaceProvider, useClass: WorkspaceProviderStub },
         { provide: DockerRunnerStatusService, useValue: runnerStatusStub },
+        { provide: NotificationsPublisher, useClass: NotificationsPublisherStub },
         EventsBusService,
         RunEventsService,
       ],

--- a/packages/platform-server/__tests__/graph.socket.gateway.bus.test.ts
+++ b/packages/platform-server/__tests__/graph.socket.gateway.bus.test.ts
@@ -115,8 +115,9 @@ function createGatewayTestContext(): GatewayTestContext {
   const runtime = { subscribe: vi.fn() } as any;
   const metrics = { getThreadsMetrics: vi.fn().mockResolvedValue({}) } as any;
   const prisma = { getClient: vi.fn().mockReturnValue({ $queryRaw: vi.fn().mockResolvedValue([]) }) } as any;
+  const notificationsPublisher = { publish: vi.fn() } as any;
 
-  const gateway = new GraphSocketGateway(runtime, metrics, prisma, eventsBus as EventsBusService);
+  const gateway = new GraphSocketGateway(runtime, metrics, prisma, eventsBus as EventsBusService, notificationsPublisher);
   const internalLogger = (gateway as unknown as { logger: { warn: (...args: unknown[]) => void; error: (...args: unknown[]) => void; log: (...args: unknown[]) => void; debug: (...args: unknown[]) => void } }).logger;
   const logger = {
     warn: vi.spyOn(internalLogger, 'warn').mockImplementation(() => undefined),

--- a/packages/platform-server/__tests__/run-events.publish.test.ts
+++ b/packages/platform-server/__tests__/run-events.publish.test.ts
@@ -37,7 +37,8 @@ maybeDescribe('RunEventsService publishEvent broadcasting', () => {
     const runtime = { subscribe: vi.fn() } as any;
     const metrics = { getThreadsMetrics: vi.fn().mockResolvedValue({}) } as any;
     const prismaStub = { getClient: vi.fn().mockReturnValue({ $queryRaw: vi.fn().mockResolvedValue([]) }) } as any;
-    gateway = new GraphSocketGateway(runtime, metrics, prismaStub, eventsBus);
+    const notificationsPublisher = { publish: vi.fn() } as any;
+    gateway = new GraphSocketGateway(runtime, metrics, prismaStub, eventsBus, notificationsPublisher);
     emitRunEventSpy = vi.spyOn(gateway, 'emitRunEvent');
     await gateway.onModuleInit();
   });

--- a/packages/platform-server/__tests__/socket.events.test.ts
+++ b/packages/platform-server/__tests__/socket.events.test.ts
@@ -31,7 +31,14 @@ describe('Socket events', () => {
       subscribeToThreadMetrics: () => () => {},
       subscribeToThreadMetricsAncestors: () => () => {},
     };
-    const gateway = new GraphSocketGateway(runtimeStub, metrics, prismaStub, eventsBusStub as any);
+    const notificationsPublisher = { publish: vi.fn() } as any;
+    const gateway = new GraphSocketGateway(
+      runtimeStub,
+      metrics,
+      prismaStub,
+      eventsBusStub as any,
+      notificationsPublisher,
+    );
     gateway.init({ server: fastify.server });
 
     const emitMap = new Map<string, ReturnType<typeof vi.fn>>();
@@ -81,7 +88,14 @@ describe('Socket events', () => {
       subscribeToThreadMetrics: () => () => {},
       subscribeToThreadMetricsAncestors: () => () => {},
     };
-    const gateway = new GraphSocketGateway(runtimeStub, metrics, prismaStub, eventsBusStub as any);
+    const notificationsPublisher = { publish: vi.fn() } as any;
+    const gateway = new GraphSocketGateway(
+      runtimeStub,
+      metrics,
+      prismaStub,
+      eventsBusStub as any,
+      notificationsPublisher,
+    );
     gateway.init({ server: fastify.server });
     const emitMap = new Map<string, ReturnType<typeof vi.fn>>();
     const toSpy = vi.fn((room: string) => {
@@ -115,7 +129,14 @@ describe('Socket events', () => {
       subscribeToThreadMetrics: () => () => {},
       subscribeToThreadMetricsAncestors: () => () => {},
     };
-    const gateway = new GraphSocketGateway(runtimeStub, metrics, prismaStub, eventsBusStub as any);
+    const notificationsPublisher = { publish: vi.fn() } as any;
+    const gateway = new GraphSocketGateway(
+      runtimeStub,
+      metrics,
+      prismaStub,
+      eventsBusStub as any,
+      notificationsPublisher,
+    );
     gateway.init({ server: fastify.server });
     const emitMap = new Map<string, ReturnType<typeof vi.fn>>();
     const toSpy = vi.fn((room: string) => {

--- a/packages/platform-server/__tests__/socket.gateway.test.ts
+++ b/packages/platform-server/__tests__/socket.gateway.test.ts
@@ -24,7 +24,14 @@ describe('GraphSocketGateway', () => {
       subscribeToThreadMetrics: () => () => {},
       subscribeToThreadMetricsAncestors: () => () => {},
     };
-    const gateway = new GraphSocketGateway(runtimeStub, metrics, prismaStub, eventsBusStub as any);
+    const notificationsPublisher = { publish: async () => {} } as any;
+    const gateway = new GraphSocketGateway(
+      runtimeStub,
+      metrics,
+      prismaStub,
+      eventsBusStub as any,
+      notificationsPublisher,
+    );
     expect(() => gateway.init({ server: fastify.server })).not.toThrow();
   });
 });

--- a/packages/platform-server/__tests__/socket.metrics.coalesce.test.ts
+++ b/packages/platform-server/__tests__/socket.metrics.coalesce.test.ts
@@ -27,7 +27,14 @@ describe('GraphSocketGateway metrics coalescing', () => {
       subscribeToThreadMetrics: () => () => {},
       subscribeToThreadMetricsAncestors: () => () => {},
     };
-    const gateway = new GraphSocketGateway(runtimeStub, metricsStub, prismaStub, eventsBusStub as any);
+    const notificationsPublisher = { publish: vi.fn() } as any;
+    const gateway = new GraphSocketGateway(
+      runtimeStub,
+      metricsStub,
+      prismaStub,
+      eventsBusStub as any,
+      notificationsPublisher,
+    );
     // Attach and stub io emit sink
     gateway.init({ server: fastify.server });
     const captured: Array<{ room: string; event: string; payload: any }> = [];

--- a/packages/platform-server/__tests__/socket.node_status.integration.test.ts
+++ b/packages/platform-server/__tests__/socket.node_status.integration.test.ts
@@ -29,7 +29,14 @@ describe('Gateway node_status integration', () => {
       subscribeToThreadMetrics: () => () => {},
       subscribeToThreadMetricsAncestors: () => () => {},
     };
-    const gateway = new GraphSocketGateway(runtimeStub, metricsStub as any, prismaStub as any, eventsBusStub as any);
+    const notificationsPublisher = { publish: async () => {} };
+    const gateway = new GraphSocketGateway(
+      runtimeStub,
+      metricsStub as any,
+      prismaStub as any,
+      eventsBusStub as any,
+      notificationsPublisher as any,
+    );
     gateway.init({ server: fastify.server });
     const node = new DummyNode();
     node.init({ nodeId: 'nX' });

--- a/packages/platform-server/__tests__/socket.realtime.integration.test.ts
+++ b/packages/platform-server/__tests__/socket.realtime.integration.test.ts
@@ -144,7 +144,14 @@ if (!shouldRunRealtimeTests) {
     await new Promise((resolve) => server.listen(0, resolve));
     const { port } = server.address() as AddressInfo;
     const eventsBus = createEventsBusNoop();
-    const gateway = new GraphSocketGateway(runtime, metricsDouble.service, prismaStub, eventsBus);
+    const notificationsPublisher = { publish: vi.fn() } as any;
+    const gateway = new GraphSocketGateway(
+      runtime,
+      metricsDouble.service,
+      prismaStub,
+      eventsBus,
+      notificationsPublisher,
+    );
     gateway.onModuleInit();
     gateway.init({ server });
 
@@ -203,7 +210,14 @@ if (!shouldRunRealtimeTests) {
     const prismaService = ({ getClient: () => prisma }) as PrismaService;
     const runEvents = new RunEventsService(prismaService);
     const eventsBus = new EventsBusService(runEvents);
-    const gateway = new GraphSocketGateway(runtime, metricsDouble.service, prismaService, eventsBus);
+    const notificationsPublisher = { publish: vi.fn() } as any;
+    const gateway = new GraphSocketGateway(
+      runtime,
+      metricsDouble.service,
+      prismaService,
+      eventsBus,
+      notificationsPublisher,
+    );
     gateway.onModuleInit();
 
     const server = createServer();
@@ -267,7 +281,14 @@ if (!shouldRunRealtimeTests) {
     const prismaService = ({ getClient: () => prisma }) as PrismaService;
     const runEvents = new RunEventsService(prismaService);
     const eventsBus = new EventsBusService(runEvents);
-    const gateway = new GraphSocketGateway(runtime, metricsDouble.service, prismaService, eventsBus);
+    const notificationsPublisher = { publish: vi.fn() } as any;
+    const gateway = new GraphSocketGateway(
+      runtime,
+      metricsDouble.service,
+      prismaService,
+      eventsBus,
+      notificationsPublisher,
+    );
     gateway.onModuleInit();
 
     const server = createServer();

--- a/packages/platform-server/__tests__/sql.threads.metrics.queries.test.ts
+++ b/packages/platform-server/__tests__/sql.threads.metrics.queries.test.ts
@@ -64,7 +64,14 @@ describe('SQL: WITH RECURSIVE and UUID casts', () => {
     const metricsStub = { getThreadsMetrics: vi.fn(async () => ({})) };
     const runtimeStub = { subscribe: () => () => {} } as any;
     const eventsBusStub = {} as any;
-    const gateway = new GraphSocketGateway(runtimeStub, metricsStub as any, prismaStub, eventsBusStub);
+    const notificationsPublisher = { publish: vi.fn() } as any;
+    const gateway = new GraphSocketGateway(
+      runtimeStub,
+      metricsStub as any,
+      prismaStub,
+      eventsBusStub,
+      notificationsPublisher,
+    );
 
     const scheduled: string[] = [];
     // Spy/override scheduleThreadMetrics to capture scheduled ids

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -25,6 +25,8 @@
     "@agyn/json-schema-to-zod": "workspace:*",
     "@agyn/llm": "workspace:*",
     "@bufbuild/protobuf": "^2.11.0",
+    "@connectrpc/connect": "^2.1.1",
+    "@connectrpc/connect-node": "^2.1.1",
     "@grpc/grpc-js": "^1.12.2",
     "@fastify/cors": "^11.1.0",
     "@fastify/websocket": "^11.2.0",

--- a/packages/platform-server/src/core/services/config.service.ts
+++ b/packages/platform-server/src/core/services/config.service.ts
@@ -229,6 +229,7 @@ export const configSchema = z.object({
     }),
   ncpsAuthHeader: z.string().optional(),
   ncpsAuthToken: z.string().optional(),
+  notificationsGrpcAddr: z.string().min(1).optional(),
   agentsDatabaseUrl: z.string().min(1, 'Agents database connection string is required'),
   // CORS origins (comma-separated in env; parsed to string[])
   corsOrigins: z
@@ -532,6 +533,9 @@ export class ConfigService implements Config {
   get ncpsAuthToken(): string | undefined {
     return this.params.ncpsAuthToken;
   }
+  get notificationsGrpcAddr(): string | undefined {
+    return this.params.notificationsGrpcAddr;
+  }
   get agentsDatabaseUrl(): string {
     return this.params.agentsDatabaseUrl;
   }
@@ -612,6 +616,7 @@ export class ConfigService implements Config {
       ncpsRotationGraceMinutes: process.env.NCPS_ROTATION_GRACE_MINUTES,
       ncpsAuthHeader: process.env.NCPS_AUTH_HEADER,
       ncpsAuthToken: process.env.NCPS_AUTH_TOKEN,
+      notificationsGrpcAddr: ConfigService.coerceString(process.env.NOTIFICATIONS_GRPC_ADDR),
       agentsDatabaseUrl: process.env.AGENTS_DATABASE_URL,
       corsOrigins: process.env.CORS_ORIGINS,
       volumeGcSweepTimeoutMs: process.env.VOLUME_GC_SWEEP_TIMEOUT_MS,

--- a/packages/platform-server/src/gateway/gateway.module.ts
+++ b/packages/platform-server/src/gateway/gateway.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { GraphApiModule } from '../graph/graph-api.module';
 import { EventsModule } from '../events/events.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { GraphSocketGateway } from './graph.socket.gateway';
 
 @Module({
-  imports: [GraphApiModule, EventsModule],
+  imports: [GraphApiModule, EventsModule, NotificationsModule],
   providers: [GraphSocketGateway],
   exports: [GraphSocketGateway],
 })

--- a/packages/platform-server/src/gateway/graph.socket.gateway.ts
+++ b/packages/platform-server/src/gateway/graph.socket.gateway.ts
@@ -19,6 +19,7 @@ import {
 import type { ToolOutputChunkPayload, ToolOutputTerminalPayload } from '../events/run-events.service';
 import { ThreadsMetricsService } from '../agents/threads.metrics.service';
 import { PrismaService } from '../core/services/prisma.service';
+import { NotificationsPublisher } from '../notifications/notifications.publisher';
 
 // Strict outbound event payloads
 export const NodeStatusEventSchema = z
@@ -116,6 +117,7 @@ export class GraphSocketGateway implements OnModuleInit, OnModuleDestroy {
     @Inject(ThreadsMetricsService) private readonly metrics: ThreadsMetricsService,
     @Inject(PrismaService) private readonly prismaService: PrismaService,
     @Inject(EventsBusService) private readonly eventsBus: EventsBusService,
+    @Inject(NotificationsPublisher) private readonly notifications: NotificationsPublisher,
   ) {}
 
   onModuleInit(): void {
@@ -688,18 +690,21 @@ export class GraphSocketGateway implements OnModuleInit, OnModuleDestroy {
     event: string,
     payload: unknown,
   ) {
-    if (!this.io || rooms.length === 0) return;
-    for (const room of rooms) {
-      try {
-        this.io.to(room).emit(event, payload);
-      } catch (error) {
-        const errPayload =
-          error instanceof Error ? { name: error.name, message: error.message } : { message: String(error) };
-        this.logger.warn(
-          `GraphSocketGateway: emit error ${this.formatContext({ event, room, error: errPayload })}`,
-        );
+    if (rooms.length === 0) return;
+    if (this.io) {
+      for (const room of rooms) {
+        try {
+          this.io.to(room).emit(event, payload);
+        } catch (error) {
+          const errPayload =
+            error instanceof Error ? { name: error.name, message: error.message } : { message: String(error) };
+          this.logger.warn(
+            `GraphSocketGateway: emit error ${this.formatContext({ event, room, error: errPayload })}`,
+          );
+        }
       }
     }
+    void this.notifications.publish(event, rooms, payload);
   }
 
   private formatContext(context: Record<string, unknown>): string {

--- a/packages/platform-server/src/notifications/notifications.grpc.client.ts
+++ b/packages/platform-server/src/notifications/notifications.grpc.client.ts
@@ -1,0 +1,41 @@
+import { createClient, type Client } from '@connectrpc/connect';
+import { createGrpcTransport } from '@connectrpc/connect-node';
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '../core/services/config.service';
+import { NotificationsService } from '../proto/gen/agynio/api/notifications/v1/notifications_pb.js';
+import type {
+  PublishRequest,
+  PublishResponse,
+} from '../proto/gen/agynio/api/notifications/v1/notifications_pb.js';
+
+@Injectable()
+export class NotificationsGrpcClient {
+  private readonly client?: Client<typeof NotificationsService>;
+
+  constructor(@Inject(ConfigService) private readonly config: ConfigService) {
+    const addr = this.config.notificationsGrpcAddr;
+    if (!addr) return;
+    const baseUrl = NotificationsGrpcClient.normalizeBaseUrl(addr);
+    const transport = createGrpcTransport({ baseUrl });
+    this.client = createClient(NotificationsService, transport);
+  }
+
+  isEnabled(): boolean {
+    return Boolean(this.client);
+  }
+
+  async publish(request: PublishRequest): Promise<PublishResponse> {
+    if (!this.client) {
+      throw new Error('Notifications gRPC client not configured');
+    }
+    return this.client.publish(request);
+  }
+
+  private static normalizeBaseUrl(addr: string): string {
+    const trimmed = addr.trim();
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+      return trimmed.replace(/\/+$/, '');
+    }
+    return `http://${trimmed.replace(/\/+$/, '')}`;
+  }
+}

--- a/packages/platform-server/src/notifications/notifications.module.ts
+++ b/packages/platform-server/src/notifications/notifications.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CoreModule } from '../core/core.module';
+import { NotificationsGrpcClient } from './notifications.grpc.client';
+import { NotificationsPublisher } from './notifications.publisher';
+
+@Module({
+  imports: [CoreModule],
+  providers: [NotificationsGrpcClient, NotificationsPublisher],
+  exports: [NotificationsPublisher],
+})
+export class NotificationsModule {}

--- a/packages/platform-server/src/notifications/notifications.publisher.ts
+++ b/packages/platform-server/src/notifications/notifications.publisher.ts
@@ -1,6 +1,7 @@
-import type { JsonObject } from '@bufbuild/protobuf';
+import { create, type JsonObject } from '@bufbuild/protobuf';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { NotificationsGrpcClient } from './notifications.grpc.client';
+import { PublishRequestSchema } from '../proto/gen/agynio/api/notifications/v1/notifications_pb.js';
 
 const NOTIFICATIONS_SOURCE = 'platform-server';
 
@@ -18,12 +19,13 @@ export class NotificationsPublisher {
     if (!jsonPayload) return;
 
     try {
-      await this.client.publish({
+      const request = create(PublishRequestSchema, {
         event,
         rooms,
         payload: jsonPayload,
         source: NOTIFICATIONS_SOURCE,
       });
+      await this.client.publish(request);
     } catch (error) {
       this.logger.warn(
         `Notifications publish failed${this.formatContext({

--- a/packages/platform-server/src/notifications/notifications.publisher.ts
+++ b/packages/platform-server/src/notifications/notifications.publisher.ts
@@ -1,0 +1,80 @@
+import type { JsonObject } from '@bufbuild/protobuf';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { NotificationsGrpcClient } from './notifications.grpc.client';
+
+const NOTIFICATIONS_SOURCE = 'platform-server';
+
+@Injectable()
+export class NotificationsPublisher {
+  private readonly logger = new Logger(NotificationsPublisher.name);
+
+  constructor(@Inject(NotificationsGrpcClient) private readonly client: NotificationsGrpcClient) {}
+
+  async publish(event: string, rooms: string[], payload: unknown): Promise<void> {
+    if (!this.client.isEnabled()) return;
+    if (!event || rooms.length === 0) return;
+
+    const jsonPayload = this.toJsonObject(event, rooms, payload);
+    if (!jsonPayload) return;
+
+    try {
+      await this.client.publish({
+        event,
+        rooms,
+        payload: jsonPayload,
+        source: NOTIFICATIONS_SOURCE,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Notifications publish failed${this.formatContext({
+          event,
+          rooms,
+          error: this.toSafeError(error),
+        })}`,
+      );
+    }
+  }
+
+  private toJsonObject(event: string, rooms: string[], payload: unknown): JsonObject | null {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      this.logger.warn(
+        `Notifications payload invalid${this.formatContext({ event, rooms, payloadType: typeof payload })}`,
+      );
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(JSON.stringify(payload)) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        this.logger.warn(
+          `Notifications payload invalid${this.formatContext({ event, rooms, payloadType: typeof parsed })}`,
+        );
+        return null;
+      }
+      return parsed as JsonObject;
+    } catch (error) {
+      this.logger.warn(
+        `Notifications payload serialization failed${this.formatContext({
+          event,
+          rooms,
+          error: this.toSafeError(error),
+        })}`,
+      );
+      return null;
+    }
+  }
+
+  private formatContext(context: Record<string, unknown>): string {
+    return ` ${JSON.stringify(context)}`;
+  }
+
+  private toSafeError(error: unknown): { name?: string; message: string } {
+    if (error instanceof Error) {
+      return { name: error.name, message: error.message };
+    }
+    try {
+      return { message: JSON.stringify(error) };
+    } catch {
+      return { message: String(error) };
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ importers:
       '@bufbuild/protobuf':
         specifier: ^2.11.0
         version: 2.11.0
+      '@connectrpc/connect':
+        specifier: ^2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.11.0)
+      '@connectrpc/connect-node':
+        specifier: ^2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.11.0))
       '@fastify/cors':
         specifier: ^11.1.0
         version: 11.1.0
@@ -900,6 +906,18 @@ packages:
     resolution: {integrity: sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg==}
     peerDependencies:
       commander: ~13.1.0
+
+  '@connectrpc/connect-node@2.1.1':
+    resolution: {integrity: sha512-s3TfsI1XF+n+1z6MBS9rTnFsxxR4Rw5wmdEnkQINli81ESGxcsfaEet8duzq8LVuuCupmhUsgpRo0Nv9pZkufg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.1
+
+  '@connectrpc/connect@2.1.1':
+    resolution: {integrity: sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -8673,6 +8691,15 @@ snapshots:
   '@commander-js/extra-typings@13.1.0(commander@13.1.0)':
     dependencies:
       commander: 13.1.0
+
+  '@connectrpc/connect-node@2.1.1(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.11.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)
+
+  '@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.11.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
## Summary
- replace socket notification publishing with gRPC client to notifications service
- add notifications module/config/env/test coverage and update docs/compose
- refresh proto generation workflow via buf export

## Testing
- pnpm lint
- AGENTS_DATABASE_URL=postgresql://agents:agents@localhost:5443/agents RUN_DB_TESTS=true DOCKER_SOCKET=/var/run/docker.sock DOCKER_RUNNER_SOCKET=/var/run/docker.sock pnpm --filter @agyn/platform-server exec vitest run --shard 1/8 --reporter=json --outputFile /tmp/vitest-shard-1-8.json
- AGENTS_DATABASE_URL=postgresql://agents:agents@localhost:5443/agents RUN_DB_TESTS=true DOCKER_SOCKET=/var/run/docker.sock DOCKER_RUNNER_SOCKET=/var/run/docker.sock pnpm --filter @agyn/platform-server exec vitest run --shard 2/8 --reporter=json --outputFile /tmp/vitest-shard-2-8.json
- AGENTS_DATABASE_URL=postgresql://agents:agents@localhost:5443/agents RUN_DB_TESTS=true DOCKER_SOCKET=/var/run/docker.sock DOCKER_RUNNER_SOCKET=/var/run/docker.sock pnpm --filter @agyn/platform-server exec vitest run --shard 3/8 --reporter=json --outputFile /tmp/vitest-shard-3-8.json
- AGENTS_DATABASE_URL=postgresql://agents:agents@localhost:5443/agents RUN_DB_TESTS=true DOCKER_SOCKET=/var/run/docker.sock DOCKER_RUNNER_SOCKET=/var/run/docker.sock pnpm --filter @agyn/platform-server exec vitest run --shard 4/8 --reporter=json --outputFile /tmp/vitest-shard-4-8.json
- AGENTS_DATABASE_URL=postgresql://agents:agents@localhost:5443/agents RUN_DB_TESTS=true DOCKER_SOCKET=/var/run/docker.sock DOCKER_RUNNER_SOCKET=/var/run/docker.sock pnpm --filter @agyn/platform-server exec vitest run --shard 5/8 --reporter=json --outputFile /tmp/vitest-shard-5-8.json
- AGENTS_DATABASE_URL=postgresql://agents:agents@localhost:5443/agents RUN_DB_TESTS=true DOCKER_SOCKET=/var/run/docker.sock DOCKER_RUNNER_SOCKET=/var/run/docker.sock pnpm --filter @agyn/platform-server exec vitest run --shard 6/8 --reporter=json --outputFile /tmp/vitest-shard-6-8.json
- AGENTS_DATABASE_URL=postgresql://agents:agents@localhost:5443/agents RUN_DB_TESTS=true DOCKER_SOCKET=/var/run/docker.sock DOCKER_RUNNER_SOCKET=/var/run/docker.sock pnpm --filter @agyn/platform-server exec vitest run --shard 7/8 --reporter=json --outputFile /tmp/vitest-shard-7-8.json
- AGENTS_DATABASE_URL=postgresql://agents:agents@localhost:5443/agents RUN_DB_TESTS=true DOCKER_SOCKET=/var/run/docker.sock DOCKER_RUNNER_SOCKET=/var/run/docker.sock pnpm --filter @agyn/platform-server exec vitest run --shard 8/8 --reporter=json --outputFile /tmp/vitest-shard-8-8.json

Closes #1371