### PR TITLE
fix(vault): parse kv v2 mounts

### DIFF
--- a/packages/platform-server/__tests__/vault.service.test.ts
+++ b/packages/platform-server/__tests__/vault.service.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ConfigService } from '../src/core/services/config.service';
+import { VaultService } from '../src/vault/vault.service';
+
+type VaultHttp = {
+  http: <T>(path: string, init?: RequestInit) => Promise<T>;
+};
+
+const createService = (): VaultService => {
+  const config = {
+    vaultAddr: 'http://vault.test',
+    vaultToken: 'test-token',
+  } as ConfigService;
+  return new VaultService(config);
+};
+
+describe('VaultService', () => {
+  it('listKvV2Mounts extracts kv v2 mounts from envelope', async () => {
+    const service = createService();
+    const envelope = {
+      data: {
+        'secret/': { type: 'kv', options: { version: '2' } },
+        'kv2/': { type: 'kv', options: { version: 2 } },
+        'kv1/': { type: 'kv', options: { version: '1' } },
+        'sys/': { type: 'system' },
+      },
+    };
+
+    const httpSpy = vi
+      .spyOn(service as unknown as VaultHttp, 'http')
+      .mockResolvedValue(envelope);
+
+    const mounts = await service.listKvV2Mounts();
+
+    expect(httpSpy).toHaveBeenCalledWith('/v1/sys/mounts', { method: 'GET' });
+    expect(mounts).toEqual(['kv2', 'secret']);
+  });
+});

--- a/packages/platform-server/src/vault/vault.service.ts
+++ b/packages/platform-server/src/vault/vault.service.ts
@@ -3,7 +3,9 @@ import { z } from 'zod';
 import { ConfigService } from '../core/services/config.service';
 
 // Typed KV v2 response shapes
-type KvV2MountsResponse = Record<string, { type?: string; options?: { version?: string | number } }>;
+type KvV2MountsEnvelope = {
+  data?: Record<string, { type?: string; options?: { version?: string | number } }>;
+};
 type KvV2ListPathsResponse = { data?: { keys?: string[] } };
 type KvV2ReadResponse = { data?: { data?: Record<string, unknown> } };
 type KvV2WriteResponse = { data?: { metadata?: { version?: number | string } } };
@@ -74,9 +76,9 @@ export class VaultService {
   // List KV v2 mounts by inspecting sys/mounts
   async listKvV2Mounts(): Promise<string[]> {
     try {
-      const resp = await this.http<KvV2MountsResponse>('/v1/sys/mounts', { method: 'GET' });
+      const resp = await this.http<KvV2MountsEnvelope>('/v1/sys/mounts', { method: 'GET' });
       const items: string[] = [];
-      for (const [name, meta] of Object.entries(resp || {})) {
+      for (const [name, meta] of Object.entries(resp?.data || {})) {
         // name ends with '/'
         const n = name.replace(/\/$/, '');
         const type = meta?.type;


### PR DESCRIPTION
## Summary
- parse KV v2 mounts from the Vault response envelope
- add a unit test covering listKvV2Mounts envelope handling

## Testing
- pnpm --filter @agyn/platform-server lint
- AGENTS_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agents_test pnpm --filter @agyn/platform-server test

#1378