### PR TITLE
Standardize docker-runner gRPC port

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ pnpm install
 ```bash
 docker compose up -d
 # Starts postgres (5442), agents-db (5443), vault (8200), ncps (8501),
-# litellm (127.0.0.1:4000), docker-runner (7071)
+# litellm (127.0.0.1:4000), docker-runner (50051)
 # Optional monitoring (prometheus/grafana) lives in docker-compose.monitoring.yml.
 # Enable with: docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 ```
@@ -186,7 +186,7 @@ Key environment variables (server) from packages/platform-server/.env.example an
 - Workspace/Docker:
   - DOCKER_MIRROR_URL (default http://registry-mirror:5000)
   - DOCKER_RUNNER_GRPC_HOST (default docker-runner)
-  - DOCKER_RUNNER_GRPC_PORT (default 7171; DOCKER_RUNNER_PORT is accepted as an alias)
+  - DOCKER_RUNNER_GRPC_PORT (default 50051; DOCKER_RUNNER_PORT is accepted as an alias)
   - DOCKER_RUNNER_SHARED_SECRET (required HMAC credential)
   - DOCKER_RUNNER_TIMEOUT_MS (optional request timeout; default 30000)
   - DOCKER_RUNNER_OPTIONAL (default true; set to false to keep fail-fast bootstrap)
@@ -233,7 +233,7 @@ UI variables (packages/platform-ui/.env.example):
   - vault — HashiCorp Vault (8200), auto-init helper vault-auto-init
   - ncps — Nix cache proxy (8501)
   - litellm + litellm-db — LLM proxy with UI (4000 loopback)
-  - docker-runner — authenticated Docker API proxy (7071, mounts /var/run/docker.sock)
+  - docker-runner — authenticated Docker API proxy (50051, mounts /var/run/docker.sock)
   - Optional monitoring overlay (docker-compose.monitoring.yml) adds prometheus (9090) and grafana (3000) without mounting the Docker socket; provide your own scrape targets via configuration.
 
 To start services:

--- a/charts/docker-runner/values.schema.json
+++ b/charts/docker-runner/values.schema.json
@@ -350,7 +350,7 @@
           "default": [
             {
               "name": "http",
-              "port": 7071,
+              "port": 50051,
               "targetPort": "http",
               "protocol": "TCP"
             }
@@ -365,7 +365,7 @@
         "ports": [
           {
             "name": "http",
-            "port": 7071,
+            "port": 50051,
             "targetPort": "http",
             "protocol": "TCP"
           }
@@ -396,7 +396,7 @@
       "default": [
         {
           "name": "http",
-          "containerPort": 7071,
+          "containerPort": 50051,
           "protocol": "TCP"
         }
       ]
@@ -528,7 +528,7 @@
         },
         {
           "name": "DOCKER_RUNNER_PORT",
-          "value": "7071"
+          "value": "50051"
         },
         {
           "name": "DOCKER_RUNNER_SIGNATURE_TTL_MS",

--- a/charts/docker-runner/values.yaml
+++ b/charts/docker-runner/values.yaml
@@ -55,13 +55,13 @@ service:
   labels: {}
   ports:
     - name: http
-      port: 7071
+      port: 50051
       targetPort: http
       protocol: TCP
 
 containerPorts:
   - name: http
-    containerPort: 7071
+    containerPort: 50051
     protocol: TCP
 
 command: []
@@ -70,7 +70,7 @@ env:
   - name: DOCKER_RUNNER_HOST
     value: 0.0.0.0
   - name: DOCKER_RUNNER_PORT
-    value: "7071"
+    value: "50051"
   - name: DOCKER_RUNNER_SIGNATURE_TTL_MS
     value: "60000"
   - name: DOCKER_RUNNER_LOG_LEVEL

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -69,7 +69,7 @@ Per-workspace Docker-in-Docker and registry mirror
 Remote Docker runner
 - The platform-server always routes container lifecycle, exec, and log streaming calls through the `@agyn/docker-runner` service.
 - The runner exposes authenticated gRPC endpoints; every request includes HMAC metadata derived solely from `DOCKER_RUNNER_SHARED_SECRET`.
-- Only the docker-runner service mounts `/var/run/docker.sock` in default stacks; platform-server and auxiliary services talk to it over the internal network (default `docker-runner:${DOCKER_RUNNER_GRPC_PORT}` with `DOCKER_RUNNER_GRPC_PORT` defaulting to 7171; `DOCKER_RUNNER_PORT` remains an accepted alias).
+- Only the docker-runner service mounts `/var/run/docker.sock` in default stacks; platform-server and auxiliary services talk to it over the internal network (default `docker-runner:${DOCKER_RUNNER_GRPC_PORT}` with `DOCKER_RUNNER_GRPC_PORT` defaulting to 50051; `DOCKER_RUNNER_PORT` remains an accepted alias).
 - Container events, logs, and exec streams flow over long-lived gRPC streams so the existing watcher pipeline (ContainerEventProcessor, cleanup jobs, metrics) remains unchanged.
 - Connectivity is tracked by a background `DockerRunnerConnectivityMonitor` that probes the gRPC `Ready` method with exponential backoff (base-delay, max-delay, jitter, probe interval, and optional retry cap are configurable via DOCKER_RUNNER_CONNECT_* env vars).
 - When `DOCKER_RUNNER_OPTIONAL=true` (default) the server continues booting even if the runner is unreachable; when set to `false` the first failed probe aborts bootstrap (legacy fail-fast mode).

--- a/packages/docker-runner/Dockerfile
+++ b/packages/docker-runner/Dockerfile
@@ -42,7 +42,7 @@ FROM node:20-slim AS runtime
 
 ENV NODE_ENV=production \
     DOCKER_RUNNER_GRPC_HOST=0.0.0.0 \
-    DOCKER_RUNNER_PORT=7171
+    DOCKER_RUNNER_PORT=50051
 
 WORKDIR /opt/app/packages/docker-runner
 
@@ -59,6 +59,6 @@ COPY --from=build --chown=node:node /workspace/packages/docker-runner/tsconfig.j
 
 USER node
 
-EXPOSE 7171
+EXPOSE 50051
 
 CMD ["tsx", "src/service/main.ts"]

--- a/packages/docker-runner/src/service/config.ts
+++ b/packages/docker-runner/src/service/config.ts
@@ -3,10 +3,10 @@ import { z } from 'zod';
 const runnerConfigSchema = z.object({
   grpcPort: z
     .union([z.string(), z.number()])
-    .default('7171')
+    .default('50051')
     .transform((value) => {
       const num = typeof value === 'number' ? value : Number(value);
-      return Number.isFinite(num) ? num : 7171;
+      return Number.isFinite(num) ? num : 50051;
     }),
   grpcHost: z.string().default('0.0.0.0'),
   sharedSecret: z.string().min(1, 'DOCKER_RUNNER_SHARED_SECRET is required'),

--- a/packages/platform-server/__tests__/containers.delete.integration.test.ts
+++ b/packages/platform-server/__tests__/containers.delete.integration.test.ts
@@ -195,7 +195,7 @@ describe('DELETE /api/containers/:id integration', () => {
         {
           provide: ConfigService,
           useValue: {
-            getDockerRunnerGrpcAddress: () => '127.0.0.1:7171',
+            getDockerRunnerGrpcAddress: () => '127.0.0.1:50051',
           } as ConfigService,
         },
         {

--- a/packages/platform-server/__tests__/helpers/config.ts
+++ b/packages/platform-server/__tests__/helpers/config.ts
@@ -3,7 +3,7 @@ import { ConfigService, configSchema } from '../../src/core/services/config.serv
 export const runnerConfigDefaults = {
   dockerRunnerSharedSecret: 'test-shared-secret',
   dockerRunnerGrpcHost: '127.0.0.1',
-  dockerRunnerGrpcPort: 7171,
+  dockerRunnerGrpcPort: 50051,
   litellmKeyAlias: 'agents/test/local',
   litellmKeyDuration: '30d',
   litellmModels: ['all-team-models'],

--- a/packages/platform-server/__tests__/infra/runnerGrpc.client.test.ts
+++ b/packages/platform-server/__tests__/infra/runnerGrpc.client.test.ts
@@ -60,9 +60,9 @@ describe('RunnerGrpcClient', () => {
 
   it('sanitizes infra details from gRPC errors', async () => {
     const client = new RunnerGrpcClient({ address: 'grpc://runner', sharedSecret: 'secret' });
-    const error = Object.assign(new Error('Deadline exceeded after 305.002s,LB pick: 0.001s,remote_addr=172.21.0.3:7071'), {
+    const error = Object.assign(new Error('Deadline exceeded after 305.002s,LB pick: 0.001s,remote_addr=172.21.0.3:50051'), {
       code: status.DEADLINE_EXCEEDED,
-      details: 'Deadline exceeded after 305.002s,LB pick: 0.001s,remote_addr=172.21.0.3:7071',
+      details: 'Deadline exceeded after 305.002s,LB pick: 0.001s,remote_addr=172.21.0.3:50051',
     });
 
     const translated = (client as unknown as {
@@ -95,9 +95,9 @@ describe('RunnerGrpcExecClient', () => {
 
     const execPromise = execClient.exec('container-1', ['echo', 'hi'], { timeoutMs: 1_500 });
 
-    const error = Object.assign(new Error('Deadline exceeded after 1500ms,remote_addr=10.0.0.2:7071'), {
+    const error = Object.assign(new Error('Deadline exceeded after 1500ms,remote_addr=10.0.0.2:50051'), {
       code: status.DEADLINE_EXCEEDED,
-      details: 'Deadline exceeded after 1500ms,remote_addr=10.0.0.2:7071',
+      details: 'Deadline exceeded after 1500ms,remote_addr=10.0.0.2:50051',
     });
 
     queueMicrotask(() => {

--- a/packages/platform-server/__tests__/routes.containers.test.ts
+++ b/packages/platform-server/__tests__/routes.containers.test.ts
@@ -288,7 +288,7 @@ describe('ContainersController routes', () => {
       deleteContainer: vi.fn().mockResolvedValue(undefined),
     } as Pick<ContainerAdminService, 'deleteContainer'>;
     configService = {
-      getDockerRunnerGrpcAddress: () => 'grpc://runner.local:9090',
+      getDockerRunnerGrpcAddress: () => 'grpc://runner.local:50051',
     } as ConfigService;
     controller = new ContainersController(prismaSvc, containerAdmin as ContainerAdminService, configService as ConfigService);
     // Typed query adapter to avoid any/double assertions
@@ -649,7 +649,7 @@ describe('ContainersController routes', () => {
       containerId: 'cid-1',
       requestId: 'req-log-1',
       runnerCalled: true,
-      runnerEndpoint: 'grpc://runner.local:9090',
+      runnerEndpoint: 'grpc://runner.local:50051',
       failureKind: 'runner_unreachable',
       runnerStatusCode: 0,
       runnerErrorCode: 'runner_connection_refused',
@@ -690,7 +690,7 @@ describe('ContainersController routes', () => {
       containerId: 'cid-1',
       requestId: 'req-log-2',
       runnerCalled: true,
-      runnerEndpoint: 'grpc://runner.local:9090',
+      runnerEndpoint: 'grpc://runner.local:50051',
       failureKind: 'unknown',
       errorMessage: 'tcp connection reset',
       errorStack: deleteError.stack,

--- a/packages/platform-server/__tests__/vitest.setup.ts
+++ b/packages/platform-server/__tests__/vitest.setup.ts
@@ -4,6 +4,6 @@ process.env.LITELLM_BASE_URL ||= 'http://127.0.0.1:4000';
 process.env.LITELLM_MASTER_KEY ||= 'sk-dev-master-1234';
 process.env.CONTEXT_ITEM_NULL_GUARD ||= '0';
 process.env.DOCKER_RUNNER_GRPC_HOST ||= 'docker-runner';
-process.env.DOCKER_RUNNER_GRPC_PORT ||= process.env.DOCKER_RUNNER_PORT || '7171';
+process.env.DOCKER_RUNNER_GRPC_PORT ||= process.env.DOCKER_RUNNER_PORT || '50051';
 process.env.DOCKER_RUNNER_PORT ||= process.env.DOCKER_RUNNER_GRPC_PORT;
 process.env.DOCKER_RUNNER_SHARED_SECRET ||= 'test-shared-secret';

--- a/packages/platform-server/__tests__/workspace.exec.grpc.test.ts
+++ b/packages/platform-server/__tests__/workspace.exec.grpc.test.ts
@@ -15,7 +15,7 @@ const RUNNER_HOST = process.env.DOCKER_RUNNER_GRPC_HOST;
 const RUNNER_PORT = process.env.DOCKER_RUNNER_GRPC_PORT;
 
 const DEFAULT_RUNNER_HOST = 'docker-runner';
-const DEFAULT_RUNNER_PORT = '7171';
+const DEFAULT_RUNNER_PORT = '50051';
 
 const resolvedRunnerAddress =
   RUNNER_ADDRESS_OVERRIDE ??

--- a/packages/platform-server/src/core/services/config.service.ts
+++ b/packages/platform-server/src/core/services/config.service.ts
@@ -78,10 +78,10 @@ export const configSchema = z.object({
   dockerRunnerGrpcHost: z.string().default('127.0.0.1'),
   dockerRunnerGrpcPort: z
     .union([z.string(), z.number()])
-    .default('7171')
+    .default('50051')
     .transform((v) => {
       const num = typeof v === 'number' ? v : Number(v);
-      return Number.isFinite(num) ? num : 7171;
+      return Number.isFinite(num) ? num : 50051;
     }),
   dockerRunnerOptional: z
     .union([z.boolean(), z.string()])

--- a/packages/platform-server/vitest.config.ts
+++ b/packages/platform-server/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     setupFiles: ["./__tests__/vitest.setup.ts"],
     env: {
       DOCKER_RUNNER_GRPC_HOST: "docker-runner",
-      DOCKER_RUNNER_GRPC_PORT: "7171",
+      DOCKER_RUNNER_GRPC_PORT: "50051",
       DOCKER_RUNNER_SHARED_SECRET: "test-shared-secret",
     },
     fileParallelism: false,


### PR DESCRIPTION
## Summary
- update docker-runner gRPC defaults to 50051
- align helm chart port defaults for docker-runner
- align platform-server docker-runner gRPC port default

## Testing
- pnpm proto:generate
- pnpm lint
- pnpm --filter @agyn/docker-runner test
- AGENTS_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test pnpm --filter @agyn/platform-server exec vitest run --shard=1/8
- AGENTS_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test pnpm --filter @agyn/platform-server exec vitest run --shard=2/8
- AGENTS_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test pnpm --filter @agyn/platform-server exec vitest run --shard=3/8
- AGENTS_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test pnpm --filter @agyn/platform-server exec vitest run --shard=4/8
- AGENTS_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test pnpm --filter @agyn/platform-server exec vitest run --shard=5/8
- AGENTS_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test pnpm --filter @agyn/platform-server exec vitest run --shard=6/8
- AGENTS_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test pnpm --filter @agyn/platform-server exec vitest run --shard=7/8
- AGENTS_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test DATABASE_URL=postgresql://postgres@127.0.0.1:5432/agents_test pnpm --filter @agyn/platform-server exec vitest run --shard=8/8
- pnpm --filter @agyn/platform-ui test

Refs #1383