### PR TITLE
chore(devspace): harden dev workflow

### DIFF
--- a/packages/platform-server/DEVSPACE.md
+++ b/packages/platform-server/DEVSPACE.md
@@ -1,0 +1,66 @@
+# DevSpace workflow for platform-server
+
+This guide walks through launching `platform-server` inside the
+`bootstrap_v2` cluster with a single `devspace dev` invocation.
+
+## Prerequisites
+
+- macOS or Linux workstation with Docker (or k3d) installed
+- [`devspace`](https://devspace.sh/docs/cli/installation)
+- Local cluster provisioned via
+  [`agynio/bootstrap_v2`](https://github.com/agynio/bootstrap_v2) (follow the
+  Quickstart in its README; it provides the kubeconfig path—usually
+  `bootstrap_v2/k8s/.kube/agyn-local-kubeconfig.yaml`).
+
+## 1. Prepare the cluster
+
+Run `agynio/bootstrap_v2` according to its Quickstart to provision the cluster
+and supporting services. The Quickstart configures kubectl with the
+`agyn-local` context (or provides the kubeconfig path). Ensure your shell has
+the appropriate kubeconfig exported before proceeding.
+
+## 2. Start DevSpace
+
+Change into `packages/platform-server` and run:
+
+```bash
+cd packages/platform-server
+devspace dev
+```
+
+DevSpace deploys the prebuilt dev image `ghcr.io/agynio/platform-server:dev`,
+which bundles the tooling needed for `pnpm dev` (corepack/pnpm, Git, file
+watchers) but no application sources. The repository is synced into the
+ephemeral workspace at `/opt/app/data/workspace` (backed by the `data`
+`emptyDir`), which is writable under the bootstrap-provisioned
+`securityContext`. The container process runs the same entrypoint as `pnpm
+dev` (`tsx src/index.ts`). Environment variables, volume mounts, and security
+context are provided by `bootstrap_v2`; DevSpace does not override them.
+Production images continue to be built by the existing CI pipeline and are
+separate from this workflow.
+
+At startup DevSpace applies an Argo CD `Application` manifest (no Argo CD CLI)
+that removes the `automated` sync policy for `platform-server` while pointing
+the application at the `noa/issue-1367` revision. This prevents the reconciler
+from reverting the dev Deployment/image while you are iterating locally and
+matches the branch tracked by this workflow.
+
+The helm release now requests 2 GiB of memory to keep `pnpm` installs from
+being OOM-killed. The dev entrypoint waits for the sync to finish, installs
+workspace dependencies with serialized `pnpm` (child concurrency `1`) when the
+install marker is missing, runs `prisma generate`, and finally starts
+`corepack pnpm --filter @agyn/platform-server dev` under `set -eu`.
+
+To confirm the deployment is ready, check the pod status:
+
+```bash
+kubectl get pods -n platform -l app.kubernetes.io/name=platform-server
+```
+
+## 3. Cleanup
+
+1. Terminate DevSpace (`Ctrl+C`).
+2. Purge the dev release:
+   ```bash
+   devspace purge
+   ```

--- a/packages/platform-server/devspace.yaml
+++ b/packages/platform-server/devspace.yaml
@@ -1,0 +1,74 @@
+version: v2beta1
+
+vars:
+  PLATFORM_NAMESPACE: platform
+
+deployments:
+  argocd-sync-off:
+    kubectl:
+      manifests:
+        - devspace/argocd-sync-off.yaml
+  platform-server:
+    namespace: ${PLATFORM_NAMESPACE}
+    helm:
+      releaseName: platform-server
+      chart:
+        path: ../../charts/platform-server
+      values:
+        image:
+          repository: ghcr.io/agynio/platform-server
+          tag: dev
+          pullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+
+dev:
+  platform-server:
+    namespace: ${PLATFORM_NAMESPACE}
+    labelSelector:
+      app.kubernetes.io/name: platform-server
+      app.kubernetes.io/instance: platform-server
+    containers:
+      platform-server:
+        container: platform-server
+        workingDir: /opt/app/data/workspace
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            set -eu
+            umask 0002
+            if [ -d /opt/app/data/workspace ] && [ ! -w /opt/app/data/workspace ]; then
+              rm -rf /opt/app/data/workspace
+            fi
+            mkdir -p /opt/app/data/workspace
+            cd /opt/app/data/workspace
+            while [ ! -f package.json ]; do
+              echo "Waiting for sources to sync..."
+              sleep 1
+            done
+            if [ ! -f node_modules/.modules.yaml ]; then
+              export PNPM_WORKSPACE_CONCURRENCY=1
+              export NODE_OPTIONS="--max-old-space-size=256"
+              export PNPM_HOME=/tmp/.pnpm
+              mkdir -p "$PNPM_HOME"
+              corepack pnpm install --filter @agyn/platform-server... --frozen-lockfile --prefer-offline --child-concurrency=1 --ignore-scripts
+              corepack pnpm --filter @agyn/platform-server exec prisma generate
+            fi
+            corepack pnpm --filter @agyn/platform-server dev
+        sync:
+          - path: ../..:/opt/app/data/workspace
+            excludePaths:
+              - node_modules
+              - dist
+              - .git
+              - .devspace
+              - packages/platform-server/node_modules
+              - packages/platform-server/dist
+              - packages/platform-server/prisma/generated

--- a/packages/platform-server/devspace/argocd-sync-off.yaml
+++ b/packages/platform-server/devspace/argocd-sync-off.yaml
@@ -1,0 +1,150 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: platform-server
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+spec:
+  project: default
+  destination:
+    namespace: platform
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://github.com/agynio/platform.git
+    targetRevision: noa/issue-1367
+    path: charts/platform-server
+    helm:
+      values: |
+        "env":
+        - "name": "NODE_ENV"
+          "value": "production"
+        - "name": "PORT"
+          "value": "3010"
+        - "name": "AGENTS_DATABASE_URL"
+          "value": "postgresql://agents:agents@platform-db:5432/agents"
+        - "name": "LLM_PROVIDER"
+          "value": "litellm"
+        - "name": "LITELLM_BASE_URL"
+          "value": "http://litellm:4000"
+        - "name": "LITELLM_MASTER_KEY"
+          "value": "sk-dev-master"
+        - "name": "LITELLM_SALT_KEY"
+          "value": "sk-dev-salt"
+        - "name": "OPENAI_BASE_URL"
+          "value": "http://litellm:4000/v1"
+        - "name": "OPENAI_API_KEY"
+          "value": "sk-dev-master"
+        - "name": "DOCKER_RUNNER_GRPC_HOST"
+          "value": "docker-runner"
+        - "name": "DOCKER_RUNNER_GRPC_PORT"
+          "value": "7071"
+        - "name": "DOCKER_RUNNER_SHARED_SECRET"
+          "value": "change-me"
+        - "name": "DOCKER_RUNNER_OPTIONAL"
+          "value": "true"
+        - "name": "DOCKER_RUNNER_TIMEOUT_MS"
+          "value": "60000"
+        - "name": "DOCKER_RUNNER_CONNECT_RETRY_BASE_DELAY_MS"
+          "value": "1000"
+        - "name": "DOCKER_RUNNER_CONNECT_RETRY_MAX_DELAY_MS"
+          "value": "60000"
+        - "name": "DOCKER_RUNNER_CONNECT_RETRY_JITTER_MS"
+          "value": "500"
+        - "name": "DOCKER_RUNNER_CONNECT_PROBE_INTERVAL_MS"
+          "value": "10000"
+        - "name": "DOCKER_RUNNER_CONNECT_MAX_RETRIES"
+          "value": "120"
+        - "name": "VAULT_ENABLED"
+          "value": "true"
+        - "name": "VAULT_ADDR"
+          "value": "http://vault:8200"
+        - "name": "VAULT_TOKEN"
+          "value": "dev-root"
+        - "name": "GRAPH_BRANCH"
+          "value": "v0.10.1"
+        - "name": "GRAPH_AUTHOR_NAME"
+          "value": "Agyn Platform"
+        - "name": "GRAPH_AUTHOR_EMAIL"
+          "value": "rowan.stein@agyn.io"
+        "extraVolumeMounts":
+        - "mountPath": "/tmp"
+          "name": "tmp"
+        - "mountPath": "/opt/app/data"
+          "name": "data"
+        - "mountPath": "/opt/app/packages/platform-server/data"
+          "name": "data"
+        - "mountPath": "/data"
+          "name": "data"
+        "extraVolumes":
+        - "emptyDir": {}
+          "name": "tmp"
+        - "emptyDir": {}
+          "name": "data"
+        "fullnameOverride": "platform-server"
+        "image":
+          "pullPolicy": "IfNotPresent"
+          "repository": "ghcr.io/agynio/platform-server"
+          "tag": "0.15.2"
+        "ingress":
+          "enabled": false
+        "initContainers":
+        - "args":
+          - "pnpm"
+          - "--dir"
+          - "/opt/app/packages/platform-server"
+          - "exec"
+          - "prisma"
+          - "migrate"
+          - "deploy"
+          "command":
+          - "corepack"
+          "env":
+          - "name": "AGENTS_DATABASE_URL"
+            "value": "postgresql://agents:agents@platform-db:5432/agents"
+          - "name": "NODE_ENV"
+            "value": "production"
+          "image": "ghcr.io/agynio/platform-server:0.15.2"
+          "imagePullPolicy": "IfNotPresent"
+          "name": "platform-server-migrations"
+          "securityContext":
+            "runAsGroup": 1000
+            "runAsNonRoot": true
+            "runAsUser": 1000
+          "volumeMounts":
+          - "mountPath": "/tmp"
+            "name": "tmp"
+          - "mountPath": "/opt/app/data"
+            "name": "data"
+          - "mountPath": "/opt/app/packages/platform-server/data"
+            "name": "data"
+          - "mountPath": "/data"
+            "name": "data"
+        "livenessProbe":
+          "enabled": false
+        "podSecurityContext":
+          "enabled": true
+          "fsGroup": 1000
+        "readinessProbe":
+          "enabled": false
+        "replicaCount": 1
+        "securityContext":
+          "allowPrivilegeEscalation": false
+          "capabilities":
+            "drop":
+            - "ALL"
+          "enabled": true
+          "readOnlyRootFilesystem": true
+          "runAsGroup": 1000
+          "runAsNonRoot": true
+          "runAsUser": 1000
+          "seccompProfile":
+            "type": "RuntimeDefault"
+  revisionHistoryLimit: 10
+  syncPolicy:
+    automated: null
+    syncOptions:
+    - CreateNamespace=true
+    - PrunePropagationPolicy=foreground
+    - PruneLast=true
+    - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
## Summary
- disable Argo CD auto-sync for noa/issue-1367 via pre-deploy manifest
- harden dev container bootstrap for pnpm/prisma and bump memory to 2Gi
- document the workflow updates in packages/platform-server/DEVSPACE.md

## Testing
- devspace dev (validated manually)
- corepack pnpm --filter @agyn/platform-server lint
