### PR TITLE
chore(devspace): align platform-server workflow

### DIFF
--- a/packages/platform-server/DEVSPACE.md
+++ b/packages/platform-server/DEVSPACE.md
@@ -1,7 +1,10 @@
 # DevSpace workflow for platform-server
 
-This guide walks through launching `platform-server` inside the
-`bootstrap_v2` cluster with a single `devspace dev` invocation.
+This guide documents the lightweight DevSpace workflow for iterating on
+`platform-server` inside the `bootstrap_v2` cluster. The configuration reuses
+the bootstrap-provisioned deployment and only disables ArgoCD auto-sync while
+the session is active, keeping the runtime environment aligned with the dev
+cluster.
 
 ## Prerequisites
 
@@ -12,41 +15,51 @@ This guide walks through launching `platform-server` inside the
   Quickstart in its README; it provides the kubeconfig path—usually
   `bootstrap_v2/k8s/.kube/agyn-local-kubeconfig.yaml`).
 
-## 1. Prepare the cluster
+## 1. Ensure the cluster is running
 
 Run `agynio/bootstrap_v2` according to its Quickstart to provision the cluster
-and supporting services. The Quickstart configures kubectl with the
-`agyn-local` context (or provides the kubeconfig path). Ensure your shell has
+and supporting services. The bootstrap scripts configure kubectl with the
+`agyn-local` context (or provide the kubeconfig path). Ensure your shell has
 the appropriate kubeconfig exported before proceeding.
 
 ## 2. Start DevSpace
 
-Change into `packages/platform-server` and run:
+Launch DevSpace from the repository root:
 
 ```bash
 cd packages/platform-server
 devspace dev
 ```
 
-DevSpace deploys the prebuilt dev image `ghcr.io/agynio/platform-server:dev`,
-which bundles the tooling needed for `pnpm dev` (corepack/pnpm, Git, file
-watchers) but no application sources. The repository is synced into `/opt/app`
-for live iteration, and the container process runs the same entrypoint as
-`pnpm dev` (`tsx src/index.ts`). Environment variables, volume mounts, and
-security context are provided by `bootstrap_v2`; DevSpace does not override
-them. Production images continue to be built by the existing CI pipeline and
-are separate from this workflow.
+The `dev` pipeline attaches to the existing `platform-server-dev` pod, disables
+ArgoCD auto-sync for the `platform-server` application (via a pre-dev hook),
+and starts `pnpm dev` inside the container using the synced workspace at
+`/opt/app/data/workspace`. The hook only touches auto-sync; all runtime
+configuration continues to come from bootstrap.
 
-To confirm the deployment is ready, check the pod status:
+During startup the container waits for the repository files to sync, prepares a
+writeable workspace (`.cache`, `.pnpm-store`, `tmp`), pins cache-related
+environment variables, and uses Corepack to run scoped `pnpm install` followed
+by `pnpm dev` for `packages/platform-server`.
+
+To confirm the pod is ready, check its status:
 
 ```bash
 kubectl get pods -n platform -l app.kubernetes.io/name=platform-server
 ```
 
-## 3. Cleanup
+### Re-enabling ArgoCD auto-sync
 
-1. Terminate DevSpace (`Ctrl+C`).
-2. Purge the dev release:
-   ```bash
-   devspace purge
-   ```
+When you finish your DevSpace session you can optionally re-enable auto-sync:
+
+```bash
+kubectl patch application platform-server -n argocd \
+  --type merge \
+  -p '{"spec":{"syncPolicy":{"automated":{}}}}'
+```
+
+## 3. End the session
+
+Terminate DevSpace with `Ctrl+C`. No additional purge step is required because
+the deployment is managed by bootstrap. If you re-enable auto-sync, ArgoCD will
+resume reconciling the deployment immediately.

--- a/packages/platform-server/devspace.yaml
+++ b/packages/platform-server/devspace.yaml
@@ -3,44 +3,68 @@ version: v2beta1
 vars:
   PLATFORM_NAMESPACE: platform
 
-deployments:
-  platform-server:
-    namespace: ${PLATFORM_NAMESPACE}
-    helm:
-      releaseName: platform-server
-      chart:
-        path: ../../charts/platform-server
-      values:
-        image:
-          repository: ghcr.io/agynio/platform-server
-          tag: dev
-          pullPolicy: IfNotPresent
+pipelines:
+  dev: |-
+    start_dev platform-server
+
+hooks:
+  - name: disable-argocd-auto-sync
+    command: sh
+    args:
+      - -lc
+      - |
+        set -eu
+        if kubectl get application platform-server -n argocd >/dev/null 2>&1; then
+          kubectl patch application platform-server -n argocd --type merge -p '{"spec":{"syncPolicy":{"automated":null}}}'
+        fi
+    events:
+      - before:dev:platform-server
 
 dev:
   platform-server:
     namespace: ${PLATFORM_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: platform-server
-      app.kubernetes.io/instance: platform-server
+      app.kubernetes.io/instance: platform-server-dev
     containers:
       platform-server:
         container: platform-server
-        workingDir: /opt/app
         command:
           - sh
         args:
-          - -c
+          - -lc
           - |
-            while [ ! -f package.json ]; do
-              echo "Waiting for sources to sync..."
-              sleep 1
+            set -eu
+            base="/opt/app/data/workspace"
+            mkdir -p "$base"
+            mkdir -p "$base/.cache/pnpm" "$base/.cache/npm" "$base/tmp" "$base/.pnpm-store"
+            cd "$base"
+            for i in $(seq 1 150); do
+              if [ -f "$base/pnpm-workspace.yaml" ]; then
+                break
+              fi
+              echo "Waiting for workspace files to sync..."
+              sleep 2
             done
-            if [ ! -d node_modules ]; then
-              pnpm install --prefer-offline
+            if [ ! -f "$base/pnpm-workspace.yaml" ]; then
+              echo "pnpm-workspace.yaml not found after waiting" >&2
+              exit 1
             fi
-            pnpm --dir packages/platform-server dev
+            echo "Starting platform-server dev workspace"
+            export TMPDIR="$base/tmp"
+            export PNPM_HOME="$base/.cache/pnpm"
+            export NPM_CONFIG_CACHE="$base/.cache/npm"
+            export PNPM_STORE_PATH="$base/.pnpm-store"
+            export NODE_OPTIONS="--max-old-space-size=384"
+            export PATH="$PNPM_HOME:$PATH"
+            if [ ! -x "$PNPM_HOME/pnpm" ]; then
+              printf '#!/bin/sh\nexec corepack pnpm "$@"\n' > "$PNPM_HOME/pnpm"
+              chmod +x "$PNPM_HOME/pnpm"
+            fi
+            corepack pnpm --dir packages/platform-server install --prefer-offline --child-concurrency=1 --network-concurrency=1
+            corepack pnpm --dir packages/platform-server dev
         sync:
-          - path: ../..:/opt/app
+          - path: ../..:/opt/app/data/workspace
             excludePaths:
               - node_modules
               - dist
@@ -49,3 +73,5 @@ dev:
               - packages/platform-server/node_modules
               - packages/platform-server/dist
               - packages/platform-server/prisma/generated
+              - .pnpm-store
+              - .cache


### PR DESCRIPTION
## Summary
- reuse the bootstrap platform-server dev pod via the dev pipeline
- add an ArgoCD auto-sync disable hook as the only runtime mutation
- document the updated DevSpace flow and optional auto-sync restore command

## Testing
- pnpm install
- pnpm lint
- LLM_PROVIDER=openai pnpm --filter @agyn/platform-server test
