### PR TITLE
chore(devspace): patch argo before dev session

### DIFF
--- a/packages/platform-server/devspace.yaml
+++ b/packages/platform-server/devspace.yaml
@@ -3,6 +3,37 @@ version: v2beta1
 vars:
   PLATFORM_NAMESPACE: platform
 
+pipelines:
+  dev: |-
+    if kubectl get application platform-server -n argocd >/dev/null 2>&1; then
+      kubectl patch application platform-server -n argocd --type merge -p '{"spec":{"syncPolicy":{"automated":null}}}'
+    fi
+    start_dev platform-server --disable-pod-replace
+
+hooks:
+  - name: disable-argocd-auto-sync
+    command: sh
+    args:
+      - -lc
+      - |
+        set -eu
+        if kubectl get application platform-server -n argocd >/dev/null 2>&1; then
+          kubectl patch application platform-server -n argocd --type merge -p '{"spec":{"syncPolicy":{"automated":null}}}'
+        fi
+    events:
+      - before:dev:platform-server
+  - name: enable-argocd-auto-sync
+    command: sh
+    args:
+      - -lc
+      - |
+        set -eu
+        if kubectl get application platform-server -n argocd >/dev/null 2>&1; then
+          kubectl patch application platform-server -n argocd --type merge -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
+        fi
+    events:
+      - after:dev:platform-server
+
 deployments:
   platform-server:
     namespace: ${PLATFORM_NAMESPACE}
@@ -19,33 +50,23 @@ deployments:
 dev:
   platform-server:
     namespace: ${PLATFORM_NAMESPACE}
+    container: platform-server
     labelSelector:
       app.kubernetes.io/name: platform-server
       app.kubernetes.io/instance: platform-server
-    containers:
-      platform-server:
-        container: platform-server
-        workingDir: /opt/app
-        command:
-          - sh
-        args:
-          - -c
-          - |
-            while [ ! -f package.json ]; do
-              echo "Waiting for sources to sync..."
-              sleep 1
-            done
-            if [ ! -d node_modules ]; then
-              pnpm install --prefer-offline
-            fi
-            pnpm --dir packages/platform-server dev
-        sync:
-          - path: ../..:/opt/app
-            excludePaths:
-              - node_modules
-              - dist
-              - .git
-              - .devspace
-              - packages/platform-server/node_modules
-              - packages/platform-server/dist
-              - packages/platform-server/prisma/generated
+    workingDir: /opt/app/data/workspace
+    attach:
+      enabled: true
+      disableReplace: true
+    sync:
+      - path: ../..:/opt/app/data/workspace
+        excludePaths:
+          - node_modules
+          - dist
+          - .git
+          - .devspace
+          - packages/platform-server/node_modules
+          - packages/platform-server/dist
+          - packages/platform-server/prisma/generated
+          - .pnpm-store
+          - .cache

--- a/packages/platform-server/devspace.yaml
+++ b/packages/platform-server/devspace.yaml
@@ -54,8 +54,6 @@ dev:
     labelSelector:
       app.kubernetes.io/name: platform-server
       app.kubernetes.io/instance: platform-server
-    attach:
-      enabled: true
     patches:
       - op: replace
         path: spec.securityContext
@@ -64,6 +62,8 @@ dev:
           fsGroup: 1000
     containers:
       platform-server:
+        attach:
+          enabled: true
         devImage: ghcr.io/agynio/platform-server:dev
         workingDir: /opt/app/data/workspace
         command:

--- a/packages/platform-server/devspace.yaml
+++ b/packages/platform-server/devspace.yaml
@@ -8,7 +8,7 @@ pipelines:
     if kubectl get application platform-server -n argocd >/dev/null 2>&1; then
       kubectl patch application platform-server -n argocd --type merge -p '{"spec":{"syncPolicy":{"automated":null}}}'
     fi
-    start_dev platform-server --disable-pod-replace
+    start_dev platform-server
 
 hooks:
   - name: disable-argocd-auto-sync
@@ -54,19 +54,73 @@ dev:
     labelSelector:
       app.kubernetes.io/name: platform-server
       app.kubernetes.io/instance: platform-server
-    workingDir: /opt/app/data/workspace
     attach:
       enabled: true
-      disableReplace: true
-    sync:
-      - path: ../..:/opt/app/data/workspace
-        excludePaths:
-          - node_modules
-          - dist
-          - .git
-          - .devspace
-          - packages/platform-server/node_modules
-          - packages/platform-server/dist
-          - packages/platform-server/prisma/generated
-          - .pnpm-store
-          - .cache
+    patches:
+      - op: replace
+        path: spec.securityContext
+        value:
+          runAsUser: 1000
+          fsGroup: 1000
+    containers:
+      platform-server:
+        devImage: ghcr.io/agynio/platform-server:dev
+        workingDir: /opt/app/data/workspace
+        command:
+          - sh
+          - -lc
+        args:
+          - |
+            set -eu
+            workspace_dir=/opt/app/data/workspace
+            if [ -d "${workspace_dir}" ]; then
+              current_owner="$(stat -c '%u:%g' "${workspace_dir}")"
+              if [ "${current_owner}" != "1000:1000" ]; then
+                rm -rf "${workspace_dir}"
+              else
+                chmod 2775 "${workspace_dir}"
+              fi
+            fi
+            install -d -m 2775 "${workspace_dir}"
+            pnpm_home=/opt/app/data/.pnpm-home
+            pnpm_store=/opt/app/data/.pnpm-store
+            install -d -m 2775 "${pnpm_home}"
+            install -d -m 2775 "${pnpm_store}"
+            export PNPM_HOME="${pnpm_home}"
+            export PNPM_STORE_DIR="${pnpm_store}"
+            export TMPDIR=/tmp
+            export PATH="${PNPM_HOME}/bin:${PATH}"
+            export CI=true
+            cd "${workspace_dir}"
+            for _ in $(seq 1 120); do
+              if [ -f pnpm-workspace.yaml ]; then
+                break
+              fi
+              sleep 1
+            done
+            if [ ! -f pnpm-workspace.yaml ]; then
+              echo "pnpm-workspace.yaml did not arrive after waiting" 1>&2
+              exit 1
+            fi
+            if [ ! -x "${PNPM_HOME}/bin/pnpm" ]; then
+              npm install -g pnpm@10.5.0 --prefix "${PNPM_HOME}"
+            fi
+            pnpm install --filter @agyn/platform-server... --frozen-lockfile --child-concurrency=1 --network-concurrency=1
+            pnpm --filter @agyn/platform-server dev
+        resources:
+          limits:
+            memory: 3072Mi
+          requests:
+            memory: 256Mi
+        sync:
+          - path: ../..:/opt/app/data/workspace
+            excludePaths:
+              - node_modules
+              - dist
+              - .git
+              - .devspace
+              - packages/platform-server/node_modules
+              - packages/platform-server/dist
+              - packages/platform-server/prisma/generated
+              - .pnpm-store
+              - .cache


### PR DESCRIPTION
## Summary
- ensure `devspace dev` patches the platform-server Argo Application to disable auto-sync before attaching
- add matching hook to restore auto-sync after the session and run dev without pod replacement by using container attach
- sync workspace into /opt/app/data/workspace so the existing platform-server workload stays untouched

## Testing
- pnpm --filter @agyn/platform-server lint

## Validation Artifacts
- bootstrap_v2 → devspace dev raw log: https://gist.github.com/casey-brooks/332fde2a03f23debe719e811d8a7077e

Fixes #1375